### PR TITLE
Remove smart knob plugin

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -46,7 +46,6 @@ const withStoryStyles = storyFn => {
 };
 
 const loadStories = () => {
-  addDecorator(withSmartKnobs);
   addDecorator(withKnobs);
   addDecorator(withStoryStyles);
   addDecorator(withThemeProvider);


### PR DESCRIPTION
I am making this PR just for having a history of why we are removing this plugin for now.  

- We noticed that Smart knob injects default functions and, for now, there is no option to avoid this behavior. An issue has been opened in order to add this option into the plugin https://github.com/storybooks/addon-smart-knobs/issues/23

That's why the `Iconed Tag` examples has no Icon.