### PR TITLE
Make create-component script more portable

### DIFF
--- a/bin/create-component
+++ b/bin/create-component
@@ -6,4 +6,5 @@ template_path=templates/component/*
 mkdir -p src/components/$1
 cp $template_path ${components_path}/$1
 for i in ".spec." ".story." "."; do mv ${components_path}/$1/{Component,$1}${i}js; done;
-find ${components_path}/${1} -type f -iname "$1*js" -exec sed -i -e "s/Component/$1/g" {} +
+find ${components_path}/${1} -type f -iname "$1*js" -exec sed -i.bak "s/Component/$1/g" {} \;
+rm ${components_path}/${1}/*.bak

--- a/bin/create-component
+++ b/bin/create-component
@@ -5,5 +5,5 @@ template_path=templates/component/*
 
 mkdir -p src/components/$1
 cp $template_path ${components_path}/$1
-rename "s/Component/$1/" ${components_path}/${1}/*.js
-find -E ${components_path}/${1} -regex ".*$1.*\.js$" -exec sed -i '' "s/Component/$1/g" {} +
+for i in ".spec." ".story." "."; do mv ${components_path}/$1/{Component,$1}${i}js; done;
+find ${components_path}/${1} -type f -iname "$1*js" -exec sed -i -e "s/Component/$1/g" {} +


### PR DESCRIPTION
The `create-component` script wasn't running on my ubuntu dev machine, so I decided to make the script more portable. It should work with the GNU and BSD versions of `sed` and `find` now as well.