### PR TITLE
Add Card components

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 export LoadingButton from './src/LoadingButton';
 export Button from './src/Button';
 
+export Card from './src/Card';
+
 export withStyles from './util/withStyles';
 export StyleProvider from './util/StyleProvider';

--- a/src/Card/__snapshots__/spec.js.snap
+++ b/src/Card/__snapshots__/spec.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card should respect the variant flag 1`] = `
+Array [
+  <div
+    className="card--standard"
+  >
+    Hi
+  </div>,
+  <div
+    className="card--inlay"
+  >
+    Hi
+  </div>,
+  <div
+    className="card--overlay"
+  >
+    Hi
+  </div>,
+]
+`;

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import styles from './index.scss';
+import withStyles from '../../util/withStyles';
+
+const Card = ({ variant, className, children, ...props }) => {
+  const cardClass = `card--${variant}`;
+  const allClasses = classNames(cardClass, className);
+  return (
+    <div className={allClasses} {...props}>
+      {children}
+    </div>
+  );
+};
+
+Card.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  variant: PropTypes.oneOf(['standard', 'overlay', 'inlay'])
+};
+
+Card.defaultProps = {
+  variant: 'standard'
+};
+
+export default withStyles(styles)(Card);

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -1,0 +1,46 @@
+@import '../shared';
+
+@mixin card-inlay {
+  background-color: $color-off;
+  border-radius: $border-radius;
+  padding: $spacing-s;
+}
+
+@mixin card-overlay {
+  @include drop-shadow;
+
+  background: rgba(255, 255, 255, .8);
+  border-radius: $border-radius;
+  padding: $spacing-s;
+}
+
+@mixin card($tablet-top, $tablet-sides, $mobile-top, $mobile-sides) {
+  $box-shadow: #dceafa;
+
+  background: $color-white;
+  border: 1px solid $color-light;
+  border-radius: $border-radius;
+  box-shadow: 0 1px 0 0 opacify($color-light, .2);
+  display: block;
+  margin-bottom: $spacing-s;
+  padding: $mobile-top $mobile-sides;
+
+  @include fancy-shadow($box-shadow);
+
+  @include media($big-screens) {
+    box-shadow: none;
+    padding: $tablet-top $tablet-sides;
+  }
+}
+
+.card--standard {
+  @include card($spacing-m, $spacing-l, $spacing-s, $spacing-m);
+}
+
+.card--inlay {
+  @include card-inlay;
+}
+
+.card--overlay {
+  @include card-overlay;
+}

--- a/src/Card/spec.js
+++ b/src/Card/spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Card from '.';
+
+describe('Card', () => {
+  it('should respect the variant flag', () => {
+    const variants = ['standard', 'inlay', 'overlay'];
+    const actuals = variants.map(v =>
+      renderer.create(<Card variant={v}>Hi</Card>)
+    );
+    expect(actuals).toMatchSnapshot();
+  });
+});

--- a/stories/cards.js
+++ b/stories/cards.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Card, Text, Headline } from '..';
+
+const style = { display: 'flex', width: '80%', margin: '0 auto' };
+const cardStyle = { width: '50%', margin: '6px' };
+
+storiesOf('Cards', module).add('Card', () => (
+  <Card>
+    <h1>This is a card</h1>
+    <div style={style}>
+      <Card variant="inlay" style={cardStyle}>
+        <p>This is the "inlay" card variant.</p>
+      </Card>
+      <Card variant="overlay" style={cardStyle}>
+        <p>This is the "overlay" card variant.</p>
+      </Card>
+    </div>
+  </Card>
+));


### PR DESCRIPTION
**Changes**
- Adds `ButtonGroup` component (used for buttons in a card).
- Adds Card component. The component index exports `CardHeader` and `CardFooter`, which can be used as children when creating a card. This helps with layout, but might be a bit verbose. Let's discuss this maybe once more?
- Adds a global decorator to Storybook that centers all stories on the canvas and adds a light grey background color (showing these white cards was horrible otherwise).
- Adds CSS resets to the global styles. I found yet more occurrences of weird user agent stylesheet selectors. This gets rid of a lot of them.

**TODO**
- [ ] Support close button.
- [ ] Write stories for `ButtonGroup`.
