### PR TITLE
Fix global styles in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 jest-test-results.json
 __coverage__
 dist
+circuit-ui-global.css
 
 # Packages #
 

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -7,7 +7,16 @@ import { withSmartKnobs } from 'storybook-addon-smart-knobs';
 import { ThemeProvider } from 'emotion-theming';
 
 import { standard } from '../src/themes';
-import globalStyles from '../src/styles/global-styles';
+import injectGlobalStyles from '../src/styles/global-styles';
+
+// Dynamically decide wich styles to load.
+if (PRODUCTION) {
+  import('./circuit-ui-global.css');
+}
+
+if (!PRODUCTION) {
+  injectGlobalStyles({ theme: standard });
+}
 
 // Sets the info addon's options.
 setDefaults({
@@ -16,29 +25,32 @@ setDefaults({
 
 const req = require.context('../src/components', true, /\.story\.js$/);
 
-function loadStories() {
-  globalStyles({ theme: standard });
+const withThemeProvider = storyFn => (
+  <ThemeProvider theme={standard}>{storyFn()}</ThemeProvider>
+);
+
+const withStoryStyles = storyFn => {
+  return (
+    <div
+      style={{
+        backgroundColor: standard.colors.n100,
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh'
+      }}
+    >
+      {storyFn()}
+    </div>
+  );
+};
+
+const loadStories = () => {
   addDecorator(withSmartKnobs);
   addDecorator(withKnobs);
+  addDecorator(withStoryStyles);
+  addDecorator(withThemeProvider);
   req.keys().forEach(filename => req(filename));
-}
-
-addDecorator(storyFn => (
-  <ThemeProvider theme={standard}>{storyFn()}</ThemeProvider>
-));
-
-addDecorator(storyFn => (
-  <div
-    style={{
-      backgroundColor: standard.colors.n100,
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      height: '100vh'
-    }}
-  >
-    {storyFn()}
-  </div>
-));
+};
 
 configure(loadStories, module);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -11,7 +11,7 @@ import injectGlobalStyles from '../src/styles/global-styles';
 
 // Dynamically decide wich styles to load.
 if (PRODUCTION) {
-  import('./circuit-ui-global.css');
+  require.resolve('./circuit-ui-global.css');
 }
 
 if (!PRODUCTION) {

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -4,11 +4,7 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 
 module.exports = function(storybookBaseConfig, configType) {
-  if (configType === 'PRODUCTION') {
-    storybookBaseConfig.plugins = storybookBaseConfig.plugins.filter(
-      plugin => plugin.constructor.name !== 'UglifyJsPlugin'
-    );
-  }
+  const isProduction = configType === 'PRODUCTION';
 
   const ourConfig = {
     externals: {
@@ -36,10 +32,24 @@ module.exports = function(storybookBaseConfig, configType) {
     },
     plugins: [
       new webpack.DefinePlugin({
-        STORYBOOK: JSON.stringify(true)
+        STORYBOOK: JSON.stringify(true),
+        PRODUCTION: JSON.stringify(isProduction)
       })
     ]
   };
 
-  return merge(storybookBaseConfig, ourConfig);
+  const ourProdSpecificConfig = {
+    module: {
+      rules: [
+        {
+          test: /\.css$/,
+          loaders: ['style-loader', 'css-loader'],
+          include: path.resolve(__dirname)
+        }
+      ]
+    }
+  };
+
+  const baseConfig = merge(storybookBaseConfig, ourConfig);
+  return isProduction ? merge(baseConfig, ourProdSpecificConfig) : baseConfig;
 };

--- a/build/global-styles
+++ b/build/global-styles
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+require('babel-register');
+
+const { format } = require('prettier');
+
+const { standard } = require('../src/themes');
+const { createGlobalStyles } = require('../src/styles/global-styles');
+
+const globalStyles = createGlobalStyles({ theme: standard });
+console.log(format(globalStyles, { parser: 'css' }));

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-svg-loader": "^2.1.0",
     "react-test-renderer": "^16.2.0",
     "storybook-addon-smart-knobs": "^3.2.10",
-    "style-loader": "^0.19.1",
+    "style-loader": "^0.20.1",
     "stylelint": "^8.4.0",
     "stylelint-config-sass-guidelines": "^4.0.1",
     "stylelint-config-standard": "^18.0.0",
@@ -100,6 +100,7 @@
   "dependencies": {
     "babel-plugin-emotion": "^9.0.0-1",
     "babel-plugin-lodash": "^3.3.2",
+    "css-loader": "^0.28.9",
     "emotion": "^9.0.0-1",
     "emotion-theming": "^8.0.12",
     "facepaint": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
     "prepush": "yarn test",
     "start": "yarn test:unit:output && start-storybook -p 6006",
     "prebuild": "yarn test:unit:output",
-    "build": "build-storybook -c .storybook -o .out",
+    "build": "yarn build:stylesheet && yarn build:global-styles && yarn build:copy-global-styles && yarn build:storybook",
+    "build:storybook": "build-storybook -c .storybook -o .out",
     "build:stylesheet": "mkdir -p dist && BABEL_ENV=static node build/stylesheet > dist/circuit-ui.css",
+    "build:global-styles": "mkdir -p dist && ./build/global-styles > dist/circuit-ui-global.css",
+    "build:copy-global-styles": "cp -f dist/circuit-ui-global.css .storybook",
     "deploy": "storybook-to-ghpages"
   },
   "lint-staged": {

--- a/src/styles/global-styles.js
+++ b/src/styles/global-styles.js
@@ -18,7 +18,7 @@ export const fontSettings = `
   text-rendering: optimizeLegibility;
 `;
 
-export default ({ theme }) => injectGlobal`
+export const resets = `
   /* http://meyerweb.com/eric/tools/css/reset/
    * v2.0 | 20110126
    * License: none (public domain)
@@ -37,33 +37,38 @@ export default ({ theme }) => injectGlobal`
   figure, figcaption, footer, header, hgroup,
   menu, nav, output, ruby, section, summary,
   time, mark, audio, video {
-  	margin: 0;
-  	padding: 0;
-  	border: 0;
-  	font-size: 100%;
-  	font: inherit;
-  	vertical-align: baseline;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
   }
   /* HTML5 display-role reset for older browsers */
   article, aside, details, figcaption, figure,
   footer, header, hgroup, menu, nav, section {
-  	display: block;
+    display: block;
   }
   body {
-  	line-height: 1;
+    line-height: 1;
   }
   blockquote, q {
-  	quotes: none;
+    quotes: none;
   }
   blockquote:before, blockquote:after,
   q:before, q:after {
-  	content: '';
-  	content: none;
+    content: '';
+    content: none;
   }
   table {
-  	border-collapse: collapse;
-  	border-spacing: 0;
+    border-collapse: collapse;
+    border-spacing: 0;
   }
+`;
+
+export const createGlobalStyles = ({ theme }) => `
+  /* Use resets */
+  ${resets}
 
   /* Our globals */
   ${fontFaces}
@@ -101,3 +106,5 @@ export default ({ theme }) => injectGlobal`
     ${fontSettings}
   }
 `;
+
+export default ({ theme }) => injectGlobal(createGlobalStyles({ theme }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,7 +2525,7 @@ css-list-helpers@^1.0.1:
   dependencies:
     tcomb "^2.5.0"
 
-css-loader@^0.28.8:
+css-loader@^0.28.8, css-loader@^0.28.9:
   version "0.28.9"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.9.tgz#68064b85f4e271d7ce4c48a58300928e535d1c95"
   dependencies:
@@ -7777,7 +7777,7 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
-schema-utils@^0.4.0, schema-utils@^0.4.2:
+schema-utils@^0.4.0, schema-utils@^0.4.2, schema-utils@^0.4.3:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
   dependencies:
@@ -8198,6 +8198,13 @@ style-loader@^0.19.1:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
+
+style-loader@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.20.1.tgz#33ac2bf4d5c65a8906bc586ad253334c246998d0"
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^0.4.3"
 
 style-search@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
So, apparently one of the recent Storybook versions broke how `injectGlobal` injects our global styles into the DOM when run in production. I found out too late to start messing around with different Storybook versions. So this is the solution I ended up using:

- The global styles can now be written to a CSS file inside the dist folder via the `build:global-styles` npm script. They weren't extracted for the static stylesheet so far and we probably should have extracted them at some point.
- When building storybook for production, the global styles are written into a CSS file, the CSS file gets copied into `.storybook`, and storybook requires the CSS file. Webpack and it's css/style loader combo take care of injecting the styles.

Eventually, I want to write all our CSS styles into a styles folder in `dist`. I think it would make sense to split them up in a way similar to this:

```
dist/
└── styles
    ├── components
    │   ├── Button.css
    │   ├── Card.css
    │   └── ...
    └── global.css
```

Then people can put together their own CSS bundle, if they don't use all our components.