### PR TITLE
Add secondary Button style

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -6,8 +6,6 @@ import HtmlElement from '../HtmlElement/HtmlElement';
 import { standard } from '../../themes';
 import { textMega } from '../../styles/style-helpers';
 
-const colorSelectorFor = baseColor => identifier => `${baseColor}${identifier}`;
-
 const calculatePadding = ({ theme, size }) => (diff = '0px') => {
   const sizeMap = {
     kilo: `calc(${theme.spacings.bit} - ${diff}) calc(${
@@ -34,24 +32,45 @@ const disabledStyles = css`
   pointer-events: none;
 `;
 
-const baseStyles = ({ theme, href }) => css`
+const baseStyles = ({ theme, href, ...otherProps }) => css`
   label: button;
+  background-color: ${theme.colors.b500};
+  border-color: ${theme.colors.b700};
   border-radius: ${theme.borderRadius.mega};
-  color: ${theme.colors.white};
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255, 255, 255, 0.06);
   display: ${href ? 'inline-block' : 'block'};
+  color: ${theme.colors.white};
+  cursor: default;
+  font-weight: ${theme.fontWeight.bold};
   width: auto;
   height: auto;
   text-decoration: none;
   ${textMega({ theme })};
 
-  &:focus {
-    outline: 0;
+  &:active {
+    background-color: ${theme.colors.b700};
+    border-color: ${theme.colors.b900};
+    box-shadow: inset 0 4px 8px 0 rgba(12, 15, 20, 0.3);
   }
 
-  &:active {
+  &:focus {
+    border-color: ${theme.colors.b700};
+    border-width: 2px;
+    outline: 0;
+    padding: ${calculatePadding({ theme, ...otherProps })('1px')};
   }
 
   &:hover {
+    background-color: ${theme.colors.b700};
+  }
+
+  &:hover,
+  &:active {
+    border-color: ${theme.colors.b900};
+    border-width: 1px;
+    padding: ${calculatePadding({ theme, ...otherProps })()};
   }
 
   &[disabled],
@@ -60,44 +79,90 @@ const baseStyles = ({ theme, href }) => css`
   }
 `;
 
-const colorStyles = ({ theme, variant, flat }) => {
-  // TODO: this will most likely have to change once we actually
-  //       introuce secondary button styles.
-  const colorMap = {
-    primary: 'b',
-    secondary: 'n'
-  };
-
-  const baseColor = colorMap[variant] || colorMap.primary;
-  const selectColor = colorSelectorFor(baseColor);
-
-  return css`
-    label: button--${variant}${flat ? '--flat' : ''};
-    background-color: ${theme.colors[selectColor(500)]};
-    border-color: ${theme.colors[selectColor(700)]};
-    cursor: default;
-
-    &:hover {
-      background-color: ${theme.colors[selectColor(700)]};
-    }
+const flatStyles = ({ theme, flat, secondary, ...otherProps }) =>
+  flat &&
+  !secondary &&
+  css`
+    label: button--flat;
+    border-width: 0px;
+    box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.02),
+      0 2px 2px 0 rgba(12, 15, 20, 0.06), 0 4px 4px 0 rgba(12, 15, 20, 0.06);
 
     &:active {
-      background-color: ${theme.colors[
-        flat ? selectColor(900) : selectColor(700)
-      ]};
-      border-color: ${theme.colors[selectColor(900)]};
+      background-color: ${theme.colors.b900};
+      box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.02),
+        0 0 1px 0 rgba(12, 15, 20, 0.06), 0 2px 2px 0 rgba(12, 15, 20, 0.06);
+    }
+
+    &:active:focus,
+    &:hover:focus {
+      border-width: 0;
+      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })()};
     }
 
     &:focus {
-      border-color: ${theme.colors[selectColor(700)]};
-    }
-
-    &:hover,
-    &:active {
-      border-color: ${theme.colors[selectColor(900)]};
+      border-width: 2px;
+      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })(
+        '2px'
+      )};
     }
   `;
-};
+
+const secondaryStyles = ({ theme, secondary, flat, ...otherProps }) =>
+  secondary &&
+  css`
+    label: button--secondary;
+    background-color: transparent;
+    border-color: ${theme.colors.n900};
+    border-width: 0;
+    box-shadow: none;
+    color: ${theme.colors.n700};
+
+    &:active {
+      background-color: transparent;
+      border-color: ${theme.colors.n900};
+      border-width: 0;
+      box-shadow: none;
+    }
+
+    &:focus {
+      border-color: ${theme.colors.n900};
+      border-width: 2px;
+      box-shadow: none;
+      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })(
+        '2px'
+      )};
+    }
+
+    &:hover {
+      background-color: transparent;
+      border-width: 0;
+      border-color: ${theme.colors.n900};
+    }
+
+    &:active,
+    &:hover,
+    &:hover:focus,
+    &:active:focus {
+      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })()};
+    }
+
+    &:active,
+    &:hover,
+    &:focus {
+      color: ${theme.colors.n900};
+    }
+
+    &:active:focus,
+    &:hover:focus {
+      border-color: ${theme.colors.n900};
+      border-width: 2px;
+      box-shadow: none;
+      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })(
+        '2px'
+      )};
+    }
+  `;
 
 const sizeStyles = props => {
   const { size } = props;
@@ -106,55 +171,6 @@ const sizeStyles = props => {
     label: `button--${size}`,
     padding
   });
-};
-
-const depthStyles = props => {
-  const { flat } = props;
-  if (flat) {
-    return css`
-      label: button--flat;
-      border-width: 0px;
-      box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.02),
-        0 2px 2px 0 rgba(12, 15, 20, 0.06), 0 4px 4px 0 rgba(12, 15, 20, 0.06);
-
-      &:active {
-        box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.02),
-          0 0 1px 0 rgba(12, 15, 20, 0.06), 0 2px 2px 0 rgba(12, 15, 20, 0.06);
-      }
-
-      &:active:focus,
-      &:hover:focus {
-        border-width: 0;
-        padding: ${calculatePadding(props)()};
-      }
-
-      &:focus {
-        border-width: 2px;
-        padding: ${calculatePadding(props)('2px')};
-      }
-    `;
-  }
-
-  return css`
-    border-width: 1px;
-    border-style: solid;
-    box-shadow: inset 0 1px 0 1px rgba(255, 255, 255, 0.06);
-
-    &:active {
-      box-shadow: inset 0 4px 8px 0 rgba(12, 15, 20, 0.3);
-    }
-
-    &:hover:focus,
-    &:hover:active {
-      border-width: 1px;
-      padding: ${calculatePadding(props)()};
-    }
-
-    &:focus {
-      border-width: 2px;
-      padding: ${calculatePadding(props)('1px')};
-    }
-  `;
 };
 
 const TextOrButtonElement = props => (
@@ -172,8 +188,8 @@ const TextOrButtonElement = props => (
 const Button = styled(TextOrButtonElement)(
   baseStyles,
   sizeStyles,
-  colorStyles,
-  depthStyles
+  flatStyles,
+  secondaryStyles
 );
 
 Button.propTypes = {
@@ -191,14 +207,14 @@ Button.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
-   * Type of button to render. For example, use 'primary' for confirmation button
-   * and 'secondary' for cancel button.
-   */
-  variant: PropTypes.oneOf(['primary', 'secondary']),
-  /**
    * Button has a 'flat' variation, triggered with this prop.
    */
   flat: PropTypes.bool,
+  /**
+   * Renders a secondary button. Secondary buttons look the same for
+   * primary (default) and flat buttons.
+   */
+  secondary: PropTypes.bool,
   /**
    * Link target. Should only be passed, if href is passed, too.
    */

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -191,7 +191,7 @@ const TextOrButtonElement = props => (
  * The Button component. Can also be styled as an anchor by passing an href
  * prop.
  */
-const Button = styled(TextOrButtonElement)(
+const Button = styled(TextOrButtonElement, { label: 'Button' })(
   baseStyles,
   sizeStyles,
   flatStyles,

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -6,15 +6,21 @@ import HtmlElement from '../HtmlElement/HtmlElement';
 import { standard } from '../../themes';
 import { textMega } from '../../styles/style-helpers';
 
+const sizes = {
+  KILO: 'kilo',
+  MEGA: 'mega',
+  GIGA: 'giga'
+};
+
 const calculatePadding = ({ theme, size }) => (diff = '0px') => {
   const sizeMap = {
-    kilo: `calc(${theme.spacings.bit} - ${diff}) calc(${
+    [sizes.KILO]: `calc(${theme.spacings.bit} - ${diff}) calc(${
       theme.spacings.mega
     } - ${diff})`,
-    mega: `calc(${theme.spacings.byte} - ${diff}) calc(${
+    [sizes.MEGA]: `calc(${theme.spacings.byte} - ${diff}) calc(${
       theme.spacings.giga
     } - ${diff})`,
-    giga: `calc(${theme.spacings.kilo} - ${diff}) calc(${
+    [sizes.GIGA]: `calc(${theme.spacings.kilo} - ${diff}) calc(${
       theme.spacings.tera
     } - ${diff})`
   };
@@ -192,6 +198,10 @@ const Button = styled(TextOrButtonElement)(
   secondaryStyles
 );
 
+Button.KILO = sizes.KILO;
+Button.MEGA = sizes.MEGA;
+Button.GIGA = sizes.GIGA;
+
 Button.propTypes = {
   /**
    * An ID rendered as data-selector attribute on the
@@ -220,6 +230,10 @@ Button.propTypes = {
    */
   target: PropTypes.string,
   /**
+   * Size of the button. Use the Button's KILO, MEGA, or GIGA properties.
+   */
+  size: PropTypes.oneOf([Button.KILO, Button.MEGA, Button.GIGA]),
+  /**
    * Standard onClick function. If used on an anchor this can be used to
    * cause additional side-effects like tracking.
    */
@@ -231,6 +245,7 @@ Button.defaultProps = {
   disabled: false,
   variant: 'primary',
   flat: false,
+  size: Button.MEGA,
   target: undefined,
   href: undefined,
   onClick: undefined

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -13,10 +13,10 @@ const calculatePadding = ({ theme, size }) => (diff = '0px') => {
     kilo: `calc(${theme.spacings.bit} - ${diff}) calc(${
       theme.spacings.mega
     } - ${diff})`,
-    mega: `calc(${theme.spacings.kilo} - ${diff}) calc(${
+    mega: `calc(${theme.spacings.byte} - ${diff}) calc(${
       theme.spacings.giga
     } - ${diff})`,
-    giga: `calc(${theme.spacings.byte} - ${diff}) calc(${
+    giga: `calc(${theme.spacings.kilo} - ${diff}) calc(${
       theme.spacings.tera
     } - ${diff})`
   };

--- a/src/components/Button/Button.spec.js
+++ b/src/components/Button/Button.spec.js
@@ -22,27 +22,65 @@ describe('Button', () => {
    * Style snapshot testing via react test renderer and emotions snapshot
    * serializer.
    */
-  it('should have primary button styles', () => {
-    const actual = create(<Button>Button</Button>).toJSON();
+  it('should have button styles', () => {
+    const actual = create(<Button>Button</Button>);
     expect(actual).toMatchSnapshot();
   });
 
-  it('should have disabled primary button styles', () => {
-    const actual = create(<Button disabled>Disabled button</Button>).toJSON();
+  it('should have kilo button styles', () => {
+    const actual = create(<Button size={Button.KILO}>Button</Button>);
     expect(actual).toMatchSnapshot();
   });
 
-  it('should have flat primary button styles', () => {
-    const actual = create(<Button flat>Flat button</Button>).toJSON();
+  it('should have mega button styles', () => {
+    const actual = create(<Button size={Button.MEGA}>Button</Button>);
     expect(actual).toMatchSnapshot();
   });
 
-  it('should have flat disabled primary button styles', () => {
+  it('should have giga button styles', () => {
+    const actual = create(<Button size={Button.GIGA}>Button</Button>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should have disabled button styles', () => {
+    const actual = create(<Button disabled>Disabled button</Button>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should have flat button styles', () => {
+    const actual = create(<Button flat>Flat button</Button>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should have flat disabled button styles', () => {
     const actual = create(
       <Button flat disabled>
         Flat button
       </Button>
-    ).toJSON();
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should have secondary button styles', () => {
+    const actual = create(<Button secondary>Secondary button</Button>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should have secondary disabled button styles', () => {
+    const actual = create(
+      <Button secondary disabled>
+        Secondary disabled button
+      </Button>
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should have secondary flat button styles', () => {
+    const actual = create(
+      <Button secondary flat>
+        Secondary flat button
+      </Button>
+    );
     expect(actual).toMatchSnapshot();
   });
 

--- a/src/components/Button/Button.spec.js
+++ b/src/components/Button/Button.spec.js
@@ -3,21 +3,6 @@ import React from 'react';
 import Button from '.';
 
 describe('Button', () => {
-  it('should provide the KILO constant', () => {
-    const actual = Button.KILO;
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should provide the MEGA constant', () => {
-    const actual = Button.MEGA;
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should provide the GIGA constant', () => {
-    const actual = Button.GIGA;
-    expect(actual).toMatchSnapshot();
-  });
-
   /**
    * Style snapshot testing via react test renderer and emotions snapshot
    * serializer.

--- a/src/components/Button/Button.spec.js
+++ b/src/components/Button/Button.spec.js
@@ -3,6 +3,21 @@ import React from 'react';
 import Button from '.';
 
 describe('Button', () => {
+  it('should provide the KILO constant', () => {
+    const actual = Button.KILO;
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should provide the MEGA constant', () => {
+    const actual = Button.MEGA;
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should provide the GIGA constant', () => {
+    const actual = Button.GIGA;
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Style snapshot testing via react test renderer and emotions snapshot
    * serializer.

--- a/src/components/Button/Button.story.js
+++ b/src/components/Button/Button.story.js
@@ -11,7 +11,7 @@ storiesOf('Button', module)
   .add('Button disabled', withInfo()(() => <Button disabled>Disabled</Button>))
   .add(
     'Button secondary',
-    withInfo()(() => <Button variant="secondary">Secondary</Button>)
+    withInfo()(() => <Button secondary>Secondary</Button>)
   )
   .add('Button kilo', withInfo()(() => <Button size="kilo">Button</Button>))
   .add('Button mega', withInfo()(() => <Button size="mega">Button</Button>))
@@ -19,7 +19,7 @@ storiesOf('Button', module)
   .add(
     'Button secondary disabled',
     withInfo()(() => (
-      <Button variant="secondary" disabled>
+      <Button secondary disabled>
         Secondary disabled
       </Button>
     ))
@@ -37,7 +37,7 @@ storiesOf('Button', module)
   .add(
     'Flat Button secondary',
     withInfo()(() => (
-      <Button variant="secondary" flat>
+      <Button secondary flat>
         Flat Button
       </Button>
     ))
@@ -45,7 +45,7 @@ storiesOf('Button', module)
   .add(
     'Flat Button secondary disabled',
     withInfo()(() => (
-      <Button variant="secondary" flat disabled>
+      <Button secondary flat disabled>
         Flat Button
       </Button>
     ))

--- a/src/components/Button/Button.story.js
+++ b/src/components/Button/Button.story.js
@@ -13,9 +13,18 @@ storiesOf('Button', module)
     'Button secondary',
     withInfo()(() => <Button secondary>Secondary</Button>)
   )
-  .add('Button kilo', withInfo()(() => <Button size="kilo">Button</Button>))
-  .add('Button mega', withInfo()(() => <Button size="mega">Button</Button>))
-  .add('Button giga', withInfo()(() => <Button size="giga">Button</Button>))
+  .add(
+    'Button kilo',
+    withInfo()(() => <Button size={Button.KILO}>Button</Button>)
+  )
+  .add(
+    'Button mega',
+    withInfo()(() => <Button size={Button.MEGA}>Button</Button>)
+  )
+  .add(
+    'Button giga',
+    withInfo()(() => <Button size={Button.GIGA}>Button</Button>)
+  )
   .add(
     'Button secondary disabled',
     withInfo()(() => (

--- a/src/components/Button/Button.story.js
+++ b/src/components/Button/Button.story.js
@@ -13,6 +13,9 @@ storiesOf('Button', module)
     'Button secondary',
     withInfo()(() => <Button variant="secondary">Secondary</Button>)
   )
+  .add('Button kilo', withInfo()(() => <Button size="kilo">Button</Button>))
+  .add('Button mega', withInfo()(() => <Button size="mega">Button</Button>))
+  .add('Button giga', withInfo()(() => <Button size="giga">Button</Button>))
   .add(
     'Button secondary disabled',
     withInfo()(() => (

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -796,9 +796,3 @@ exports[`Button should have secondary flat button styles 1`] = `
   Secondary flat button
 </button>
 `;
-
-exports[`Button should provide the GIGA constant 1`] = `"giga"`;
-
-exports[`Button should provide the KILO constant 1`] = `"kilo"`;
-
-exports[`Button should provide the MEGA constant 1`] = `"mega"`;

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -55,6 +55,7 @@ exports[`Button should have disabled primary button styles 1`] = `
   disabled={true}
   href={undefined}
   onClick={undefined}
+  size="mega"
   target={undefined}
 >
   Disabled button
@@ -134,6 +135,7 @@ exports[`Button should have flat disabled primary button styles 1`] = `
   disabled={true}
   href={undefined}
   onClick={undefined}
+  size="mega"
   target={undefined}
 >
   Flat button
@@ -213,6 +215,7 @@ exports[`Button should have flat primary button styles 1`] = `
   disabled={false}
   href={undefined}
   onClick={undefined}
+  size="mega"
   target={undefined}
 >
   Flat button
@@ -274,8 +277,15 @@ exports[`Button should have primary button styles 1`] = `
   disabled={false}
   href={undefined}
   onClick={undefined}
+  size="mega"
   target={undefined}
 >
   Button
 </button>
 `;
+
+exports[`Button should provide the GIGA constant 1`] = `"giga"`;
+
+exports[`Button should provide the KILO constant 1`] = `"kilo"`;
+
+exports[`Button should provide the MEGA constant 1`] = `"mega"`;

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -10,7 +10,7 @@ exports[`Button should have disabled primary button styles 1`] = `
   text-decoration: none;
   font-size: 15px;
   line-height: 24px;
-  padding: calc(12px - 0px) calc(24px - 0px);
+  padding: calc(8px - 0px) calc(24px - 0px);
   background-color: #3388FF;
   border-color: #2567D8;
   cursor: default;
@@ -54,12 +54,12 @@ exports[`Button should have disabled primary button styles 1`] = `
 .circuit-0:hover:focus,
 .circuit-0:hover:active {
   border-width: 1px;
-  padding: calc(12px - 0px) calc(24px - 0px);
+  padding: calc(8px - 0px) calc(24px - 0px);
 }
 
 .circuit-0:focus {
   border-width: 2px;
-  padding: calc(12px - 1px) calc(24px - 1px);
+  padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 <button
@@ -83,7 +83,7 @@ exports[`Button should have flat disabled primary button styles 1`] = `
   text-decoration: none;
   font-size: 15px;
   line-height: 24px;
-  padding: calc(12px - 0px) calc(24px - 0px);
+  padding: calc(8px - 0px) calc(24px - 0px);
   background-color: #3388FF;
   border-color: #2567D8;
   cursor: default;
@@ -126,12 +126,12 @@ exports[`Button should have flat disabled primary button styles 1`] = `
 .circuit-0:active:focus,
 .circuit-0:hover:focus {
   border-width: 0;
-  padding: calc(12px - 0px) calc(24px - 0px);
+  padding: calc(8px - 0px) calc(24px - 0px);
 }
 
 .circuit-0:focus {
   border-width: 2px;
-  padding: calc(12px - 2px) calc(24px - 2px);
+  padding: calc(8px - 2px) calc(24px - 2px);
 }
 
 <button
@@ -155,7 +155,7 @@ exports[`Button should have flat primary button styles 1`] = `
   text-decoration: none;
   font-size: 15px;
   line-height: 24px;
-  padding: calc(12px - 0px) calc(24px - 0px);
+  padding: calc(8px - 0px) calc(24px - 0px);
   background-color: #3388FF;
   border-color: #2567D8;
   cursor: default;
@@ -198,12 +198,12 @@ exports[`Button should have flat primary button styles 1`] = `
 .circuit-0:active:focus,
 .circuit-0:hover:focus {
   border-width: 0;
-  padding: calc(12px - 0px) calc(24px - 0px);
+  padding: calc(8px - 0px) calc(24px - 0px);
 }
 
 .circuit-0:focus {
   border-width: 2px;
-  padding: calc(12px - 2px) calc(24px - 2px);
+  padding: calc(8px - 2px) calc(24px - 2px);
 }
 
 <button
@@ -227,7 +227,7 @@ exports[`Button should have primary button styles 1`] = `
   text-decoration: none;
   font-size: 15px;
   line-height: 24px;
-  padding: calc(12px - 0px) calc(24px - 0px);
+  padding: calc(8px - 0px) calc(24px - 0px);
   background-color: #3388FF;
   border-color: #2567D8;
   cursor: default;
@@ -271,12 +271,12 @@ exports[`Button should have primary button styles 1`] = `
 .circuit-0:hover:focus,
 .circuit-0:hover:active {
   border-width: 1px;
-  padding: calc(12px - 0px) calc(24px - 0px);
+  padding: calc(8px - 0px) calc(24px - 0px);
 }
 
 .circuit-0:focus {
   border-width: 2px;
-  padding: calc(12px - 1px) calc(24px - 1px);
+  padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 <button

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -2,64 +2,52 @@
 
 exports[`Button should have disabled primary button styles 1`] = `
 .circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
   border-radius: 4px;
-  color: #FFFFFF;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
   width: auto;
   height: auto;
   text-decoration: none;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
-  background-color: #3388FF;
-  border-color: #2567D8;
-  cursor: default;
-  border-width: 1px;
-  border-style: solid;
-  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
+}
+
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
+  border-color: #2567D8;
+  border-width: 2px;
   outline: 0;
-}
-
-.circuit-0[disabled],
-.circuit-0:disabled {
-  opacity: 0.4;
-  pointer-events: none;
+  padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
   background-color: #2567D8;
 }
 
-.circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
-}
-
-.circuit-0:focus {
-  border-color: #2567D8;
-}
-
 .circuit-0:hover,
 .circuit-0:active {
   border-color: #1641AC;
-}
-
-.circuit-0:active {
-  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
-}
-
-.circuit-0:hover:focus,
-.circuit-0:hover:active {
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-0:focus {
-  border-width: 2px;
-  padding: calc(8px - 1px) calc(24px - 1px);
+.circuit-0[disabled],
+.circuit-0:disabled {
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 <button
@@ -75,24 +63,48 @@ exports[`Button should have disabled primary button styles 1`] = `
 
 exports[`Button should have flat disabled primary button styles 1`] = `
 .circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
   border-radius: 4px;
-  color: #FFFFFF;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
   width: auto;
   height: auto;
   text-decoration: none;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
-  background-color: #3388FF;
-  border-color: #2567D8;
-  cursor: default;
   border-width: 0px;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06),0 4px 4px 0 rgba(12,15,20,0.06);
 }
 
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
+}
+
 .circuit-0:focus {
+  border-color: #2567D8;
+  border-width: 2px;
   outline: 0;
+  padding: calc(8px - 1px) calc(24px - 1px);
+}
+
+.circuit-0:hover {
+  background-color: #2567D8;
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  border-color: #1641AC;
+  border-width: 1px;
+  padding: calc(8px - 0px) calc(24px - 0px);
 }
 
 .circuit-0[disabled],
@@ -101,25 +113,8 @@ exports[`Button should have flat disabled primary button styles 1`] = `
   pointer-events: none;
 }
 
-.circuit-0:hover {
-  background-color: #2567D8;
-}
-
 .circuit-0:active {
   background-color: #1641AC;
-  border-color: #1641AC;
-}
-
-.circuit-0:focus {
-  border-color: #2567D8;
-}
-
-.circuit-0:hover,
-.circuit-0:active {
-  border-color: #1641AC;
-}
-
-.circuit-0:active {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
@@ -147,24 +142,48 @@ exports[`Button should have flat disabled primary button styles 1`] = `
 
 exports[`Button should have flat primary button styles 1`] = `
 .circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
   border-radius: 4px;
-  color: #FFFFFF;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
   width: auto;
   height: auto;
   text-decoration: none;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
-  background-color: #3388FF;
-  border-color: #2567D8;
-  cursor: default;
   border-width: 0px;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06),0 4px 4px 0 rgba(12,15,20,0.06);
 }
 
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
+}
+
 .circuit-0:focus {
+  border-color: #2567D8;
+  border-width: 2px;
   outline: 0;
+  padding: calc(8px - 1px) calc(24px - 1px);
+}
+
+.circuit-0:hover {
+  background-color: #2567D8;
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  border-color: #1641AC;
+  border-width: 1px;
+  padding: calc(8px - 0px) calc(24px - 0px);
 }
 
 .circuit-0[disabled],
@@ -173,25 +192,8 @@ exports[`Button should have flat primary button styles 1`] = `
   pointer-events: none;
 }
 
-.circuit-0:hover {
-  background-color: #2567D8;
-}
-
 .circuit-0:active {
   background-color: #1641AC;
-  border-color: #1641AC;
-}
-
-.circuit-0:focus {
-  border-color: #2567D8;
-}
-
-.circuit-0:hover,
-.circuit-0:active {
-  border-color: #1641AC;
-}
-
-.circuit-0:active {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
@@ -219,64 +221,52 @@ exports[`Button should have flat primary button styles 1`] = `
 
 exports[`Button should have primary button styles 1`] = `
 .circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
   border-radius: 4px;
-  color: #FFFFFF;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
   width: auto;
   height: auto;
   text-decoration: none;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
-  background-color: #3388FF;
-  border-color: #2567D8;
-  cursor: default;
-  border-width: 1px;
-  border-style: solid;
-  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
+}
+
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
+  border-color: #2567D8;
+  border-width: 2px;
   outline: 0;
-}
-
-.circuit-0[disabled],
-.circuit-0:disabled {
-  opacity: 0.4;
-  pointer-events: none;
+  padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
   background-color: #2567D8;
 }
 
-.circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
-}
-
-.circuit-0:focus {
-  border-color: #2567D8;
-}
-
 .circuit-0:hover,
 .circuit-0:active {
   border-color: #1641AC;
-}
-
-.circuit-0:active {
-  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
-}
-
-.circuit-0:hover:focus,
-.circuit-0:hover:active {
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-0:focus {
-  border-width: 2px;
-  padding: calc(8px - 1px) calc(24px - 1px);
+.circuit-0[disabled],
+.circuit-0:disabled {
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 <button

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -1,6 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Button should have disabled primary button styles 1`] = `
+exports[`Button should have button styles 1`] = `
+.circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
+  display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
+  width: auto;
+  height: auto;
+  text-decoration: none;
+  font-size: 15px;
+  line-height: 24px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
+}
+
+.circuit-0:focus {
+  border-color: #2567D8;
+  border-width: 2px;
+  outline: 0;
+  padding: calc(8px - 1px) calc(24px - 1px);
+}
+
+.circuit-0:hover {
+  background-color: #2567D8;
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  border-color: #1641AC;
+  border-width: 1px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0[disabled],
+.circuit-0:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+<button
+  className="circuit-0"
+  disabled={false}
+  href={undefined}
+  onClick={undefined}
+  size="mega"
+  target={undefined}
+>
+  Button
+</button>
+`;
+
+exports[`Button should have disabled button styles 1`] = `
 .circuit-0 {
   background-color: #3388FF;
   border-color: #2567D8;
@@ -62,7 +124,87 @@ exports[`Button should have disabled primary button styles 1`] = `
 </button>
 `;
 
-exports[`Button should have flat disabled primary button styles 1`] = `
+exports[`Button should have flat button styles 1`] = `
+.circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
+  display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
+  width: auto;
+  height: auto;
+  text-decoration: none;
+  font-size: 15px;
+  line-height: 24px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+  border-width: 0px;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06),0 4px 4px 0 rgba(12,15,20,0.06);
+}
+
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
+}
+
+.circuit-0:focus {
+  border-color: #2567D8;
+  border-width: 2px;
+  outline: 0;
+  padding: calc(8px - 1px) calc(24px - 1px);
+}
+
+.circuit-0:hover {
+  background-color: #2567D8;
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  border-color: #1641AC;
+  border-width: 1px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0[disabled],
+.circuit-0:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.circuit-0:active {
+  background-color: #1641AC;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
+.circuit-0:active:focus,
+.circuit-0:hover:focus {
+  border-width: 0;
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0:focus {
+  border-width: 2px;
+  padding: calc(8px - 2px) calc(24px - 2px);
+}
+
+<button
+  className="circuit-0"
+  disabled={false}
+  href={undefined}
+  onClick={undefined}
+  size="mega"
+  target={undefined}
+>
+  Flat button
+</button>
+`;
+
+exports[`Button should have flat disabled button styles 1`] = `
 .circuit-0 {
   background-color: #3388FF;
   border-color: #2567D8;
@@ -142,7 +284,7 @@ exports[`Button should have flat disabled primary button styles 1`] = `
 </button>
 `;
 
-exports[`Button should have flat primary button styles 1`] = `
+exports[`Button should have giga button styles 1`] = `
 .circuit-0 {
   background-color: #3388FF;
   border-color: #2567D8;
@@ -159,9 +301,7 @@ exports[`Button should have flat primary button styles 1`] = `
   text-decoration: none;
   font-size: 15px;
   line-height: 24px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-  border-width: 0px;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06),0 4px 4px 0 rgba(12,15,20,0.06);
+  padding: calc(12px - 0px) calc(32px - 0px);
 }
 
 .circuit-0:active {
@@ -174,7 +314,7 @@ exports[`Button should have flat primary button styles 1`] = `
   border-color: #2567D8;
   border-width: 2px;
   outline: 0;
-  padding: calc(8px - 1px) calc(24px - 1px);
+  padding: calc(12px - 1px) calc(32px - 1px);
 }
 
 .circuit-0:hover {
@@ -185,7 +325,7 @@ exports[`Button should have flat primary button styles 1`] = `
 .circuit-0:active {
   border-color: #1641AC;
   border-width: 1px;
-  padding: calc(8px - 0px) calc(24px - 0px);
+  padding: calc(12px - 0px) calc(32px - 0px);
 }
 
 .circuit-0[disabled],
@@ -194,20 +334,66 @@ exports[`Button should have flat primary button styles 1`] = `
   pointer-events: none;
 }
 
-.circuit-0:active {
-  background-color: #1641AC;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
+<button
+  className="circuit-0"
+  disabled={false}
+  href={undefined}
+  onClick={undefined}
+  size="giga"
+  target={undefined}
+>
+  Button
+</button>
+`;
+
+exports[`Button should have kilo button styles 1`] = `
+.circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
+  display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
+  width: auto;
+  height: auto;
+  text-decoration: none;
+  font-size: 15px;
+  line-height: 24px;
+  padding: calc(4px - 0px) calc(16px - 0px);
 }
 
-.circuit-0:active:focus,
-.circuit-0:hover:focus {
-  border-width: 0;
-  padding: calc(8px - 0px) calc(24px - 0px);
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
+  border-color: #2567D8;
   border-width: 2px;
-  padding: calc(8px - 2px) calc(24px - 2px);
+  outline: 0;
+  padding: calc(4px - 1px) calc(16px - 1px);
+}
+
+.circuit-0:hover {
+  background-color: #2567D8;
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  border-color: #1641AC;
+  border-width: 1px;
+  padding: calc(4px - 0px) calc(16px - 0px);
+}
+
+.circuit-0[disabled],
+.circuit-0:disabled {
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 <button
@@ -215,14 +401,14 @@ exports[`Button should have flat primary button styles 1`] = `
   disabled={false}
   href={undefined}
   onClick={undefined}
-  size="mega"
+  size="kilo"
   target={undefined}
 >
-  Flat button
+  Button
 </button>
 `;
 
-exports[`Button should have primary button styles 1`] = `
+exports[`Button should have mega button styles 1`] = `
 .circuit-0 {
   background-color: #3388FF;
   border-color: #2567D8;
@@ -281,6 +467,333 @@ exports[`Button should have primary button styles 1`] = `
   target={undefined}
 >
   Button
+</button>
+`;
+
+exports[`Button should have secondary button styles 1`] = `
+.circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
+  display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
+  width: auto;
+  height: auto;
+  text-decoration: none;
+  font-size: 15px;
+  line-height: 24px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+  background-color: transparent;
+  border-color: #212933;
+  border-width: 0;
+  box-shadow: none;
+  color: #5C656F;
+}
+
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
+}
+
+.circuit-0:focus {
+  border-color: #2567D8;
+  border-width: 2px;
+  outline: 0;
+  padding: calc(8px - 1px) calc(24px - 1px);
+}
+
+.circuit-0:hover {
+  background-color: #2567D8;
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  border-color: #1641AC;
+  border-width: 1px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0[disabled],
+.circuit-0:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.circuit-0:active {
+  background-color: transparent;
+  border-color: #212933;
+  border-width: 0;
+  box-shadow: none;
+}
+
+.circuit-0:focus {
+  border-color: #212933;
+  border-width: 2px;
+  box-shadow: none;
+  padding: calc(8px - 2px) calc(24px - 2px);
+}
+
+.circuit-0:hover {
+  background-color: transparent;
+  border-width: 0;
+  border-color: #212933;
+}
+
+.circuit-0:active,
+.circuit-0:hover,
+.circuit-0:hover:focus,
+.circuit-0:active:focus {
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0:active,
+.circuit-0:hover,
+.circuit-0:focus {
+  color: #212933;
+}
+
+.circuit-0:active:focus,
+.circuit-0:hover:focus {
+  border-color: #212933;
+  border-width: 2px;
+  box-shadow: none;
+  padding: calc(8px - 2px) calc(24px - 2px);
+}
+
+<button
+  className="circuit-0"
+  disabled={false}
+  href={undefined}
+  onClick={undefined}
+  secondary={true}
+  size="mega"
+  target={undefined}
+>
+  Secondary button
+</button>
+`;
+
+exports[`Button should have secondary disabled button styles 1`] = `
+.circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
+  display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
+  width: auto;
+  height: auto;
+  text-decoration: none;
+  font-size: 15px;
+  line-height: 24px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+  background-color: transparent;
+  border-color: #212933;
+  border-width: 0;
+  box-shadow: none;
+  color: #5C656F;
+}
+
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
+}
+
+.circuit-0:focus {
+  border-color: #2567D8;
+  border-width: 2px;
+  outline: 0;
+  padding: calc(8px - 1px) calc(24px - 1px);
+}
+
+.circuit-0:hover {
+  background-color: #2567D8;
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  border-color: #1641AC;
+  border-width: 1px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0[disabled],
+.circuit-0:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.circuit-0:active {
+  background-color: transparent;
+  border-color: #212933;
+  border-width: 0;
+  box-shadow: none;
+}
+
+.circuit-0:focus {
+  border-color: #212933;
+  border-width: 2px;
+  box-shadow: none;
+  padding: calc(8px - 2px) calc(24px - 2px);
+}
+
+.circuit-0:hover {
+  background-color: transparent;
+  border-width: 0;
+  border-color: #212933;
+}
+
+.circuit-0:active,
+.circuit-0:hover,
+.circuit-0:hover:focus,
+.circuit-0:active:focus {
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0:active,
+.circuit-0:hover,
+.circuit-0:focus {
+  color: #212933;
+}
+
+.circuit-0:active:focus,
+.circuit-0:hover:focus {
+  border-color: #212933;
+  border-width: 2px;
+  box-shadow: none;
+  padding: calc(8px - 2px) calc(24px - 2px);
+}
+
+<button
+  className="circuit-0"
+  disabled={true}
+  href={undefined}
+  onClick={undefined}
+  secondary={true}
+  size="mega"
+  target={undefined}
+>
+  Secondary disabled button
+</button>
+`;
+
+exports[`Button should have secondary flat button styles 1`] = `
+.circuit-0 {
+  background-color: #3388FF;
+  border-color: #2567D8;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
+  display: block;
+  color: #FFFFFF;
+  cursor: default;
+  font-weight: 700;
+  width: auto;
+  height: auto;
+  text-decoration: none;
+  font-size: 15px;
+  line-height: 24px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+  background-color: transparent;
+  border-color: #212933;
+  border-width: 0;
+  box-shadow: none;
+  color: #5C656F;
+}
+
+.circuit-0:active {
+  background-color: #2567D8;
+  border-color: #1641AC;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
+}
+
+.circuit-0:focus {
+  border-color: #2567D8;
+  border-width: 2px;
+  outline: 0;
+  padding: calc(8px - 1px) calc(24px - 1px);
+}
+
+.circuit-0:hover {
+  background-color: #2567D8;
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  border-color: #1641AC;
+  border-width: 1px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0[disabled],
+.circuit-0:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.circuit-0:active {
+  background-color: transparent;
+  border-color: #212933;
+  border-width: 0;
+  box-shadow: none;
+}
+
+.circuit-0:focus {
+  border-color: #212933;
+  border-width: 2px;
+  box-shadow: none;
+  padding: calc(8px - 2px) calc(24px - 2px);
+}
+
+.circuit-0:hover {
+  background-color: transparent;
+  border-width: 0;
+  border-color: #212933;
+}
+
+.circuit-0:active,
+.circuit-0:hover,
+.circuit-0:hover:focus,
+.circuit-0:active:focus {
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-0:active,
+.circuit-0:hover,
+.circuit-0:focus {
+  color: #212933;
+}
+
+.circuit-0:active:focus,
+.circuit-0:hover:focus {
+  border-color: #212933;
+  border-width: 2px;
+  box-shadow: none;
+  padding: calc(8px - 2px) calc(24px - 2px);
+}
+
+<button
+  className="circuit-0"
+  disabled={false}
+  href={undefined}
+  onClick={undefined}
+  secondary={true}
+  size="mega"
+  target={undefined}
+>
+  Secondary flat button
 </button>
 `;
 

--- a/src/components/FormLabel/__snapshots__/FormLabel.spec.js.snap
+++ b/src/components/FormLabel/__snapshots__/FormLabel.spec.js.snap
@@ -4,7 +4,7 @@ exports[`FormLabel should have the correct styles 1`] = `
 .circuit-0 {
   font-size: 13px;
   line-height: 20px;
-  font-weight: 800;
+  font-weight: 700;
   margin-bottom: 4px;
 }
 

--- a/src/components/Heading/__snapshots__/Heading.spec.js.snap
+++ b/src/components/Heading/__snapshots__/Heading.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Heading should render as h1 element, when passed "h1" for the element prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -21,7 +21,7 @@ exports[`Heading should render as h1 element, when passed "h1" for the element p
 
 exports[`Heading should render as h2 element, when passed "h2" for the element prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -40,7 +40,7 @@ exports[`Heading should render as h2 element, when passed "h2" for the element p
 
 exports[`Heading should render as h3 element, when passed "h3" for the element prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -59,7 +59,7 @@ exports[`Heading should render as h3 element, when passed "h3" for the element p
 
 exports[`Heading should render as h4 element, when passed "h4" for the element prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -78,7 +78,7 @@ exports[`Heading should render as h4 element, when passed "h4" for the element p
 
 exports[`Heading should render as h5 element, when passed "h5" for the element prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -97,7 +97,7 @@ exports[`Heading should render as h5 element, when passed "h5" for the element p
 
 exports[`Heading should render as h6 element, when passed "h6" for the element prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -116,7 +116,7 @@ exports[`Heading should render as h6 element, when passed "h6" for the element p
 
 exports[`Heading should render with size exa, when passed "exa" for the size prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -135,7 +135,7 @@ exports[`Heading should render with size exa, when passed "exa" for the size pro
 
 exports[`Heading should render with size giga, when passed "giga" for the size prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -154,7 +154,7 @@ exports[`Heading should render with size giga, when passed "giga" for the size p
 
 exports[`Heading should render with size kilo, when passed "kilo" for the size prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -173,7 +173,7 @@ exports[`Heading should render with size kilo, when passed "kilo" for the size p
 
 exports[`Heading should render with size mega, when passed "mega" for the size prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -192,7 +192,7 @@ exports[`Heading should render with size mega, when passed "mega" for the size p
 
 exports[`Heading should render with size peta, when passed "peta" for the size prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -211,7 +211,7 @@ exports[`Heading should render with size peta, when passed "peta" for the size p
 
 exports[`Heading should render with size tera, when passed "tera" for the size prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -230,7 +230,7 @@ exports[`Heading should render with size tera, when passed "tera" for the size p
 
 exports[`Heading should render with size zetta, when passed "zetta" for the size prop 1`] = `
 .circuit-0 {
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;

--- a/src/components/SubHeading/__snapshots__/SubHeading.spec.js.snap
+++ b/src/components/SubHeading/__snapshots__/SubHeading.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`SubHeading should render as H2 element, when passed "h2" for the element prop 1`] = `
 .circuit-0 {
   text-transform: uppercase;
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -23,7 +23,7 @@ exports[`SubHeading should render as H2 element, when passed "h2" for the elemen
 exports[`SubHeading should render as H3 element, when passed "h3" for the element prop 1`] = `
 .circuit-0 {
   text-transform: uppercase;
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -43,7 +43,7 @@ exports[`SubHeading should render as H3 element, when passed "h3" for the elemen
 exports[`SubHeading should render as H4 element, when passed "h4" for the element prop 1`] = `
 .circuit-0 {
   text-transform: uppercase;
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -63,7 +63,7 @@ exports[`SubHeading should render as H4 element, when passed "h4" for the elemen
 exports[`SubHeading should render as H5 element, when passed "h5" for the element prop 1`] = `
 .circuit-0 {
   text-transform: uppercase;
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -83,7 +83,7 @@ exports[`SubHeading should render as H5 element, when passed "h5" for the elemen
 exports[`SubHeading should render as H6 element, when passed "h6" for the element prop 1`] = `
 .circuit-0 {
   text-transform: uppercase;
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -103,7 +103,7 @@ exports[`SubHeading should render as H6 element, when passed "h6" for the elemen
 exports[`SubHeading should render with size kilo, when passed "kilo" for the size prop 1`] = `
 .circuit-0 {
   text-transform: uppercase;
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;
@@ -123,7 +123,7 @@ exports[`SubHeading should render with size kilo, when passed "kilo" for the siz
 exports[`SubHeading should render with size mega, when passed "mega" for the size prop 1`] = `
 .circuit-0 {
   text-transform: uppercase;
-  font-weight: 800;
+  font-weight: 700;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: 0;

--- a/src/themes/default.js
+++ b/src/themes/default.js
@@ -110,7 +110,7 @@ export const typography = {
 
 export const fontWeight = {
   regular: '400',
-  bold: '800'
+  bold: '700'
 };
 
 export const breakpoints = {


### PR DESCRIPTION
**Changes**
- Refactored the Button component should be simpler now, but also has a lot of overwriting rules.
- Implemented secondary modifier styles.
- Added the previously missing documentation and usage of the size modifier. Used the constant property suggestion @cristianoliveira made on the `IconInputWrapper` here. Seems much cleaner.
- Added more unit tests.

[Previews of the buttons here](https://sumup.github.io/circuit-ui/?selectedKind=Button&selectedStory=Button%20secondary&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).

@melmdesign, could you review them visually?

Closes #30.