### PR TITLE
Jest and ESLint improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-  extends: ['airbnb', 'prettier', 'prettier/react'],
-  plugins: ['prettier'],
+  extends: ['airbnb', 'plugin:jest/recommended', 'prettier', 'prettier/react'],
+  plugins: ['prettier', 'jest'],
   rules: {
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
     'no-use-before-define': ['error', { functions: false }],

--- a/jest.transform.js
+++ b/jest.transform.js
@@ -6,7 +6,15 @@ const babelConfig = {
     'syntax-dynamic-import',
     'transform-es2015-modules-commonjs',
     'transform-object-rest-spread',
-    'transform-class-properties'
+    'transform-class-properties',
+    [
+      'emotion',
+      {
+        autoLabel: true,
+        hoist: true,
+        sourceMap: true
+      }
+    ]
   ],
   presets: [['env', { targets: { node: 'current' } }], 'react', 'stage-3']
 };

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-loader": "^1.9.0",
     "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jest": "^21.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.4.0",
     "eslint-plugin-react": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,12 @@
   "description": "SumUp's React UI component library",
   "main": "index.js",
   "scripts": {
-    "fix:prettier":
-      "prettier --config prettier.config.js --write src/**/*.js && prettier --config prettier.config.js --write stories/*.js",
+    "fix:prettier": "prettier --config prettier.config.js --write src/**/*.js && prettier --config prettier.config.js --write stories/*.js",
     "fix:eslint": "eslint --fix --quiet src/**/*.js",
     "fix:stylelint": "stylelint \"src/**/*.scss\" --cache --fix",
     "fix": "npm run fix:prettier; npm run fix:eslint; npm run fix:stylelint",
-    "test":
-      "npm run test:lint-js && npm run test:lint-css && npm run test:unit",
-    "test:lint-css:watch":
-      "onchange \"src/**/*.scss\" \"src/**/*.scss\" -- npm run test:lint-css",
+    "test": "npm run test:lint-js && npm run test:lint-css && npm run test:unit",
+    "test:lint-css:watch": "onchange \"src/**/*.scss\" \"src/**/*.scss\" -- npm run test:lint-css",
     "test:lint-css": "stylelint \"src/**/*.scss\" --cache",
     "test:lint-js": "eslint --cache --quiet src/**/*.js",
     "test:lint-js:watch": "onchange \"src/**/*.js\" -- npm run test:lint-js",
@@ -26,7 +23,10 @@
     "deploy": "storybook-to-ghpages"
   },
   "lint-staged": {
-    "*.js": ["npm run fix:prettier", "git add"]
+    "*.js": [
+      "npm run fix:prettier",
+      "git add"
+    ]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "SumUp's React UI component library",
   "main": "index.js",
   "scripts": {
-    "fix:prettier": "prettier --config prettier.config.js --write src/**/*.js && prettier --config prettier.config.js --write stories/*.js",
+    "fix:prettier":
+      "prettier --config prettier.config.js --write src/**/*.js && prettier --config prettier.config.js --write stories/*.js",
     "fix:eslint": "eslint --fix --quiet src/**/*.js",
     "fix:stylelint": "stylelint \"src/**/*.scss\" --cache --fix",
     "fix": "npm run fix:prettier; npm run fix:eslint; npm run fix:stylelint",
-    "test": "npm run test:lint-js && npm run test:lint-css && npm run test:unit",
-    "test:lint-css:watch": "onchange \"src/**/*.scss\" \"src/**/*.scss\" -- npm run test:lint-css",
+    "test":
+      "npm run test:lint-js && npm run test:lint-css && npm run test:unit",
+    "test:lint-css:watch":
+      "onchange \"src/**/*.scss\" \"src/**/*.scss\" -- npm run test:lint-css",
     "test:lint-css": "stylelint \"src/**/*.scss\" --cache",
     "test:lint-js": "eslint --cache --quiet src/**/*.js",
     "test:lint-js:watch": "onchange \"src/**/*.js\" -- npm run test:lint-js",
@@ -23,10 +26,7 @@
     "deploy": "storybook-to-ghpages"
   },
   "lint-staged": {
-    "*.js": [
-      "npm run fix:prettier",
-      "git add"
-    ]
+    "*.js": ["npm run fix:prettier", "git add"]
   },
   "repository": {
     "type": "git",

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -191,7 +191,7 @@ const TextOrButtonElement = props => (
  * The Button component. Can also be styled as an anchor by passing an href
  * prop.
  */
-const Button = styled(TextOrButtonElement, { label: 'Button' })(
+const Button = styled(TextOrButtonElement)(
   baseStyles,
   sizeStyles,
   flatStyles,

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -51,7 +51,7 @@ exports[`Button should have button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
   href={undefined}
   onClick={undefined}
@@ -113,7 +113,7 @@ exports[`Button should have disabled button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={true}
   href={undefined}
   onClick={undefined}
@@ -143,7 +143,7 @@ exports[`Button should have flat button styles 1`] = `
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
   border-width: 0px;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06),0 4px 4px 0 rgba(12,15,20,0.06);
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02),0 2px 2px 0 rgba(12,15,20,0.06),0 4px 4px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-0:active {
@@ -178,7 +178,7 @@ exports[`Button should have flat button styles 1`] = `
 
 .circuit-0:active {
   background-color: #1641AC;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02),0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-0:active:focus,
@@ -193,7 +193,7 @@ exports[`Button should have flat button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
   href={undefined}
   onClick={undefined}
@@ -223,7 +223,7 @@ exports[`Button should have flat disabled button styles 1`] = `
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
   border-width: 0px;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06),0 4px 4px 0 rgba(12,15,20,0.06);
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02),0 2px 2px 0 rgba(12,15,20,0.06),0 4px 4px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-0:active {
@@ -258,7 +258,7 @@ exports[`Button should have flat disabled button styles 1`] = `
 
 .circuit-0:active {
   background-color: #1641AC;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02),0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-0:active:focus,
@@ -273,7 +273,7 @@ exports[`Button should have flat disabled button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={true}
   href={undefined}
   onClick={undefined}
@@ -335,7 +335,7 @@ exports[`Button should have giga button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
   href={undefined}
   onClick={undefined}
@@ -397,7 +397,7 @@ exports[`Button should have kilo button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
   href={undefined}
   onClick={undefined}
@@ -459,7 +459,7 @@ exports[`Button should have mega button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
   href={undefined}
   onClick={undefined}
@@ -567,7 +567,7 @@ exports[`Button should have secondary button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
   href={undefined}
   onClick={undefined}
@@ -676,7 +676,7 @@ exports[`Button should have secondary disabled button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={true}
   href={undefined}
   onClick={undefined}
@@ -785,7 +785,7 @@ exports[`Button should have secondary flat button styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
   href={undefined}
   onClick={undefined}

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -13,7 +13,7 @@ const listStyles = ({ theme }) => css`
   }
 `;
 
-const ButtonGroupList = styled('ul', { label: 'ButtonGroupList' })(listStyles);
+const ButtonGroupList = styled('ul')(listStyles);
 
 /**
  * Groups its Button children into a list and adds margins between.

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
@@ -13,6 +13,6 @@ exports[`ButtonGroup should have the correct styles 1`] = `
 }
 
 <ul
-  className="circuit-0"
+  className="circuit-0 circuit-1"
 />
 `;

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -19,7 +19,7 @@ const baseStyles = ({ theme }) => css`
 /**
  * Card component that is used for displaying content on a grid.
  */
-const Card = styled('div', { label: 'Card' })(baseStyles);
+const Card = styled('div')(baseStyles);
 
 Card.propTypes = {
   /**

--- a/src/components/Card/components/Footer/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Card/components/Footer/__snapshots__/Footer.spec.js.snap
@@ -18,6 +18,6 @@ exports[`CardFooter should have the correct styles 1`] = `
 }
 
 <footer
-  className="circuit-0"
+  className="circuit-0 circuit-1"
 />
 `;

--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -16,7 +16,7 @@ const baseStyles = ({ theme }) => css`
  * Header used in the Card component. Used for styling and alignment
  * purposes only.
  */
-const CardHeaderContainer = styled('header', { label: 'CardHeader' })(
+const CardHeaderContainer = styled('header')(
   baseStyles
 );
 

--- a/src/components/Card/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Card/components/Header/__snapshots__/Header.spec.js.snap
@@ -18,6 +18,6 @@ exports[`CardHeader should have the correct styles 1`] = `
 }
 
 <header
-  className="circuit-0"
+  className="circuit-0 circuit-1"
 />
 `;

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -100,9 +100,9 @@ const inputStyles = ({ theme }) => css`
   }
 `;
 
-const Input = styled('input')(inputStyles);
+const CheckboxInput = styled('input')(inputStyles);
 
-const Label = styled('label')(
+const CheckboxLabel = styled('label')(
   baseStyles,
   checkedStyles,
   disabledStyles,
@@ -114,10 +114,10 @@ const Label = styled('label')(
  */
 const Checkbox = ({ onToggle, children, name, ...props }) => (
   <Fragment>
-    <Input id={name} type="checkbox" {...{ ...props, name }} />
-    <Label htmlFor={name} onClick={onToggle} {...{ ...props }}>
+    <CheckboxInput id={name} type="checkbox" {...{ ...props, name }} />
+    <CheckboxLabel htmlFor={name} onClick={onToggle} {...{ ...props }}>
       {children}
-    </Label>
+    </CheckboxLabel>
   </Fragment>
 );
 

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -100,9 +100,9 @@ const inputStyles = ({ theme }) => css`
   }
 `;
 
-const Input = styled('input', { label: 'CheckboxInput' })(inputStyles);
+const Input = styled('input')(inputStyles);
 
-const Label = styled('label', { label: 'CheckboxLabel' })(
+const Label = styled('label')(
   baseStyles,
   checkedStyles,
   disabledStyles,

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -24,7 +24,7 @@ Array [
 
 <input
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
     id={undefined}
     name={undefined}
@@ -75,7 +75,7 @@ Array [
 
 <label
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
     htmlFor={undefined}
     onClick={[Function]}
@@ -107,7 +107,7 @@ Array [
 
 <input
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={true}
     id={undefined}
     name={undefined}
@@ -168,7 +168,7 @@ Array [
 
 <label
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={true}
     htmlFor={undefined}
     onClick={[Function]}
@@ -200,7 +200,7 @@ Array [
 
 <input
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
     id={undefined}
     name={undefined}
@@ -259,7 +259,7 @@ Array [
 
 <label
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
     htmlFor={undefined}
     onClick={[Function]}

--- a/src/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -23,7 +23,7 @@ exports[`CloseButton should have the correct styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
 >
   <div>
     close-icon.svg

--- a/src/components/FormLabel/__snapshots__/FormLabel.spec.js.snap
+++ b/src/components/FormLabel/__snapshots__/FormLabel.spec.js.snap
@@ -9,7 +9,7 @@ exports[`FormLabel should have the correct styles 1`] = `
 }
 
 <label
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   htmlFor="some-id"
 >
   Label

--- a/src/components/Heading/__snapshots__/Heading.spec.js.snap
+++ b/src/components/Heading/__snapshots__/Heading.spec.js.snap
@@ -12,7 +12,7 @@ exports[`Heading should render as h1 element, when passed "h1" for the element p
 }
 
 <h1
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="peta"
 >
   H1 heading
@@ -31,7 +31,7 @@ exports[`Heading should render as h2 element, when passed "h2" for the element p
 }
 
 <h2
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="peta"
 >
   H2 heading
@@ -50,7 +50,7 @@ exports[`Heading should render as h3 element, when passed "h3" for the element p
 }
 
 <h3
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="peta"
 >
   H3 heading
@@ -69,7 +69,7 @@ exports[`Heading should render as h4 element, when passed "h4" for the element p
 }
 
 <h4
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="peta"
 >
   H4 heading
@@ -88,7 +88,7 @@ exports[`Heading should render as h5 element, when passed "h5" for the element p
 }
 
 <h5
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="peta"
 >
   H5 heading
@@ -107,7 +107,7 @@ exports[`Heading should render as h6 element, when passed "h6" for the element p
 }
 
 <h6
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="peta"
 >
   H6 heading
@@ -126,7 +126,7 @@ exports[`Heading should render with size exa, when passed "exa" for the size pro
 }
 
 <h2
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="exa"
 >
   exa heading
@@ -145,7 +145,7 @@ exports[`Heading should render with size giga, when passed "giga" for the size p
 }
 
 <h2
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="giga"
 >
   giga heading
@@ -164,7 +164,7 @@ exports[`Heading should render with size kilo, when passed "kilo" for the size p
 }
 
 <h2
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="kilo"
 >
   kilo heading
@@ -183,7 +183,7 @@ exports[`Heading should render with size mega, when passed "mega" for the size p
 }
 
 <h2
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="mega"
 >
   mega heading
@@ -202,7 +202,7 @@ exports[`Heading should render with size peta, when passed "peta" for the size p
 }
 
 <h2
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="peta"
 >
   peta heading
@@ -221,7 +221,7 @@ exports[`Heading should render with size tera, when passed "tera" for the size p
 }
 
 <h2
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="tera"
 >
   tera heading
@@ -240,7 +240,7 @@ exports[`Heading should render with size zetta, when passed "zetta" for the size
 }
 
 <h2
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="zetta"
 >
   zetta heading

--- a/src/components/IconInputWrapper/IconInputWrapper.js
+++ b/src/components/IconInputWrapper/IconInputWrapper.js
@@ -12,7 +12,7 @@ const containerStyles = css`
   position: relative;
 `;
 
-const IconInputContainer = styled('div', { label: 'IconInputContainer' })(
+const IconInputContainer = styled('div')(
   containerStyles
 );
 

--- a/src/components/IconInputWrapper/IconInputWrapper.spec.js
+++ b/src/components/IconInputWrapper/IconInputWrapper.spec.js
@@ -3,7 +3,7 @@ import styled from 'react-emotion';
 
 import IconInputWrapper from '.';
 
-const RenderDummy = styled('div', { label: 'RenderDummy' })();
+const RenderDummy = styled('div')();
 
 describe('IconInputWrapper', () => {
   it("should have it's base styles", () => {

--- a/src/components/IconInputWrapper/__snapshots__/IconInputWrapper.spec.js.snap
+++ b/src/components/IconInputWrapper/__snapshots__/IconInputWrapper.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IconInputWrapper should allow rendering the icon on the right 1`] = `
-.circuit-2 {
+.circuit-4 {
   display: inline-block;
   position: relative;
 }
@@ -10,7 +10,7 @@ exports[`IconInputWrapper should allow rendering the icon on the right 1`] = `
   padding-right: calc( 12px + 16px + 12px );
 }
 
-.circuit-1 {
+.circuit-2 {
   position: absolute;
   height: 16px;
   width: 16px;
@@ -23,20 +23,20 @@ exports[`IconInputWrapper should allow rendering the icon on the right 1`] = `
 }
 
 <div
-  className="circuit-2"
+  className="circuit-4 circuit-5"
   data-selector="some-wrapper"
 >
   <div
-    className="circuit-0"
+    className="circuit-0 circuit-1"
   />
   <div
-    className="circuit-1"
+    className="circuit-2 circuit-1"
   />
 </div>
 `;
 
 exports[`IconInputWrapper should have it's base styles 1`] = `
-.circuit-2 {
+.circuit-4 {
   display: inline-block;
   position: relative;
 }
@@ -45,7 +45,7 @@ exports[`IconInputWrapper should have it's base styles 1`] = `
   padding-left: calc( 12px + 16px + 12px );
 }
 
-.circuit-1 {
+.circuit-2 {
   position: absolute;
   height: 16px;
   width: 16px;
@@ -58,14 +58,14 @@ exports[`IconInputWrapper should have it's base styles 1`] = `
 }
 
 <div
-  className="circuit-2"
+  className="circuit-4 circuit-5"
   data-selector="some-wrapper"
 >
   <div
-    className="circuit-0"
+    className="circuit-0 circuit-1"
   />
   <div
-    className="circuit-1"
+    className="circuit-2 circuit-1"
   />
 </div>
 `;

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -79,7 +79,7 @@ const baseStyles = ({ theme }) => css`
 /**
  * Input component for forms.
  */
-const Input = styled('input', { label: 'Input' })(
+const Input = styled('input')(
   baseStyles,
   disabledStyles,
   optionalStyles,

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -38,7 +38,7 @@ exports[`Input should have the correct default styles 1`] = `
 
 <input
   autoComplete="none"
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
 />
 `;
@@ -106,7 +106,7 @@ exports[`Input should prioritize error over optional styles 1`] = `
 
 <input
   autoComplete="none"
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={true}
 />
 `;
@@ -151,7 +151,7 @@ exports[`Input should show with disabled styled when passed the disabled prop 1`
 
 <input
   autoComplete="none"
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={true}
 />
 `;
@@ -217,7 +217,7 @@ exports[`Input should show with invalid styles when passed the isInvalid prop 1`
 
 <input
   autoComplete="none"
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
 />
 `;
@@ -263,7 +263,7 @@ exports[`Input should show with optional styles when passed the isOptional prop 
 
 <input
   autoComplete="none"
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={false}
 />
 `;

--- a/src/components/PasswordInput/__snapshots__/PasswordInput.spec.js.snap
+++ b/src/components/PasswordInput/__snapshots__/PasswordInput.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PasswordInput should render with default styles 1`] = `
-.circuit-2 {
+.circuit-4 {
   display: inline-block;
   position: relative;
 }
@@ -42,7 +42,7 @@ exports[`PasswordInput should render with default styles 1`] = `
   color: #9DA7B1;
 }
 
-.circuit-1 {
+.circuit-2 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -60,29 +60,29 @@ exports[`PasswordInput should render with default styles 1`] = `
   left: auto;
 }
 
-.circuit-1:focus,
-.circuit-1:active {
+.circuit-2:focus,
+.circuit-2:active {
   outline: none;
 }
 
-.circuit-1 > svg {
+.circuit-2 > svg {
   height: 100%;
   width: 100%;
 }
 
 <div
-  className="circuit-2"
+  className="circuit-4 circuit-5"
   data-selector="pw"
 >
   <input
     autoComplete="none"
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
     placeholder="Password"
     type="password"
   />
   <button
-    className="circuit-1"
+    className="circuit-2 circuit-3"
     onClick={[Function]}
   >
     <div>
@@ -93,7 +93,7 @@ exports[`PasswordInput should render with default styles 1`] = `
 `;
 
 exports[`PasswordInput should render with disabled styles 1`] = `
-.circuit-2 {
+.circuit-4 {
   display: inline-block;
   position: relative;
 }
@@ -136,7 +136,7 @@ exports[`PasswordInput should render with disabled styles 1`] = `
   color: #9DA7B1;
 }
 
-.circuit-1 {
+.circuit-2 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -156,29 +156,29 @@ exports[`PasswordInput should render with disabled styles 1`] = `
   pointer-events: none;
 }
 
-.circuit-1:focus,
-.circuit-1:active {
+.circuit-2:focus,
+.circuit-2:active {
   outline: none;
 }
 
-.circuit-1 > svg {
+.circuit-2 > svg {
   height: 100%;
   width: 100%;
 }
 
 <div
-  className="circuit-2"
+  className="circuit-4 circuit-5"
   data-selector="pw"
 >
   <input
     autoComplete="none"
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={true}
     placeholder="Password"
     type="password"
   />
   <button
-    className="circuit-1"
+    className="circuit-2 circuit-3"
     onClick={[Function]}
   >
     <div>

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -94,9 +94,9 @@ const inputStyles = ({ theme }) => css`
   }
 `;
 
-const Input = styled('input', { label: 'RadioButtonInput' })(inputStyles);
+const Input = styled('input')(inputStyles);
 
-const Label = styled('label', { label: 'RadioButtonLabel' })(
+const Label = styled('label')(
   baseStyles,
   checkedStyles,
   disabledStyles,

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -94,9 +94,9 @@ const inputStyles = ({ theme }) => css`
   }
 `;
 
-const Input = styled('input')(inputStyles);
+const RadioButtonInput = styled('input')(inputStyles);
 
-const Label = styled('label')(
+const RadioButtonLabel = styled('label')(
   baseStyles,
   checkedStyles,
   disabledStyles,
@@ -108,10 +108,10 @@ const Label = styled('label')(
  */
 const RadioButton = ({ onToggle, children, name, ...props }) => (
   <Fragment>
-    <Input id={name} type="radio" {...{ ...props, name }} />
-    <Label htmlFor={name} onClick={onToggle} {...{ ...props }}>
+    <RadioButtonInput id={name} type="radio" {...{ ...props, name }} />
+    <RadioButtonLabel htmlFor={name} onClick={onToggle} {...{ ...props }}>
       {children}
-    </Label>
+    </RadioButtonLabel>
   </Fragment>
 );
 

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
@@ -24,7 +24,7 @@ Array [
 
 <input
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
     id={undefined}
     name={undefined}
@@ -76,7 +76,7 @@ Array [
 
 <label
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
     htmlFor={undefined}
     onClick={[Function]}
@@ -108,7 +108,7 @@ Array [
 
 <input
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={true}
     id={undefined}
     name={undefined}
@@ -170,7 +170,7 @@ Array [
 
 <label
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={true}
     htmlFor={undefined}
     onClick={[Function]}
@@ -202,7 +202,7 @@ Array [
 
 <input
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
     id={undefined}
     name={undefined}
@@ -262,7 +262,7 @@ Array [
 
 <label
     checked={false}
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
     htmlFor={undefined}
     onClick={[Function]}

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchInput should render icon with 0.4 opacity when disabled 1`] = `
-.circuit-1 {
+.circuit-2 {
   display: inline-block;
   position: relative;
 }
@@ -45,12 +45,12 @@ exports[`SearchInput should render icon with 0.4 opacity when disabled 1`] = `
 }
 
 <div
-  className="circuit-1"
+  className="circuit-2 circuit-3"
   data-selector="search"
 >
   <input
     autoComplete="none"
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={true}
   />
   <div>
@@ -60,7 +60,7 @@ exports[`SearchInput should render icon with 0.4 opacity when disabled 1`] = `
 `;
 
 exports[`SearchInput should render with default styles 1`] = `
-.circuit-1 {
+.circuit-2 {
   display: inline-block;
   position: relative;
 }
@@ -102,12 +102,12 @@ exports[`SearchInput should render with default styles 1`] = `
 }
 
 <div
-  className="circuit-1"
+  className="circuit-2 circuit-3"
   data-selector="search"
 >
   <input
     autoComplete="none"
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
   />
   <div>

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -57,11 +57,11 @@ const baseIconStyles = ({ theme }) => css`
   pointer-events: none;
 `;
 
-const SelectElement = styled('select', { label: 'SelectElement' })(
+const SelectElement = styled('select')(
   baseSelectStyles,
   disabledSelectStyles
 );
-const Icon = styled(DownTriangleIcon, { label: 'SelectIcon' })(baseIconStyles);
+const Icon = styled(DownTriangleIcon)(baseIconStyles);
 
 /**
  * A native select component.

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select should render with default styles 1`] = `
-.circuit-1 {
+.circuit-2 {
   display: inline-block;
   position: relative;
 }
@@ -41,11 +41,11 @@ exports[`Select should render with default styles 1`] = `
 }
 
 <div
-  className="circuit-1"
+  className="circuit-2 circuit-3"
   data-selector={undefined}
 >
   <select
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={false}
   >
     <option>
@@ -77,7 +77,7 @@ exports[`Select should render with default styles 1`] = `
 `;
 
 exports[`Select should render with disabled styles when passed the disabled prop 1`] = `
-.circuit-1 {
+.circuit-2 {
   display: inline-block;
   position: relative;
 }
@@ -119,11 +119,11 @@ exports[`Select should render with disabled styles when passed the disabled prop
 }
 
 <div
-  className="circuit-1"
+  className="circuit-2 circuit-3"
   data-selector={undefined}
 >
   <select
-    className="circuit-0"
+    className="circuit-0 circuit-1"
     disabled={true}
   >
     <option>

--- a/src/components/SubHeading/__snapshots__/SubHeading.spec.js.snap
+++ b/src/components/SubHeading/__snapshots__/SubHeading.spec.js.snap
@@ -13,7 +13,7 @@ exports[`SubHeading should render as H2 element, when passed "h2" for the elemen
 }
 
 <h2
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="kilo"
 >
   H2 heading
@@ -33,7 +33,7 @@ exports[`SubHeading should render as H3 element, when passed "h3" for the elemen
 }
 
 <h3
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="kilo"
 >
   H3 heading
@@ -53,7 +53,7 @@ exports[`SubHeading should render as H4 element, when passed "h4" for the elemen
 }
 
 <h4
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="kilo"
 >
   H4 heading
@@ -73,7 +73,7 @@ exports[`SubHeading should render as H5 element, when passed "h5" for the elemen
 }
 
 <h5
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="kilo"
 >
   H5 heading
@@ -93,7 +93,7 @@ exports[`SubHeading should render as H6 element, when passed "h6" for the elemen
 }
 
 <h6
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="kilo"
 >
   H6 heading
@@ -113,7 +113,7 @@ exports[`SubHeading should render with size kilo, when passed "kilo" for the siz
 }
 
 <h3
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="kilo"
 >
   kilo heading
@@ -133,7 +133,7 @@ exports[`SubHeading should render with size mega, when passed "mega" for the siz
 }
 
 <h3
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="mega"
 >
   mega heading

--- a/src/components/SvgButton/SvgButton.js
+++ b/src/components/SvgButton/SvgButton.js
@@ -24,7 +24,7 @@ const baseStyles = css`
 /**
  * SvgButton component for forms.
  */
-const SvgButton = styled('button', { label: 'SvgButton' })(baseStyles);
+const SvgButton = styled('button')(baseStyles);
 
 SvgButton.propTypes = {
   children: PropTypes.element.isRequired

--- a/src/components/SvgButton/__snapshots__/SvgButton.spec.js.snap
+++ b/src/components/SvgButton/__snapshots__/SvgButton.spec.js.snap
@@ -21,7 +21,7 @@ exports[`SvgButton should render with the default styles 1`] = `
 }
 
 <button
-  className="circuit-0"
+  className="circuit-0 circuit-1"
 >
   <div>
     SVG here

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -12,7 +12,7 @@ exports[`Text should render as article element, when passed "article" for the el
 }
 
 <article
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="mega"
 >
   ARTICLE heading
@@ -31,7 +31,7 @@ exports[`Text should render as div element, when passed "div" for the element pr
 }
 
 <div
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="mega"
 >
   DIV heading
@@ -50,7 +50,7 @@ exports[`Text should render as p element, when passed "p" for the element prop 1
 }
 
 <p
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="mega"
 >
   P heading
@@ -69,7 +69,7 @@ exports[`Text should render with size giga, when passed "giga" for the size prop
 }
 
 <p
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="giga"
 >
   giga heading
@@ -88,7 +88,7 @@ exports[`Text should render with size kilo, when passed "kilo" for the size prop
 }
 
 <p
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="kilo"
 >
   kilo heading
@@ -107,7 +107,7 @@ exports[`Text should render with size mega, when passed "mega" for the size prop
 }
 
 <p
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   size="mega"
 >
   mega heading

--- a/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
@@ -38,7 +38,7 @@ exports[`TextArea should have the correct default styles 1`] = `
 }
 
 <textarea
-  className="circuit-0"
+  className="circuit-0 circuit-1"
 />
 `;
 
@@ -105,7 +105,7 @@ exports[`TextArea should prioritize error over optional styles 1`] = `
 }
 
 <textarea
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={true}
 />
 `;
@@ -150,7 +150,7 @@ exports[`TextArea should show with disabled styled when passed the disabled prop
 }
 
 <textarea
-  className="circuit-0"
+  className="circuit-0 circuit-1"
   disabled={true}
 />
 `;
@@ -216,7 +216,7 @@ exports[`TextArea should show with invalid styles when passed the isInvalid prop
 }
 
 <textarea
-  className="circuit-0"
+  className="circuit-0 circuit-1"
 />
 `;
 
@@ -261,6 +261,6 @@ exports[`TextArea should show with optional styles when passed the isOptional pr
 }
 
 <textarea
-  className="circuit-0"
+  className="circuit-0 circuit-1"
 />
 `;

--- a/templates/component/Component.spec.js
+++ b/templates/component/Component.spec.js
@@ -3,5 +3,5 @@ import React from 'react';
 import Component from '.';
 
 describe('Component', () => {
-  it.skip('should write a test');
+  it.skip('should', () => {});
 });

--- a/templates/component/Component.spec.js
+++ b/templates/component/Component.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Component } from '.';
+import Component from '.';
 
 describe('Component', () => {
   it.skip('should write a test');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3249,6 +3249,10 @@ eslint-plugin-import@^2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
+eslint-plugin-jest@^21.7.0:
+  version "21.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.7.0.tgz#651f1c6ce999af3ac59ab8bf8a376d742fd0fc23"
+
 eslint-plugin-jsx-a11y@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz#54583d1ae442483162e040e13cc31865465100e5"


### PR DESCRIPTION
Made some improvements:

- Updated/fixed the component template spec file. It was importing the no longer existing named export from the index. I also gave the `it` call a callback to make it even less work starting the first test.
- Added the `babel-emotion-plugin` to our Jest build stack. This is a big change, as it gives us [automatic labelling of our styled components](https://github.com/emotion-js/emotion/tree/master/packages/babel-plugin-emotion#styled). This means you longer have to label your component in the `styled` call. Babel will give them a label based on the variable name you assign the `styled` call to. This also means your variable names should be prefixed with the main component name (i.e. `RadioButtonInput`, where `RadioButton` is the block and `Input` is the element. The example behind the link makes this very obvious. Please continue to write styles in functions and keep setting your BEM labels in the `css` calls. I'll update the docs accordingly. I've removed all manual labels from existing code.
- Adds the jest ESLint plugin. This adds some rules for unit tests and also enables all the various global Jest variables in ESLint.