### PR TITLE
Adds bottom margin prop to typography components

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -176,7 +176,7 @@ const sizeStyles = props => {
 
 const TextOrButtonElement = props => (
   <HtmlElement
-    blacklist={['variant', 'flat']}
+    blacklist={{ size: true, flat: true }}
     element={({ href }) => (href ? 'a' : 'button')}
     {...props}
   />

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -238,7 +238,6 @@ Button.propTypes = {
 Button.defaultProps = {
   theme: standard,
   disabled: false,
-  variant: 'primary',
   flat: false,
   size: Button.MEGA,
   target: undefined,

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -55,7 +55,6 @@ exports[`Button should have button styles 1`] = `
   disabled={false}
   href={undefined}
   onClick={undefined}
-  size="mega"
   target={undefined}
 >
   Button
@@ -117,7 +116,6 @@ exports[`Button should have disabled button styles 1`] = `
   disabled={true}
   href={undefined}
   onClick={undefined}
-  size="mega"
   target={undefined}
 >
   Disabled button
@@ -197,7 +195,6 @@ exports[`Button should have flat button styles 1`] = `
   disabled={false}
   href={undefined}
   onClick={undefined}
-  size="mega"
   target={undefined}
 >
   Flat button
@@ -277,7 +274,6 @@ exports[`Button should have flat disabled button styles 1`] = `
   disabled={true}
   href={undefined}
   onClick={undefined}
-  size="mega"
   target={undefined}
 >
   Flat button
@@ -339,7 +335,6 @@ exports[`Button should have giga button styles 1`] = `
   disabled={false}
   href={undefined}
   onClick={undefined}
-  size="giga"
   target={undefined}
 >
   Button
@@ -401,7 +396,6 @@ exports[`Button should have kilo button styles 1`] = `
   disabled={false}
   href={undefined}
   onClick={undefined}
-  size="kilo"
   target={undefined}
 >
   Button
@@ -463,7 +457,6 @@ exports[`Button should have mega button styles 1`] = `
   disabled={false}
   href={undefined}
   onClick={undefined}
-  size="mega"
   target={undefined}
 >
   Button
@@ -572,7 +565,6 @@ exports[`Button should have secondary button styles 1`] = `
   href={undefined}
   onClick={undefined}
   secondary={true}
-  size="mega"
   target={undefined}
 >
   Secondary button
@@ -681,7 +673,6 @@ exports[`Button should have secondary disabled button styles 1`] = `
   href={undefined}
   onClick={undefined}
   secondary={true}
-  size="mega"
   target={undefined}
 >
   Secondary disabled button
@@ -790,7 +781,6 @@ exports[`Button should have secondary flat button styles 1`] = `
   href={undefined}
   onClick={undefined}
   secondary={true}
-  size="mega"
   target={undefined}
 >
   Secondary flat button

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -17,10 +17,10 @@ const sizeStyles = ({ theme, size }) => css`
   line-height: ${theme.typography.headings[size].lineHeight};
 `;
 
-const marginStyles = ({ theme, withMargin }) =>
-  withMargin &&
+const marginStyles = ({ theme, margin }) =>
+  margin &&
   css`
-    label: heading--with-margin;
+    label: heading--no-margin;
     margin-bottom: ${theme.spacings.giga};
   `;
 
@@ -35,7 +35,7 @@ const HeadingElement = styled(HtmlElement)(
  * different HTML tags.
  */
 const Heading = props => (
-  <HeadingElement {...props} blacklist={{ withMargin: true }} />
+  <HeadingElement {...props} blacklist={{ margin: true }} />
 );
 
 Text.KILO = KILO;
@@ -67,7 +67,7 @@ Heading.propTypes = {
   /**
    * Adds bottom margin to the heading.
    */
-  withMargin: PropTypes.bool,
+  margin: PropTypes.bool,
   /**
    * The HTML heading element to render.
    */
@@ -78,7 +78,7 @@ Heading.defaultProps = {
   element: 'h2',
   size: PETA,
   className: '',
-  withMargin: false,
+  margin: true,
   children: null
 };
 

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
-import { typeMarginResets } from '../../styles/global-styles';
 import HtmlElement from '../HtmlElement/HtmlElement';
 import { childrenPropType } from '../../util/shared-prop-types';
 import { KILO, MEGA, GIGA, TERA, PETA, EXA, ZETTA } from '../../util/sizes';
@@ -9,7 +8,6 @@ import { KILO, MEGA, GIGA, TERA, PETA, EXA, ZETTA } from '../../util/sizes';
 const baseStyles = ({ theme }) => css`
   label: heading;
   font-weight: ${theme.fontWeight.bold};
-  ${typeMarginResets};
 `;
 
 const sizeStyles = ({ theme, size }) => css`

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
@@ -23,11 +24,19 @@ const marginStyles = ({ theme, withMargin }) =>
     margin-bottom: ${theme.spacings.giga};
   `;
 
+const HeadingElement = styled(HtmlElement)(
+  baseStyles,
+  sizeStyles,
+  marginStyles
+);
+
 /**
  * A heading flexible heading component capable of rendering using
  * different HTML tags.
  */
-const Heading = styled(HtmlElement)(baseStyles, sizeStyles, marginStyles);
+const Heading = props => (
+  <HeadingElement {...props} blacklist={{ withMargin: true }} />
+);
 
 Text.KILO = KILO;
 Text.MEGA = MEGA;
@@ -69,7 +78,8 @@ Heading.defaultProps = {
   element: 'h2',
   size: PETA,
   className: '',
-  withMargin: false
+  withMargin: false,
+  children: null
 };
 
 export default Heading;

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -16,13 +16,18 @@ const sizeStyles = ({ theme, size }) => css`
   line-height: ${theme.typography.headings[size].lineHeight};
 `;
 
+const marginStyles = ({ theme, withMargin }) =>
+  withMargin &&
+  css`
+    label: heading--with-margin;
+    margin-bottom: ${theme.spacings.giga};
+  `;
+
 /**
  * A heading flexible heading component capable of rendering using
  * different HTML tags.
  */
-const Heading = styled(HtmlElement)`
-  ${baseStyles} ${sizeStyles};
-`;
+const Heading = styled(HtmlElement)(baseStyles, sizeStyles, marginStyles);
 
 Text.KILO = KILO;
 Text.MEGA = MEGA;
@@ -51,6 +56,10 @@ Heading.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * Adds bottom margin to the heading.
+   */
+  withMargin: PropTypes.bool,
+  /**
    * The HTML heading element to render.
    */
   element: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
@@ -59,7 +68,8 @@ Heading.propTypes = {
 Heading.defaultProps = {
   element: 'h2',
   size: PETA,
-  className: ''
+  className: '',
+  withMargin: false
 };
 
 export default Heading;

--- a/src/components/Heading/__snapshots__/Heading.spec.js.snap
+++ b/src/components/Heading/__snapshots__/Heading.spec.js.snap
@@ -3,10 +3,6 @@
 exports[`Heading should render as h1 element, when passed "h1" for the element prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 28px;
   line-height: 32px;
 }
@@ -22,10 +18,6 @@ exports[`Heading should render as h1 element, when passed "h1" for the element p
 exports[`Heading should render as h2 element, when passed "h2" for the element prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 28px;
   line-height: 32px;
 }
@@ -41,10 +33,6 @@ exports[`Heading should render as h2 element, when passed "h2" for the element p
 exports[`Heading should render as h3 element, when passed "h3" for the element prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 28px;
   line-height: 32px;
 }
@@ -60,10 +48,6 @@ exports[`Heading should render as h3 element, when passed "h3" for the element p
 exports[`Heading should render as h4 element, when passed "h4" for the element prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 28px;
   line-height: 32px;
 }
@@ -79,10 +63,6 @@ exports[`Heading should render as h4 element, when passed "h4" for the element p
 exports[`Heading should render as h5 element, when passed "h5" for the element prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 28px;
   line-height: 32px;
 }
@@ -98,10 +78,6 @@ exports[`Heading should render as h5 element, when passed "h5" for the element p
 exports[`Heading should render as h6 element, when passed "h6" for the element prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 28px;
   line-height: 32px;
 }
@@ -117,10 +93,6 @@ exports[`Heading should render as h6 element, when passed "h6" for the element p
 exports[`Heading should render with size exa, when passed "exa" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 36px;
   line-height: 44px;
 }
@@ -136,10 +108,6 @@ exports[`Heading should render with size exa, when passed "exa" for the size pro
 exports[`Heading should render with size giga, when passed "giga" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 22px;
   line-height: 24px;
 }
@@ -155,10 +123,6 @@ exports[`Heading should render with size giga, when passed "giga" for the size p
 exports[`Heading should render with size kilo, when passed "kilo" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 17px;
   line-height: 24px;
 }
@@ -174,10 +138,6 @@ exports[`Heading should render with size kilo, when passed "kilo" for the size p
 exports[`Heading should render with size mega, when passed "mega" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 19px;
   line-height: 24px;
 }
@@ -193,10 +153,6 @@ exports[`Heading should render with size mega, when passed "mega" for the size p
 exports[`Heading should render with size peta, when passed "peta" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 28px;
   line-height: 32px;
 }
@@ -212,10 +168,6 @@ exports[`Heading should render with size peta, when passed "peta" for the size p
 exports[`Heading should render with size tera, when passed "tera" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 24px;
   line-height: 32px;
 }
@@ -231,10 +183,6 @@ exports[`Heading should render with size tera, when passed "tera" for the size p
 exports[`Heading should render with size zetta, when passed "zetta" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 42px;
   line-height: 48px;
 }

--- a/src/components/Heading/__snapshots__/Heading.spec.js.snap
+++ b/src/components/Heading/__snapshots__/Heading.spec.js.snap
@@ -5,6 +5,7 @@ exports[`Heading should render as h1 element, when passed "h1" for the element p
   font-weight: 700;
   font-size: 28px;
   line-height: 32px;
+  margin-bottom: 24px;
 }
 
 <h1
@@ -20,6 +21,7 @@ exports[`Heading should render as h2 element, when passed "h2" for the element p
   font-weight: 700;
   font-size: 28px;
   line-height: 32px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -35,6 +37,7 @@ exports[`Heading should render as h3 element, when passed "h3" for the element p
   font-weight: 700;
   font-size: 28px;
   line-height: 32px;
+  margin-bottom: 24px;
 }
 
 <h3
@@ -50,6 +53,7 @@ exports[`Heading should render as h4 element, when passed "h4" for the element p
   font-weight: 700;
   font-size: 28px;
   line-height: 32px;
+  margin-bottom: 24px;
 }
 
 <h4
@@ -65,6 +69,7 @@ exports[`Heading should render as h5 element, when passed "h5" for the element p
   font-weight: 700;
   font-size: 28px;
   line-height: 32px;
+  margin-bottom: 24px;
 }
 
 <h5
@@ -80,6 +85,7 @@ exports[`Heading should render as h6 element, when passed "h6" for the element p
   font-weight: 700;
   font-size: 28px;
   line-height: 32px;
+  margin-bottom: 24px;
 }
 
 <h6
@@ -95,6 +101,7 @@ exports[`Heading should render with size exa, when passed "exa" for the size pro
   font-weight: 700;
   font-size: 36px;
   line-height: 44px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -110,6 +117,7 @@ exports[`Heading should render with size giga, when passed "giga" for the size p
   font-weight: 700;
   font-size: 22px;
   line-height: 24px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -125,6 +133,7 @@ exports[`Heading should render with size kilo, when passed "kilo" for the size p
   font-weight: 700;
   font-size: 17px;
   line-height: 24px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -140,6 +149,7 @@ exports[`Heading should render with size mega, when passed "mega" for the size p
   font-weight: 700;
   font-size: 19px;
   line-height: 24px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -155,6 +165,7 @@ exports[`Heading should render with size peta, when passed "peta" for the size p
   font-weight: 700;
   font-size: 28px;
   line-height: 32px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -170,6 +181,7 @@ exports[`Heading should render with size tera, when passed "tera" for the size p
   font-weight: 700;
   font-size: 24px;
   line-height: 32px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -185,6 +197,7 @@ exports[`Heading should render with size zetta, when passed "zetta" for the size
   font-weight: 700;
   font-size: 42px;
   line-height: 48px;
+  margin-bottom: 24px;
 }
 
 <h2

--- a/src/components/HtmlElement/HtmlElement.js
+++ b/src/components/HtmlElement/HtmlElement.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 
 const isFunction = val => typeof val === 'function';
 
-const filterProps = (blacklist, props) => {
-  const newProps = { ...props };
-  blacklist.forEach(prop => {
-    delete newProps[prop];
-  });
-  return newProps;
-};
+const filterProps = (blacklist, props) =>
+  Object.keys(props).reduce((filteredProps, prop) => {
+    if (blacklist[prop]) {
+      return filteredProps;
+    }
+    filteredProps[prop] = props[prop];
+    return filteredProps;
+  }, {});
 
 const HtmlElement = ({ element, children, blacklist, ...props }) => {
   const Element = isFunction(element) ? element(props) : element;
@@ -25,10 +26,10 @@ HtmlElement.propTypes = {
    */
   element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
   /**
-   * A list of props that should not be forwarded as attributes to the HTML element.
+   * A hash of props that should not be forwarded as attributes to the HTML element.
    * Prevents React from complaining about invalid attribute values.
    */
-  blacklist: PropTypes.arrayOf(PropTypes.string),
+  blacklist: PropTypes.objectOf(PropTypes.bool),
   /**
    * Child nodes to be rendered.
    */
@@ -39,7 +40,7 @@ HtmlElement.propTypes = {
 };
 
 HtmlElement.defaultProps = {
-  blacklist: [],
+  blacklist: {},
   children: null
 };
 

--- a/src/components/SubHeading/SubHeading.js
+++ b/src/components/SubHeading/SubHeading.js
@@ -18,10 +18,10 @@ const sizeStyles = ({ theme, size }) => css`
   line-height: ${theme.typography.subHeadings[size].lineHeight};
 `;
 
-const marginStyles = ({ theme, withMargin }) =>
-  withMargin &&
+const marginStyles = ({ theme, margin }) =>
+  margin &&
   css`
-    label: sub-heading--with-margin;
+    label: sub-heading--margin;
     margin-bottom: ${theme.spacings.kilo};
   `;
 
@@ -37,7 +37,7 @@ const SubHeadingElement = styled(HtmlElement)(
  */
 
 const SubHeading = props => (
-  <SubHeadingElement {...props} blacklist={{ withMargin: true }} />
+  <SubHeadingElement {...props} blacklist={{ margin: true }} />
 );
 
 SubHeading.propTypes = {
@@ -61,7 +61,7 @@ SubHeading.propTypes = {
   /**
    * Adds bottom margin to the sub-heading.
    */
-  withMargin: PropTypes.bool,
+  margin: PropTypes.bool,
   /**
    * The HTML heading element to render.
    */
@@ -72,7 +72,7 @@ SubHeading.defaultProps = {
   element: 'h3',
   size: KILO,
   className: '',
-  withMargin: false,
+  margin: true,
   children: null
 };
 

--- a/src/components/SubHeading/SubHeading.js
+++ b/src/components/SubHeading/SubHeading.js
@@ -17,11 +17,18 @@ const sizeStyles = ({ theme, size }) => css`
   line-height: ${theme.typography.subHeadings[size].lineHeight};
 `;
 
+const marginStyles = ({ theme, withMargin }) =>
+  withMargin &&
+  css`
+    label: sub-heading--with-margin;
+    margin-bottom: ${theme.spacings.kilo};
+  `;
+
 /**
  * A flexible component for subheadings. Capable of rendering using
  * different any of the heading HTML tags.
  */
-const SubHeading = styled(HtmlElement)(baseStyles, sizeStyles);
+const SubHeading = styled(HtmlElement)(baseStyles, sizeStyles, marginStyles);
 
 SubHeading.propTypes = {
   /**
@@ -42,6 +49,10 @@ SubHeading.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * Adds bottom margin to the sub-heading.
+   */
+  withMargin: PropTypes.bool,
+  /**
    * The HTML heading element to render.
    */
   element: PropTypes.oneOf(['h2', 'h3', 'h4', 'h5', 'h6'])
@@ -50,7 +61,8 @@ SubHeading.propTypes = {
 SubHeading.defaultProps = {
   element: 'h3',
   size: KILO,
-  className: ''
+  className: '',
+  withMargin: false
 };
 
 export default SubHeading;

--- a/src/components/SubHeading/SubHeading.js
+++ b/src/components/SubHeading/SubHeading.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
-import { typeMarginResets } from '../../styles/global-styles';
 import HtmlElement from '../HtmlElement/HtmlElement';
 import { childrenPropType } from '../../util/shared-prop-types';
 import { KILO, MEGA } from '../../util/sizes';
@@ -10,7 +9,6 @@ const baseStyles = ({ theme }) => css`
   label: sub-heading;
   text-transform: uppercase;
   font-weight: ${theme.fontWeight.bold};
-  ${typeMarginResets};
 `;
 
 const sizeStyles = ({ theme, size }) => css`

--- a/src/components/SubHeading/SubHeading.js
+++ b/src/components/SubHeading/SubHeading.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
@@ -24,11 +25,20 @@ const marginStyles = ({ theme, withMargin }) =>
     margin-bottom: ${theme.spacings.kilo};
   `;
 
+const SubHeadingElement = styled(HtmlElement)(
+  baseStyles,
+  sizeStyles,
+  marginStyles
+);
+
 /**
  * A flexible component for subheadings. Capable of rendering using
  * different any of the heading HTML tags.
  */
-const SubHeading = styled(HtmlElement)(baseStyles, sizeStyles, marginStyles);
+
+const SubHeading = props => (
+  <SubHeadingElement {...props} blacklist={{ withMargin: true }} />
+);
 
 SubHeading.propTypes = {
   /**
@@ -62,7 +72,8 @@ SubHeading.defaultProps = {
   element: 'h3',
   size: KILO,
   className: '',
-  withMargin: false
+  withMargin: false,
+  children: null
 };
 
 export default SubHeading;

--- a/src/components/SubHeading/__snapshots__/SubHeading.spec.js.snap
+++ b/src/components/SubHeading/__snapshots__/SubHeading.spec.js.snap
@@ -6,6 +6,7 @@ exports[`SubHeading should render as H2 element, when passed "h2" for the elemen
   font-weight: 700;
   font-size: 12px;
   line-height: 20px;
+  margin-bottom: 12px;
 }
 
 <h2
@@ -22,6 +23,7 @@ exports[`SubHeading should render as H3 element, when passed "h3" for the elemen
   font-weight: 700;
   font-size: 12px;
   line-height: 20px;
+  margin-bottom: 12px;
 }
 
 <h3
@@ -38,6 +40,7 @@ exports[`SubHeading should render as H4 element, when passed "h4" for the elemen
   font-weight: 700;
   font-size: 12px;
   line-height: 20px;
+  margin-bottom: 12px;
 }
 
 <h4
@@ -54,6 +57,7 @@ exports[`SubHeading should render as H5 element, when passed "h5" for the elemen
   font-weight: 700;
   font-size: 12px;
   line-height: 20px;
+  margin-bottom: 12px;
 }
 
 <h5
@@ -70,6 +74,7 @@ exports[`SubHeading should render as H6 element, when passed "h6" for the elemen
   font-weight: 700;
   font-size: 12px;
   line-height: 20px;
+  margin-bottom: 12px;
 }
 
 <h6
@@ -86,6 +91,7 @@ exports[`SubHeading should render with size kilo, when passed "kilo" for the siz
   font-weight: 700;
   font-size: 12px;
   line-height: 20px;
+  margin-bottom: 12px;
 }
 
 <h3
@@ -102,6 +108,7 @@ exports[`SubHeading should render with size mega, when passed "mega" for the siz
   font-weight: 700;
   font-size: 14px;
   line-height: 18px;
+  margin-bottom: 12px;
 }
 
 <h3

--- a/src/components/SubHeading/__snapshots__/SubHeading.spec.js.snap
+++ b/src/components/SubHeading/__snapshots__/SubHeading.spec.js.snap
@@ -4,10 +4,6 @@ exports[`SubHeading should render as H2 element, when passed "h2" for the elemen
 .circuit-0 {
   text-transform: uppercase;
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 12px;
   line-height: 20px;
 }
@@ -24,10 +20,6 @@ exports[`SubHeading should render as H3 element, when passed "h3" for the elemen
 .circuit-0 {
   text-transform: uppercase;
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 12px;
   line-height: 20px;
 }
@@ -44,10 +36,6 @@ exports[`SubHeading should render as H4 element, when passed "h4" for the elemen
 .circuit-0 {
   text-transform: uppercase;
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 12px;
   line-height: 20px;
 }
@@ -64,10 +52,6 @@ exports[`SubHeading should render as H5 element, when passed "h5" for the elemen
 .circuit-0 {
   text-transform: uppercase;
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 12px;
   line-height: 20px;
 }
@@ -84,10 +68,6 @@ exports[`SubHeading should render as H6 element, when passed "h6" for the elemen
 .circuit-0 {
   text-transform: uppercase;
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 12px;
   line-height: 20px;
 }
@@ -104,10 +84,6 @@ exports[`SubHeading should render with size kilo, when passed "kilo" for the siz
 .circuit-0 {
   text-transform: uppercase;
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 12px;
   line-height: 20px;
 }
@@ -124,10 +100,6 @@ exports[`SubHeading should render with size mega, when passed "mega" for the siz
 .circuit-0 {
   text-transform: uppercase;
   font-weight: 700;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 14px;
   line-height: 18px;
 }

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -6,12 +6,12 @@ import { childrenPropType } from '../../util/shared-prop-types';
 import { KILO, MEGA, GIGA } from '../../util/sizes';
 
 const baseStyles = ({ theme }) => css`
-  label: body-text;
+  label: text;
   font-weight: ${theme.fontWeight.regular};
 `;
 
 const sizeStyles = ({ theme, size }) => css`
-  label: body-text--${size};
+  label: text--${size};
   font-size: ${theme.typography.text[size].fontSize};
   line-height: ${theme.typography.text[size].lineHeight};
 `;
@@ -19,7 +19,7 @@ const sizeStyles = ({ theme, size }) => css`
 const marginStyles = ({ theme, withMargin }) =>
   withMargin &&
   css`
-    label: body-text--with-margin;
+    label: text--with-margin;
     margin-bottom: ${theme.spacings.mega};
   `;
 

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
-import { typeMarginResets } from '../../styles/global-styles';
 import HtmlElement from '../HtmlElement/HtmlElement';
 import { childrenPropType } from '../../util/shared-prop-types';
 import { KILO, MEGA, GIGA } from '../../util/sizes';
@@ -9,7 +8,6 @@ import { KILO, MEGA, GIGA } from '../../util/sizes';
 const baseStyles = ({ theme }) => css`
   label: body-text;
   font-weight: ${theme.fontWeight.regular};
-  ${typeMarginResets};
 `;
 
 const sizeStyles = ({ theme, size }) => css`

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -17,8 +17,8 @@ const sizeStyles = ({ theme, size }) => css`
   line-height: ${theme.typography.text[size].lineHeight};
 `;
 
-const marginStyles = ({ theme, withMargin }) =>
-  withMargin &&
+const marginStyles = ({ theme, margin }) =>
+  margin &&
   css`
     label: text--with-margin;
     margin-bottom: ${theme.spacings.mega};
@@ -31,9 +31,7 @@ const TextElement = styled(HtmlElement)(baseStyles, sizeStyles, marginStyles);
  * <p>, <div>, <article>, or <section> elements. Capable of rendering
  * using different HTML tags.
  */
-const Text = props => (
-  <TextElement {...props} blacklist={{ withMargin: true }} />
-);
+const Text = props => <TextElement {...props} blacklist={{ margin: true }} />;
 
 Text.KILO = KILO;
 Text.MEGA = MEGA;
@@ -60,7 +58,7 @@ Text.propTypes = {
   /**
    * Adds bottom margin to the text.
    */
-  withMargin: PropTypes.bool,
+  margin: PropTypes.bool,
   /**
    * The HTML element to render.
    */
@@ -71,7 +69,7 @@ Text.defaultProps = {
   element: 'p',
   size: MEGA,
   className: '',
-  withMargin: false,
+  margin: true,
   children: null
 };
 

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
@@ -23,12 +24,16 @@ const marginStyles = ({ theme, withMargin }) =>
     margin-bottom: ${theme.spacings.mega};
   `;
 
+const TextElement = styled(HtmlElement)(baseStyles, sizeStyles, marginStyles);
+
 /**
  * The Text component is used for long-form text. Typically with
  * <p>, <div>, <article>, or <section> elements. Capable of rendering
  * using different HTML tags.
  */
-const Text = styled(HtmlElement)(baseStyles, sizeStyles, marginStyles);
+const Text = props => (
+  <TextElement {...props} blacklist={{ withMargin: true }} />
+);
 
 Text.KILO = KILO;
 Text.MEGA = MEGA;
@@ -66,7 +71,8 @@ Text.defaultProps = {
   element: 'p',
   size: MEGA,
   className: '',
-  withMargin: false
+  withMargin: false,
+  children: null
 };
 
 export default Text;

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -16,12 +16,19 @@ const sizeStyles = ({ theme, size }) => css`
   line-height: ${theme.typography.text[size].lineHeight};
 `;
 
+const marginStyles = ({ theme, withMargin }) =>
+  withMargin &&
+  css`
+    label: body-text--with-margin;
+    margin-bottom: ${theme.spacings.mega};
+  `;
+
 /**
  * The Text component is used for long-form text. Typically with
  * <p>, <div>, <article>, or <section> elements. Capable of rendering
  * using different HTML tags.
  */
-const Text = styled(HtmlElement)(baseStyles, sizeStyles);
+const Text = styled(HtmlElement)(baseStyles, sizeStyles, marginStyles);
 
 Text.KILO = KILO;
 Text.MEGA = MEGA;
@@ -46,6 +53,10 @@ Text.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * Adds bottom margin to the text.
+   */
+  withMargin: PropTypes.bool,
+  /**
    * The HTML element to render.
    */
   element: PropTypes.string
@@ -54,7 +65,8 @@ Text.propTypes = {
 Text.defaultProps = {
   element: 'p',
   size: MEGA,
-  className: ''
+  className: '',
+  withMargin: false
 };
 
 export default Text;

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -5,6 +5,7 @@ exports[`Text should render as article element, when passed "article" for the el
   font-weight: 400;
   font-size: 15px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 <article
@@ -20,6 +21,7 @@ exports[`Text should render as div element, when passed "div" for the element pr
   font-weight: 400;
   font-size: 15px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 <div
@@ -35,6 +37,7 @@ exports[`Text should render as p element, when passed "p" for the element prop 1
   font-weight: 400;
   font-size: 15px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 <p
@@ -50,6 +53,7 @@ exports[`Text should render with size giga, when passed "giga" for the size prop
   font-weight: 400;
   font-size: 18px;
   line-height: 28px;
+  margin-bottom: 16px;
 }
 
 <p
@@ -65,6 +69,7 @@ exports[`Text should render with size kilo, when passed "kilo" for the size prop
   font-weight: 400;
   font-size: 13px;
   line-height: 20px;
+  margin-bottom: 16px;
 }
 
 <p
@@ -80,6 +85,7 @@ exports[`Text should render with size mega, when passed "mega" for the size prop
   font-weight: 400;
   font-size: 15px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 <p

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -3,10 +3,6 @@
 exports[`Text should render as article element, when passed "article" for the element prop 1`] = `
 .circuit-0 {
   font-weight: 400;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 15px;
   line-height: 24px;
 }
@@ -22,10 +18,6 @@ exports[`Text should render as article element, when passed "article" for the el
 exports[`Text should render as div element, when passed "div" for the element prop 1`] = `
 .circuit-0 {
   font-weight: 400;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 15px;
   line-height: 24px;
 }
@@ -41,10 +33,6 @@ exports[`Text should render as div element, when passed "div" for the element pr
 exports[`Text should render as p element, when passed "p" for the element prop 1`] = `
 .circuit-0 {
   font-weight: 400;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 15px;
   line-height: 24px;
 }
@@ -60,10 +48,6 @@ exports[`Text should render as p element, when passed "p" for the element prop 1
 exports[`Text should render with size giga, when passed "giga" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 400;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 18px;
   line-height: 28px;
 }
@@ -79,10 +63,6 @@ exports[`Text should render with size giga, when passed "giga" for the size prop
 exports[`Text should render with size kilo, when passed "kilo" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 400;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 13px;
   line-height: 20px;
 }
@@ -98,10 +78,6 @@ exports[`Text should render with size kilo, when passed "kilo" for the size prop
 exports[`Text should render with size mega, when passed "mega" for the size prop 1`] = `
 .circuit-0 {
   font-weight: 400;
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
   font-size: 15px;
   line-height: 24px;
 }

--- a/src/styles/global-styles.js
+++ b/src/styles/global-styles.js
@@ -16,13 +16,6 @@ export const fontSettings = `
   text-rendering: optimizeLegibility;
 `;
 
-export const typeMarginResets = `
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
-  -webkit-margin-start: 0;
-  -webkit-margin-end: 0;
-`;
-
 export default ({ theme }) => injectGlobal`
   /* http://meyerweb.com/eric/tools/css/reset/
    * v2.0 | 20110126


### PR DESCRIPTION
**Changes**
- Adds `margin` (default: `true`) option to typography components.
- Updates the way to prop of the `HtmlElement` component works. Moved to a hash implementation for better performance.
- Removes typography margin reset from globals as we're now doing that using the meyerweb resets.
- Smaller fixes here and there.

Closes #22. Let's revisit the topic of double spacing once we get there.