### PR TITLE
Add new default button style

### DIFF
--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -8,7 +8,7 @@ const baseStyles = ({ theme }) => css`
   label: badge;
   background-color: ${theme.colors.r500};
   border-radius: 100px;
-  color: ${theme.colors.buttonColor};
+  color: ${theme.colors.white};
   cursor: default;
   padding: 0 ${theme.spacings.byte};
   ${subHeadingKilo({ theme })};

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -48,14 +48,14 @@ const stretchStyles = ({ stretch }) =>
 
 const baseStyles = ({ theme, href, ...otherProps }) => css`
   label: button;
-  background-color: ${theme.colors.p500};
-  border-color: ${theme.colors.p700};
+  background-color: ${theme.colors.n100};
+  border-color: ${theme.colors.n300};
   border-radius: ${theme.borderRadius.mega};
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255, 255, 255, 0.06);
   display: ${href ? 'inline-block' : 'block'};
-  color: ${theme.colors.buttonColor};
+  color: ${theme.colors.n700};
   cursor: pointer;
   font-weight: ${theme.fontWeight.bold};
   width: auto;
@@ -64,25 +64,25 @@ const baseStyles = ({ theme, href, ...otherProps }) => css`
   ${textMega({ theme })};
 
   &:active {
-    background-color: ${theme.colors.p700};
-    border-color: ${theme.colors.p900};
+    background-color: ${theme.colors.n300};
+    border-color: ${theme.colors.n500};
     box-shadow: inset 0 4px 8px 0 rgba(12, 15, 20, 0.3);
   }
 
   &:focus {
-    border-color: ${theme.colors.p700};
+    border-color: ${theme.colors.n500};
     border-width: 2px;
     outline: 0;
     padding: ${calculatePadding({ theme, ...otherProps })('1px')};
   }
 
   &:hover {
-    background-color: ${theme.colors.p700};
+    background-color: ${theme.colors.n300};
   }
 
   &:hover,
   &:active {
-    border-color: ${theme.colors.p900};
+    border-color: ${theme.colors.n500};
     border-width: 1px;
     padding: ${calculatePadding({ theme, ...otherProps })()};
   }
@@ -92,6 +92,33 @@ const baseStyles = ({ theme, href, ...otherProps }) => css`
     ${disabledStyles};
   }
 `;
+
+const primaryStyles = ({ theme, primary }) =>
+  primary &&
+  css`
+    label: button--primary;
+    background-color: ${theme.colors.p500};
+    border-color: ${theme.colors.p700};
+    color: ${theme.colors.white};
+
+    &:active {
+      background-color: ${theme.colors.p700};
+      border-color: ${theme.colors.p900};
+    }
+
+    &:focus {
+      border-color: ${theme.colors.p700};
+    }
+
+    &:hover {
+      background-color: ${theme.colors.p700};
+    }
+
+    &:hover,
+    &:active {
+      border-color: ${theme.colors.p900};
+    }
+  `;
 
 const flatStyles = ({ theme, flat, secondary, ...otherProps }) =>
   flat &&
@@ -200,7 +227,12 @@ const TextOrButtonElement = props => (
  * prop.
  */
 const Button = styled(TextOrButtonElement)`
-  ${baseStyles} ${sizeStyles} ${flatStyles} ${secondaryStyles} ${stretchStyles};
+  ${baseStyles};
+  ${primaryStyles};
+  ${sizeStyles};
+  ${flatStyles};
+  ${secondaryStyles};
+  ${stretchStyles};
 `;
 
 Button.KILO = KILO;
@@ -225,6 +257,10 @@ Button.propTypes = {
    * primary (default) and flat buttons.
    */
   secondary: PropTypes.bool,
+  /**
+   * Renders a primary button using the brand color.
+   */
+  primary: PropTypes.bool,
   /**
    * Link target. Should only be passed, if href is passed, too.
    */
@@ -251,6 +287,7 @@ Button.defaultProps = {
   target: null,
   href: null,
   onClick: null,
+  primary: false,
   secondary: false,
   stretch: false
 };

--- a/src/components/Button/Button.story.js
+++ b/src/components/Button/Button.story.js
@@ -12,21 +12,22 @@ storiesOf('Button', module)
   .addDecorator(withTests('Button'))
   .add('Button', withInfo()(() => <Button>Button</Button>))
   .add('Button disabled', withInfo()(() => <Button disabled>Disabled</Button>))
+  .add('Button primary', withInfo()(() => <Button primary>Primary</Button>))
+  .add(
+    'Button primary disabled',
+    withInfo()(() => (
+      <Button primary disabled>
+        Primary
+      </Button>
+    ))
+  )
   .add(
     'Button secondary',
-    withInfo()(() => <Button secondary>Secondary</Button>)
-  )
-  .add(
-    'Button kilo',
-    withInfo()(() => <Button size={Button.KILO}>Button</Button>)
-  )
-  .add(
-    'Button mega',
-    withInfo()(() => <Button size={Button.MEGA}>Button</Button>)
-  )
-  .add(
-    'Button giga',
-    withInfo()(() => <Button size={Button.GIGA}>Button</Button>)
+    withInfo()(() => (
+      <Button secondary flat>
+        Flat Button
+      </Button>
+    ))
   )
   .add(
     'Button secondary disabled',
@@ -43,6 +44,14 @@ storiesOf('Button', module)
     withInfo()(() => (
       <Button flat disabled>
         Flat
+      </Button>
+    ))
+  )
+  .add(
+    'Flat Button primary',
+    withInfo()(() => (
+      <Button secondary flat>
+        Flat Button
       </Button>
     ))
   )
@@ -70,4 +79,16 @@ storiesOf('Button', module)
         <Button stretch>Stretched button</Button>
       </div>
     ))
+  )
+  .add(
+    'Button kilo',
+    withInfo()(() => <Button size={Button.KILO}>Button</Button>)
+  )
+  .add(
+    'Button mega',
+    withInfo()(() => <Button size={Button.MEGA}>Button</Button>)
+  )
+  .add(
+    'Button giga',
+    withInfo()(() => <Button size={Button.GIGA}>Button</Button>)
   );

--- a/src/components/Button/Button.story.js
+++ b/src/components/Button/Button.story.js
@@ -23,11 +23,7 @@ storiesOf('Button', module)
   )
   .add(
     'Button secondary',
-    withInfo()(() => (
-      <Button secondary flat>
-        Flat Button
-      </Button>
-    ))
+    withInfo()(() => <Button secondary>Flat Button</Button>)
   )
   .add(
     'Button secondary disabled',
@@ -37,7 +33,6 @@ storiesOf('Button', module)
       </Button>
     ))
   )
-  .add('Link Button', withInfo()(() => <Button href="#">Link</Button>))
   .add('Flat Button', withInfo()(() => <Button flat>Flat</Button>))
   .add(
     'Flat Button disabled',
@@ -50,7 +45,7 @@ storiesOf('Button', module)
   .add(
     'Flat Button primary',
     withInfo()(() => (
-      <Button secondary flat>
+      <Button primary flat>
         Flat Button
       </Button>
     ))
@@ -71,6 +66,7 @@ storiesOf('Button', module)
       </Button>
     ))
   )
+  .add('Link Button', withInfo()(() => <Button href="#">Link</Button>))
   .add(
     'Stretched Button',
     withInfo()(() => (

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -2,14 +2,14 @@
 
 exports[`Button should have button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -21,25 +21,25 @@ exports[`Button should have button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -55,6 +55,7 @@ exports[`Button should have button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Button
@@ -63,14 +64,14 @@ exports[`Button should have button styles 1`] = `
 
 exports[`Button should have disabled button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -82,25 +83,25 @@ exports[`Button should have disabled button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -116,6 +117,7 @@ exports[`Button should have disabled button styles 1`] = `
   disabled={true}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Disabled button
@@ -124,14 +126,14 @@ exports[`Button should have disabled button styles 1`] = `
 
 exports[`Button should have flat button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -145,25 +147,25 @@ exports[`Button should have flat button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -195,6 +197,7 @@ exports[`Button should have flat button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Flat button
@@ -203,14 +206,14 @@ exports[`Button should have flat button styles 1`] = `
 
 exports[`Button should have flat disabled button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -224,25 +227,25 @@ exports[`Button should have flat disabled button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -274,6 +277,7 @@ exports[`Button should have flat disabled button styles 1`] = `
   disabled={true}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Flat button
@@ -282,14 +286,14 @@ exports[`Button should have flat disabled button styles 1`] = `
 
 exports[`Button should have giga button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -301,25 +305,25 @@ exports[`Button should have giga button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(12px - 1px) calc(32px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(12px - 0px) calc(32px - 0px);
 }
@@ -335,6 +339,7 @@ exports[`Button should have giga button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Button
@@ -343,14 +348,14 @@ exports[`Button should have giga button styles 1`] = `
 
 exports[`Button should have kilo button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -362,25 +367,25 @@ exports[`Button should have kilo button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(4px - 1px) calc(16px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(4px - 0px) calc(16px - 0px);
 }
@@ -396,6 +401,7 @@ exports[`Button should have kilo button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Button
@@ -404,14 +410,14 @@ exports[`Button should have kilo button styles 1`] = `
 
 exports[`Button should have mega button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -423,25 +429,25 @@ exports[`Button should have mega button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -457,6 +463,7 @@ exports[`Button should have mega button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Button
@@ -465,14 +472,14 @@ exports[`Button should have mega button styles 1`] = `
 
 exports[`Button should have secondary button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -489,25 +496,25 @@ exports[`Button should have secondary button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -564,6 +571,7 @@ exports[`Button should have secondary button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Secondary button
@@ -572,14 +580,14 @@ exports[`Button should have secondary button styles 1`] = `
 
 exports[`Button should have secondary disabled button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -596,25 +604,25 @@ exports[`Button should have secondary disabled button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -671,6 +679,7 @@ exports[`Button should have secondary disabled button styles 1`] = `
   disabled={true}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Secondary disabled button
@@ -679,14 +688,14 @@ exports[`Button should have secondary disabled button styles 1`] = `
 
 exports[`Button should have secondary flat button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -703,25 +712,25 @@ exports[`Button should have secondary flat button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -778,6 +787,7 @@ exports[`Button should have secondary flat button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Secondary flat button
@@ -786,14 +796,14 @@ exports[`Button should have secondary flat button styles 1`] = `
 
 exports[`Button should have stretch button styles 1`] = `
 .circuit-0 {
-  background-color: #3388FF;
-  border-color: #2567D8;
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
   display: block;
-  color: #FFFFFF;
+  color: #5C656F;
   cursor: pointer;
   font-weight: 700;
   width: auto;
@@ -807,25 +817,25 @@ exports[`Button should have stretch button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:focus {
-  border-color: #2567D8;
+  border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
 .circuit-0:hover {
-  background-color: #2567D8;
+  background-color: #D8DDE1;
 }
 
 .circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -841,6 +851,7 @@ exports[`Button should have stretch button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
+  primary={false}
   target={null}
 >
   Stretched button

--- a/src/themes/default.js
+++ b/src/themes/default.js
@@ -52,8 +52,7 @@ const primary = {
 const misc = {
   shadow: '#0C0F14',
   bodyBg: neutrals.n100,
-  bodyColor: black,
-  buttonColor: '#FFFFFF'
+  bodyColor: black
 };
 
 export const colors = {


### PR DESCRIPTION
##### Changes

- Adds a new default button style (just a plain grey button).
- Makes the previous default button style available under a `primary` prop.
- Deleted a theme variable `buttonColor` under `misc`. It was not a consistent enough variable and was also used to badges, which isn't what you would expect given the name. I'm now using `theme.colors.white` instead.

##### Notes

- This PR does not add a specific `IconButton` component, as I think this is better addressed by using the `Button` component and passing in an Icon as child. It would be nice to export something like icon styles or a helper component that people can use to wrap their button (i.e. some styled `<div>`).

What do you think?

Closes #103 