### PR TITLE
Add proper fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Project #
+
 package-lock.json
 .stylelintcache
 .eslintcache
@@ -5,3 +7,37 @@ package-lock.json
 node_modules
 jest-test-results.json
 __coverage__
+
+# Packages #
+
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Text editor files #
+
+*.sublime-workspace
+*.sublime-project
+*.editorconfig
+*.swp
+
+# Logs #
+
+*.log
+
+# OS generated files #
+
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:lint-js:watch": "onchange \"src/**/*.js\" -- npm run test:lint-js",
     "test:unit": "jest --coverage --no-cache",
     "test:unit:watch": "npm run test:unit:output -- --watch",
-    "test:unit:output": "jest --json --outputFile=jest-test-results.json",
+    "test:unit:output": "jest --json --outputFile=jest-test-results.json --no-cache",
     "prepush": "npm test",
     "start": "npm run test:unit:output && start-storybook -p 6006",
     "prebuild": "npm run test:unit:output",

--- a/src/styles/global-styles.js
+++ b/src/styles/global-styles.js
@@ -1,11 +1,13 @@
 import { injectGlobal } from 'emotion';
 import { textMega } from './style-helpers';
 
-// TODO: make this define actual font faces and optimize for size.
-//       I think there is a better way to do this nowadays without
-//       @fontface.
+// TODO: Make this define actual font faces and optimize for size.
 export const fontFaces = `
   @import url("https://use.typekit.net/dxb5kvg.css");
+`;
+
+export const fontStack = `
+  aktiv-grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI"
 `;
 
 export const fontSettings = `
@@ -75,7 +77,6 @@ export default ({ theme }) => injectGlobal`
 
   /* Our globals */
   ${fontFaces}
-  ${fontSettings}
 
   /**
    * Best practice from http://callmenick.com/post/the-new-box-sizing-reset
@@ -89,7 +90,6 @@ export default ({ theme }) => injectGlobal`
 
   html {
     box-sizing: border-box;
-    font-family: aktiv-grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI";
 
     [type='button'] {
       appearance: none;
@@ -98,9 +98,16 @@ export default ({ theme }) => injectGlobal`
 
   body {
     color: ${theme.colors.black};
-    font-weight: ${theme.fontWeight.regular};
-    font-family: aktiv-grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI";
     ${textMega({ theme })}
   }
 
+  /**
+   * NOTE: Form elements don't inherit font settings.
+   * https://stackoverflow.com/questions/26140050/why-is-font-family-not-inherited-in-button-tags-automatically
+   */
+  html, body, input, select, textarea, button {
+    font-weight: ${theme.fontWeight.regular};
+    font-family: ${fontStack};
+    ${fontSettings}
+  }
 `;


### PR DESCRIPTION
**Changes**

- Add sensible defaults to `.gitignore`
- Configure default global font-family

After researching the simplest and most performant approach to loading fonts, I must conclude that _simple_ and _performant_ are not achievable at the same time. I've opted to use the simple approach in Storybook.
I plan to add a section on performant font loading to our documentation, or we link to this [blog post](https://www.bramstein.com/writing/web-font-loading-patterns.html#prioritised-loading).

Closes #25.