### PR TITLE
Feature avoid breaking line for button content

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -61,6 +61,7 @@ const baseStyles = ({ theme, href, ...otherProps }) => css`
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   ${textMega({ theme })};
 
   &:active {

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -15,6 +15,7 @@ exports[`Button should have button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
@@ -76,6 +77,7 @@ exports[`Button should have disabled button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
@@ -137,6 +139,7 @@ exports[`Button should have flat button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
@@ -216,6 +219,7 @@ exports[`Button should have flat disabled button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
@@ -295,6 +299,7 @@ exports[`Button should have giga button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(12px - 0px) calc(32px - 0px);
@@ -356,6 +361,7 @@ exports[`Button should have kilo button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(4px - 0px) calc(16px - 0px);
@@ -417,6 +423,7 @@ exports[`Button should have mega button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
@@ -478,6 +485,7 @@ exports[`Button should have secondary button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
@@ -585,6 +593,7 @@ exports[`Button should have secondary disabled button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
@@ -692,6 +701,7 @@ exports[`Button should have secondary flat button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
@@ -799,6 +809,7 @@ exports[`Button should have stretch button styles 1`] = `
   width: auto;
   height: auto;
   text-decoration: none;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);


### PR DESCRIPTION
In my understanding, the most common use case is where the button content doesn't break lines so I think is fine defining this behavior to the default button style 