### PR TITLE
Export size enums as component properties

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -227,7 +227,7 @@ Button.propTypes = {
   /**
    * Size of the button. Use the Button's KILO, MEGA, or GIGA properties.
    */
-  size: PropTypes.oneOf([KILO, MEGA, GIGA]),
+  size: PropTypes.oneOf([Button.KILO, Button.MEGA, Button.GIGA]),
   /**
    * Standard onClick function. If used on an anchor this can be used to
    * cause additional side-effects like tracking.

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -54,7 +54,15 @@ Heading.propTypes = {
   /**
    * A Circuit UI heading size.
    */
-  size: PropTypes.oneOf([KILO, MEGA, GIGA, TERA, PETA, EXA, ZETTA]),
+  size: PropTypes.oneOf([
+    Heading.KILO,
+    Heading.MEGA,
+    Heading.GIGA,
+    Heading.TERA,
+    Heading.PETA,
+    Heading.EXA,
+    Heading.ZETTA
+  ]),
   /**
    * An ID rendered as data-selector attribute on the
    * component. Used for tracking and e2e testing.
@@ -76,7 +84,7 @@ Heading.propTypes = {
 
 Heading.defaultProps = {
   element: 'h2',
-  size: PETA,
+  size: Heading.PETA,
   className: '',
   margin: true,
   children: null

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -53,6 +53,7 @@ const ListElement = props => (
  * A list, which can be ordered or unordered
  */
 const List = styled(ListElement)(baseStyles, sizeStyles);
+
 List.KILO = KILO;
 List.MEGA = MEGA;
 
@@ -64,7 +65,7 @@ List.propTypes = {
   /**
    * A Circuit UI body text size.
    */
-  size: PropTypes.oneOf([KILO, MEGA]),
+  size: PropTypes.oneOf([List.KILO, List.MEGA]),
   /**
    * Whether the list should be presented as an <ol>
    */
@@ -72,7 +73,7 @@ List.propTypes = {
 };
 
 List.defaultProps = {
-  size: KILO,
+  size: List.KILO,
   ordered: false
 };
 

--- a/src/components/List/List.story.js
+++ b/src/components/List/List.story.js
@@ -36,10 +36,10 @@ storiesOf('List', module)
   .add(
     'List kilo',
     withInfo()(() => (
-      <List size="kilo">
+      <List size={List.KILO}>
         <li>This is a list</li>
         <li>A very find list</li>
-        <List size="kilo">
+        <List size={List.KILO}>
           <li>Sometimes a nested list</li>
         </List>
         <li>The kind of list you like</li>
@@ -49,10 +49,10 @@ storiesOf('List', module)
   .add(
     'List mega',
     withInfo()(() => (
-      <List size="mega">
+      <List size={List.MEGA}>
         <li>This is a list</li>
         <li>A very find list</li>
-        <List size="mega">
+        <List size={List.MEGA}>
           <li>Sometimes a nested list</li>
         </List>
         <li>The kind of list you like</li>

--- a/src/components/LoadingBar/LoadingBar.js
+++ b/src/components/LoadingBar/LoadingBar.js
@@ -6,12 +6,13 @@ import { stripUnit } from 'polished';
 import { childrenPropType } from '../../util/shared-prop-types';
 import { textKilo } from '../../styles/style-helpers';
 import { uniqueId } from '../../util/id';
+import { KILO, MEGA, GIGA } from '../../util/sizes';
 
 const calculateSize = ({ theme, size }) => {
   const sizeMap = {
-    kilo: theme.spacings.byte,
-    mega: theme.spacings.mega,
-    giga: theme.spacings.tera
+    [KILO]: theme.spacings.byte,
+    [MEGA]: theme.spacings.mega,
+    [GIGA]: theme.spacings.tera
   };
   return sizeMap[size];
 };
@@ -84,6 +85,10 @@ const LoadingBar = ({ children, max, value, ...props }) => {
   );
 };
 
+LoadingBar.KILO = KILO;
+LoadingBar.MEGA = MEGA;
+LoadingBar.GIGA = GIGA;
+
 LoadingBar.propTypes = {
   /**
    * A number greater than zero, indicating how much work the task requires.
@@ -97,7 +102,7 @@ LoadingBar.propTypes = {
   /**
    * Size
    */
-  size: PropTypes.oneOf(['kilo', 'mega', 'giga']),
+  size: PropTypes.oneOf([LoadingBar.KILO, LoadingBar.MEGA, LoadingBar.GIGA]),
   /**
    * Child nodes to be rendered as the label.
    */
@@ -105,7 +110,7 @@ LoadingBar.propTypes = {
 };
 
 LoadingBar.defaultProps = {
-  size: 'kilo',
+  size: LoadingBar.KILO,
   max: 1.0,
   value: 0,
   children: null

--- a/src/components/LoadingBar/LoadingBar.story.js
+++ b/src/components/LoadingBar/LoadingBar.story.js
@@ -11,9 +11,9 @@ storiesOf('LoadingBar', module)
     'LoadingBar',
     withInfo()(() => (
       <div style={{ width: '25vw' }}>
-        <LoadingBar value={3} max={10} size="giga" />
-        <LoadingBar value={5} max={10} size="mega" />
-        <LoadingBar value={8} max={10} size="kilo" />
+        <LoadingBar value={3} max={10} size={LoadingBar.GIGA} />
+        <LoadingBar value={5} max={10} size={LoadingBar.MEGA} />
+        <LoadingBar value={8} max={10} size={LoadingBar.KILO} />
       </div>
     ))
   )
@@ -21,13 +21,13 @@ storiesOf('LoadingBar', module)
     'LoadingBar with label',
     withInfo()(() => (
       <div style={{ width: '25vw' }}>
-        <LoadingBar value={3} max={10} size="giga">
+        <LoadingBar value={3} max={10} size={LoadingBar.GIGA}>
           3/10
         </LoadingBar>
-        <LoadingBar value={5} max={10} size="mega">
+        <LoadingBar value={5} max={10} size={LoadingBar.MEGA}>
           50%
         </LoadingBar>
-        <LoadingBar value={8} max={10} size="kilo">
+        <LoadingBar value={8} max={10} size={LoadingBar.KILO}>
           Loading...
         </LoadingBar>
       </div>

--- a/src/components/SubHeading/SubHeading.js
+++ b/src/components/SubHeading/SubHeading.js
@@ -40,6 +40,9 @@ const SubHeading = props => (
   <SubHeadingElement {...props} blacklist={{ margin: true }} />
 );
 
+SubHeading.KILO = KILO;
+SubHeading.MEGA = MEGA;
+
 SubHeading.propTypes = {
   /**
    * An ID rendered as data-selector attribute on the
@@ -53,7 +56,7 @@ SubHeading.propTypes = {
   /**
    * A Circuit UI sub-heading size.
    */
-  size: PropTypes.oneOf([KILO, MEGA]),
+  size: PropTypes.oneOf([SubHeading.KILO, SubHeading.MEGA]),
   /**
    * Optional additional className string to overwrite styles.
    */
@@ -70,7 +73,7 @@ SubHeading.propTypes = {
 
 SubHeading.defaultProps = {
   element: 'h3',
-  size: KILO,
+  size: SubHeading.KILO,
   className: '',
   margin: true,
   children: null

--- a/src/components/SubHeading/SubHeading.story.js
+++ b/src/components/SubHeading/SubHeading.story.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
 import withTests from '../../util/withTests';
-import { KILO, MEGA } from '../../util/sizes';
 import SubHeading from '.';
 
 storiesOf('SubHeading', module)
@@ -11,7 +10,7 @@ storiesOf('SubHeading', module)
   .add(
     'Kilo SubHeading with h2',
     withInfo()(() => (
-      <SubHeading element="h2" size={KILO}>
+      <SubHeading element="h2" size={SubHeading.KILO}>
         This is an kilo SubHeading with an h2 element
       </SubHeading>
     ))
@@ -19,7 +18,7 @@ storiesOf('SubHeading', module)
   .add(
     'Mega SubHeading with h3',
     withInfo()(() => (
-      <SubHeading element="h3" size={MEGA}>
+      <SubHeading element="h3" size={SubHeading.MEGA}>
         This is a mega SubHeading with an h3 element
       </SubHeading>
     ))

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -50,7 +50,7 @@ Text.propTypes = {
   /**
    * A Circuit UI body text size.
    */
-  size: PropTypes.oneOf([KILO, MEGA, GIGA]),
+  size: PropTypes.oneOf([Text.KILO, Text.MEGA, Text.GIGA]),
   /**
    * Optional additional className string to overwrite styles.
    */
@@ -67,7 +67,7 @@ Text.propTypes = {
 
 Text.defaultProps = {
   element: 'p',
-  size: MEGA,
+  size: Text.MEGA,
   className: '',
   margin: true,
   children: null

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -6,6 +6,7 @@ import Input from '../Input';
 const baseStyles = css`
   label: textarea;
   overflow: auto;
+  resize: vertical;
 `;
 
 /**

--- a/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
@@ -13,6 +13,7 @@ exports[`TextArea should have the correct default styles 1`] = `
   font-size: 15px;
   line-height: 24px;
   overflow: auto;
+  resize: vertical;
 }
 
 .circuit-0:focus,
@@ -57,6 +58,7 @@ exports[`TextArea should prioritize error over optional styles 1`] = `
   opacity: 0.5;
   pointer-events: none;
   overflow: auto;
+  resize: vertical;
 }
 
 .circuit-0:focus,
@@ -125,6 +127,7 @@ exports[`TextArea should show with disabled styled when passed the disabled prop
   opacity: 0.5;
   pointer-events: none;
   overflow: auto;
+  resize: vertical;
 }
 
 .circuit-0:focus,
@@ -168,6 +171,7 @@ exports[`TextArea should show with invalid styles when passed the isInvalid prop
   font-size: 15px;
   line-height: 24px;
   overflow: auto;
+  resize: vertical;
 }
 
 .circuit-0:focus,
@@ -236,6 +240,7 @@ exports[`TextArea should show with optional styles when passed the isOptional pr
   border-style: dashed;
   box-shadow: none;
   overflow: auto;
+  resize: vertical;
 }
 
 .circuit-0:focus,

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -65,12 +65,14 @@ const Toggle = ({ label, explanation, margin, ...props }) => (
       explanation && (
         <ToggleTextWrapper>
           {label && (
-            <ToggleLabel element="label" size="kilo">
+            <ToggleLabel element="label" size={Text.KILO}>
               {label}
             </ToggleLabel>
           )}
           {explanation && (
-            <ToggleExplanation size="kilo">{explanation}</ToggleExplanation>
+            <ToggleExplanation size={Text.KILO}>
+              {explanation}
+            </ToggleExplanation>
           )}
         </ToggleTextWrapper>
       )}

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -4,9 +4,9 @@ import styled, { css } from 'react-emotion';
 
 import { textKilo } from '../../styles/style-helpers';
 
-const ALIGN_CENTER = 'center';
-const ALIGN_RIGHT = 'right';
-const ALIGN_LEFT = 'left';
+const CENTER = 'center';
+const RIGHT = 'right';
+const LEFT = 'left';
 
 const baseStyles = css`
   label: tooltip;
@@ -108,9 +108,9 @@ const Tooltip = ({ children, content, align, ...props }) => (
   </TooltipElement>
 );
 
-Tooltip.Center = ALIGN_CENTER;
-Tooltip.Right = ALIGN_RIGHT;
-Tooltip.Left = ALIGN_LEFT;
+Tooltip.CENTER = CENTER;
+Tooltip.RIGHT = RIGHT;
+Tooltip.LEFT = LEFT;
 
 Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
@@ -123,7 +123,7 @@ Tooltip.propTypes = {
    * The alignment of the tooltip.
    * It can be right, left or centered.
    */
-  align: PropTypes.oneOf([Tooltip.Center, Tooltip.Right, Tooltip.Left])
+  align: PropTypes.oneOf([Tooltip.CENTER, Tooltip.RIGHT, Tooltip.LEFT])
 };
 
 Tooltip.defaultProps = {

--- a/src/components/Tooltip/Tooltip.spec.js
+++ b/src/components/Tooltip/Tooltip.spec.js
@@ -11,7 +11,7 @@ describe('Tooltip', () => {
 
   it('should align to the center', () => {
     const component = create(
-      <Tooltip align={Tooltip.Center} content="The tooltip content">
+      <Tooltip align={Tooltip.CENTER} content="The tooltip content">
         Something with tooltip
       </Tooltip>
     );
@@ -20,7 +20,7 @@ describe('Tooltip', () => {
 
   it('should align to the right', () => {
     const component = create(
-      <Tooltip align={Tooltip.Right} content="The tooltip content">
+      <Tooltip align={Tooltip.RIGHT} content="The tooltip content">
         Something with tooltip
       </Tooltip>
     );
@@ -29,7 +29,7 @@ describe('Tooltip', () => {
 
   it('should align to the left', () => {
     const component = create(
-      <Tooltip align={Tooltip.Left} content="The tooltip content">
+      <Tooltip align={Tooltip.LEFT} content="The tooltip content">
         Something with tooltip
       </Tooltip>
     );
@@ -38,7 +38,7 @@ describe('Tooltip', () => {
 
   it('should render with icon', () => {
     const component = create(
-      <Tooltip align={Tooltip.Center} content="The tooltip content">
+      <Tooltip align={Tooltip.CENTER} content="The tooltip content">
         <span>Text and a</span>
         <DummyIcon />
       </Tooltip>
@@ -48,7 +48,7 @@ describe('Tooltip', () => {
 
   it('should accept icon as content', () => {
     const component = create(
-      <Tooltip align={Tooltip.Center} content={<DummyIcon />}>
+      <Tooltip align={Tooltip.CENTER} content={<DummyIcon />}>
         Some text
       </Tooltip>
     );

--- a/src/components/Tooltip/Tooltip.story.js
+++ b/src/components/Tooltip/Tooltip.story.js
@@ -28,7 +28,7 @@ storiesOf('Tooltip', module)
   .add(
     'Centered ',
     withInfo()(() => (
-      <Tooltip align={Tooltip.Center} content="The tooltip content">
+      <Tooltip align={Tooltip.CENTER} content="The tooltip content">
         Something with tooltip
       </Tooltip>
     ))
@@ -36,7 +36,7 @@ storiesOf('Tooltip', module)
   .add(
     'Left ',
     withInfo()(() => (
-      <Tooltip align={Tooltip.Left} content="The tooltip content">
+      <Tooltip align={Tooltip.LEFT} content="The tooltip content">
         Something with tooltip
       </Tooltip>
     ))
@@ -44,7 +44,7 @@ storiesOf('Tooltip', module)
   .add(
     'Right ',
     withInfo()(() => (
-      <Tooltip align={Tooltip.Right} content="The tooltip content">
+      <Tooltip align={Tooltip.RIGHT} content="The tooltip content">
         Something with tooltip
       </Tooltip>
     ))


### PR DESCRIPTION
**Changes**

- All components that accept a `size` prop now export their possible sizes as `Component.SIZE` 
- Prop types and default props now use `Component.SIZE` as well
- Updated stories and tests to follow same pattern