### PR TITLE
Feature enables absolute path for webpack and jest.

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -38,7 +38,10 @@ module.exports = function(storybookBaseConfig, configType) {
       new webpack.DefinePlugin({
         STORYBOOK: JSON.stringify(true)
       })
-    ]
+    ],
+    resolve: {
+      modules: [path.resolve('./src'), 'node_modules']
+    }
   };
 
   return merge(storybookBaseConfig, ourConfig);


### PR DESCRIPTION
 Noticed that we are using relative paths in all our imports.
 This change enables the use of absolute paths which is much more convenient. :)
 It makes the "root" for imports the folder "src" so you can import things directly from this path.
 
Just changed one Component as an example, but we can update the others after.

**TODO**
- [ ] Update module resolution mechanism in ESLint
- [ ] Update all module imports
