### PR TITLE
Add Modal component

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   "dependencies": {
     "babel-plugin-emotion": "^9.0.0-1",
     "babel-plugin-lodash": "^3.3.2",
+    "create-react-context": "^0.2.1",
     "css-loader": "^0.28.9",
     "emotion": "^9.0.0-1",
     "emotion-theming": "^8.0.12",
@@ -114,6 +115,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-emotion": "^9.0.0-1",
+    "react-modal": "^3.3.2",
     "recompose": "^0.26.0"
   }
 }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -216,7 +216,13 @@ const sizeStyles = props => {
 
 const TextOrButtonElement = props => (
   <HtmlElement
-    blacklist={{ size: true, flat: true, secondary: true, stretch: true }}
+    blacklist={{
+      size: true,
+      flat: true,
+      primary: true,
+      secondary: true,
+      stretch: true
+    }}
     element={({ href }) => (href ? 'a' : 'button')}
     {...props}
   />

--- a/src/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__snapshots__/Button.spec.js.snap
@@ -55,7 +55,6 @@ exports[`Button should have button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Button
@@ -117,7 +116,6 @@ exports[`Button should have disabled button styles 1`] = `
   disabled={true}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Disabled button
@@ -197,7 +195,6 @@ exports[`Button should have flat button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Flat button
@@ -277,7 +274,6 @@ exports[`Button should have flat disabled button styles 1`] = `
   disabled={true}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Flat button
@@ -339,7 +335,6 @@ exports[`Button should have giga button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Button
@@ -401,7 +396,6 @@ exports[`Button should have kilo button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Button
@@ -463,7 +457,6 @@ exports[`Button should have mega button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Button
@@ -571,7 +564,6 @@ exports[`Button should have secondary button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Secondary button
@@ -679,7 +671,6 @@ exports[`Button should have secondary disabled button styles 1`] = `
   disabled={true}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Secondary disabled button
@@ -787,7 +778,6 @@ exports[`Button should have secondary flat button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Secondary flat button
@@ -851,7 +841,6 @@ exports[`Button should have stretch button styles 1`] = `
   disabled={false}
   href={null}
   onClick={null}
-  primary={false}
   target={null}
 >
   Stretched button

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -1,8 +1,7 @@
 import React, { Children } from 'react';
-import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
-import Button from '../Button';
+import { childrenPropType } from '../../util/shared-prop-types';
 
 const listStyles = ({ theme }) => css`
   label: button-group;
@@ -31,7 +30,7 @@ ButtonGroup.propTypes = {
   /**
    * Buttons to group.
    */
-  children: PropTypes.arrayOf(Button).isRequired
+  children: childrenPropType.isRequired
 };
 
 /**

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -20,6 +20,7 @@ const baseStyles = ({ theme }) => css`
   flex-direction: column;
   justify-content: space-between;
   min-width: 400px;
+  overflow: hidden;
 `;
 
 const shadowStyles = ({ theme, shadow }) => {

--- a/src/components/Card/Card.story.js
+++ b/src/components/Card/Card.story.js
@@ -73,7 +73,7 @@ storiesOf('Card', module)
     withInfo()(() => (
       <Card>
         <CardHeader>
-          <Heading size={Heading.KILO} margin={false}>
+          <Heading size={Heading.KILO} noMargin>
             Card heading
           </Heading>
         </CardHeader>
@@ -86,7 +86,7 @@ storiesOf('Card', module)
     withInfo()(() => (
       <Card>
         <CardHeader onClose={action('CloseButton clicked')}>
-          <Heading size={Heading.KILO} margin={false}>
+          <Heading size={Heading.KILO} noMargin>
             Card heading
           </Heading>
         </CardHeader>

--- a/src/components/Card/__snapshots__/Card.spec.js.snap
+++ b/src/components/Card/__snapshots__/Card.spec.js.snap
@@ -16,6 +16,7 @@ exports[`Card should render with default styles 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   min-width: 400px;
+  overflow: hidden;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   padding: 16px 24px;
 }
@@ -42,6 +43,7 @@ exports[`Card should render with shadow styles 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   min-width: 400px;
+  overflow: hidden;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   padding: 16px 24px;
 }
@@ -68,6 +70,7 @@ exports[`Card should render with shadow styles 2`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   min-width: 400px;
+  overflow: hidden;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06), 0 4px 4px 0 rgba(12,15,20,0.06);
   padding: 16px 24px;
 }
@@ -94,6 +97,7 @@ exports[`Card should render with shadow styles 3`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   min-width: 400px;
+  overflow: hidden;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 4px 4px 0 rgba(12,15,20,0.06), 0 8px 8px 0 rgba(12,15,20,0.06);
   padding: 16px 24px;
 }
@@ -120,6 +124,7 @@ exports[`Card should render with spacing styles 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   min-width: 400px;
+  overflow: hidden;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   padding: 16px 16px;
 }
@@ -146,6 +151,7 @@ exports[`Card should render with spacing styles 2`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   min-width: 400px;
+  overflow: hidden;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   padding: 16px 24px;
 }

--- a/src/components/Card/components/Footer/Footer.js
+++ b/src/components/Card/components/Footer/Footer.js
@@ -21,7 +21,7 @@ CardFooter.propTypes = {
   /**
    * Buttons wrapped in a ButtonGroup.
    */
-  children: PropTypes.arrayOf(PropTypes.element).isRequired
+  children: PropTypes.element
 };
 
 /**

--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -12,12 +12,20 @@ const baseStyles = ({ theme }) => css`
   margin-bottom: ${theme.spacings.giga};
 `;
 
+const noHeadingStyles = ({ children }) =>
+  !children[0] &&
+  css`
+    label: card__header--no-heading;
+    justify-content: flex-end;
+  `;
+
 /**
  * Header used in the Card component. Used for styling and alignment
  * purposes only.
  */
 const CardHeaderContainer = styled('header')`
   ${baseStyles};
+  ${noHeadingStyles};
 `;
 
 const CardHeader = ({ onClose, children }) => (

--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 import CloseButton from '../../../CloseButton';
+import { childrenPropType } from '../../../../util/shared-prop-types';
 
 const baseStyles = ({ theme }) => css`
   label: card__header;
@@ -37,9 +38,9 @@ const CardHeader = ({ onClose, children }) => (
 
 CardHeader.propTypes = {
   /**
-   * Heading and/or CloseButton for closing.
+   * Heading to be shown.
    */
-  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  children: childrenPropType,
   /**
    * Callback for the close button. If not specified, the button won't
    * be shown.
@@ -48,7 +49,8 @@ CardHeader.propTypes = {
 };
 
 CardHeader.defaultProps = {
-  onClose: null
+  onClose: null,
+  children: null
 };
 
 /**

--- a/src/components/Card/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Card/components/Header/__snapshots__/Header.spec.js.snap
@@ -15,6 +15,10 @@ exports[`CardHeader should render with default styles 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   margin-bottom: 24px;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
 }
 
 <header

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -38,7 +38,7 @@ const HeadingElement = styled(HtmlElement)`
  * different HTML tags.
  */
 const Heading = props => (
-  <HeadingElement {...props} blacklist={{ margin: true }} />
+  <HeadingElement {...props} blacklist={{ noMargin: true }} />
 );
 
 Heading.KILO = KILO;

--- a/src/components/Heading/__snapshots__/Heading.spec.js.snap
+++ b/src/components/Heading/__snapshots__/Heading.spec.js.snap
@@ -10,7 +10,6 @@ exports[`Heading should render as h1 element, when passed "h1" for the element p
 
 <h1
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="peta"
 >
   H1 heading
@@ -27,7 +26,6 @@ exports[`Heading should render as h2 element, when passed "h2" for the element p
 
 <h2
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="peta"
 >
   H2 heading
@@ -44,7 +42,6 @@ exports[`Heading should render as h3 element, when passed "h3" for the element p
 
 <h3
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="peta"
 >
   H3 heading
@@ -61,7 +58,6 @@ exports[`Heading should render as h4 element, when passed "h4" for the element p
 
 <h4
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="peta"
 >
   H4 heading
@@ -78,7 +74,6 @@ exports[`Heading should render as h5 element, when passed "h5" for the element p
 
 <h5
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="peta"
 >
   H5 heading
@@ -95,7 +90,6 @@ exports[`Heading should render as h6 element, when passed "h6" for the element p
 
 <h6
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="peta"
 >
   H6 heading
@@ -113,7 +107,6 @@ exports[`Heading should render with no margin styles when passed the noMargin pr
 
 <h2
   className="circuit-0 circuit-1"
-  noMargin={true}
   size="peta"
 />
 `;
@@ -128,7 +121,6 @@ exports[`Heading should render with size exa, when passed "exa" for the size pro
 
 <h2
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="exa"
 >
   exa heading
@@ -145,7 +137,6 @@ exports[`Heading should render with size giga, when passed "giga" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="giga"
 >
   giga heading
@@ -162,7 +153,6 @@ exports[`Heading should render with size kilo, when passed "kilo" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="kilo"
 >
   kilo heading
@@ -179,7 +169,6 @@ exports[`Heading should render with size mega, when passed "mega" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="mega"
 >
   mega heading
@@ -196,7 +185,6 @@ exports[`Heading should render with size peta, when passed "peta" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="peta"
 >
   peta heading
@@ -213,7 +201,6 @@ exports[`Heading should render with size tera, when passed "tera" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="tera"
 >
   tera heading
@@ -230,7 +217,6 @@ exports[`Heading should render with size zetta, when passed "zetta" for the size
 
 <h2
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="zetta"
 >
   zetta heading

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -8,6 +8,7 @@ import { transparentize } from 'polished';
 import Card from '../Card';
 import { childrenPropType, themePropType } from '../../util/shared-prop-types';
 import { mapValues } from '../../util/fp';
+import IS_IOS from '../../util/ios';
 
 export const TRANSITION_DURATION = 200;
 const TOP_MARGIN = '10vh';
@@ -129,26 +130,25 @@ injectGlobal`
     overflow: hidden;
     -webkit-overflow-scrolling: auto;
     width: 100vw;
-  }
-
-  /*
-   * This is a fix for IOS browsers which doesn't respect
-   * 'overflow: hidden' on body it makes the body scrollable.
-   *
-   * Related issue: https://bugs.webkit.org/show_bug.cgi?id=153852
-   */
-  .ReactModal__Body-ios.ReactModal__Body--open {
-    position: fixed;
+    /* Supposed to prevent scrolling and maintaining scroll
+     * position on iOS as per this Issue:
+     * https://github.com/reactjs/react-modal/issues/191
+     * Default solution would be to set position: fixed;
+     * but that still scrolls to the top and requires
+     * scrolling back to the original scroll position
+     * onClose. Nasty hack and we don't want that.
+     */
+    ${IS_IOS ? 'position: absolute;' : ''};
   }
 `;
 /* eslint-enable no-unused-expressions */
 
 /**
  * Circuit UI's wrapper component for ReactModal. Uses the Card component
- * to wrap content passed as the children prop.
+ * to wrap content passed as the children prop. Don't forget to set
+ * the aria prop when using this.
+ * http://reactcommunity.org/react-modal/accessibility/#aria
  */
-// TODO:
-// - implement Safari fix scroll position.
 const Modal = ({
   children,
   className,

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -94,7 +94,7 @@ const modalClassName = {
 
 const overlayClassName = {
   base: ({ theme }) => css`
-    background: ${transparentize(0.5, theme.colors.shadow)};
+    background: ${transparentize(0.84, theme.colors.shadow)};
     bottom: 0;
     left: 0;
     opacity: 0;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -148,14 +148,7 @@ injectGlobal`
  */
 // TODO:
 // - implement Safari fix scroll position.
-const Modal = ({
-  children,
-  title,
-  onClose,
-  contentLabel,
-  theme,
-  ...otherProps
-}) => {
+const Modal = ({ children, onClose, contentLabel, theme, ...otherProps }) => {
   // TODO: can we do this better?
   ReactModal.setAppElement(document.body);
   const getClassValues = mapValues(styleFn => styleFn({ theme }));
@@ -177,9 +170,7 @@ Modal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   theme: themePropType.isRequired,
-  title: PropTypes.string.isRequired,
-  contentLabel: PropTypes.string,
-  noCloseIcon: PropTypes.bool
+  contentLabel: PropTypes.string
 };
 
 Modal.defaultProps = {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
-import { injectGlobal, css } from 'react-emotion';
+import { injectGlobal, css, cx } from 'react-emotion';
 import { withTheme } from 'emotion-theming';
 import { transparentize } from 'polished';
 
@@ -144,11 +144,19 @@ injectGlobal`
 /* eslint-enable no-unused-expressions */
 
 /**
- * Circuit UI's wrapper component for ReactModal.
+ * Circuit UI's wrapper component for ReactModal. Uses the Card component
+ * to wrap content passed as the children prop.
  */
 // TODO:
 // - implement Safari fix scroll position.
-const Modal = ({ children, onClose, contentLabel, theme, ...otherProps }) => {
+const Modal = ({
+  children,
+  className,
+  onClose,
+  contentLabel,
+  theme,
+  ...otherProps
+}) => {
   // TODO: can we do this better?
   ReactModal.setAppElement(document.body);
   const getClassValues = mapValues(styleFn => styleFn({ theme }));
@@ -160,7 +168,12 @@ const Modal = ({ children, onClose, contentLabel, theme, ...otherProps }) => {
     onRequestClose: onClose,
     closeTimeoutMS: TRANSITION_DURATION,
     children: (
-      <Card className={cardStyles({ theme })}>{children({ onClose })}</Card>
+      <Card
+        className={cx(cardStyles({ theme }), className)}
+        shadow={Card.TRIPLE}
+      >
+        {children ? children({ onClose }) : null}
+      </Card>
     )
   };
 
@@ -172,10 +185,12 @@ Modal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   theme: themePropType.isRequired,
+  className: PropTypes.string,
   contentLabel: PropTypes.string
 };
 
 Modal.defaultProps = {
+  className: '',
   contentLabel: 'Modal'
 };
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 import { injectGlobal, css } from 'react-emotion';
 import { withTheme } from 'emotion-theming';
+import { transparentize } from 'polished';
 
 import Card from '../Card';
 import { childrenPropType, themePropType } from '../../util/shared-prop-types';
@@ -93,7 +94,7 @@ const modalClassName = {
 
 const overlayClassName = {
   base: ({ theme }) => css`
-    background: rgba(61, 66, 76, 0.25);
+    background: ${transparentize(0.5, theme.colors.shadow)};
     bottom: 0;
     left: 0;
     opacity: 0;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -159,7 +159,9 @@ const Modal = ({ children, onClose, contentLabel, theme, ...otherProps }) => {
     contentLabel,
     onRequestClose: onClose,
     closeTimeoutMS: TRANSITION_DURATION,
-    children: <Card className={cardStyles({ theme })}>{children()}</Card>
+    children: (
+      <Card className={cardStyles({ theme })}>{children({ onClose })}</Card>
+    )
   };
 
   return <ReactModal {...reactModalProps} />;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -7,7 +7,7 @@ import { transparentize } from 'polished';
 
 import Card, { CardHeader, CardFooter } from '../Card';
 import Heading from '../Heading';
-import { childrenPropType, themePropType } from '../../util/shared-prop-types';
+import { themePropType } from '../../util/shared-prop-types';
 import { mapValues } from '../../util/fp';
 import IS_IOS from '../../util/ios';
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -181,11 +181,32 @@ const Modal = ({
 };
 
 Modal.propTypes = {
+  /**
+   * Render prop for the content of the Modal.
+   */
   children: childrenPropType.isRequired,
+  /**
+   * Determines if the modal is visible or not.
+   */
   isOpen: PropTypes.bool.isRequired,
+  /**
+   * Function to close the modal. Passed down to the children
+   * render prop.
+   */
   onClose: PropTypes.func.isRequired,
+  /**
+   * The Circuit UI theme.
+   */
   theme: themePropType.isRequired,
+  /**
+   * Class name string to overwrite the default
+   * Card styles. Useful for removing padding from
+   * the Card.
+   */
   className: PropTypes.string,
+  /**
+   * React Modal's accessibility string.
+   */
   contentLabel: PropTypes.string
 };
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,0 +1,192 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactModal from 'react-modal';
+import { injectGlobal, css } from 'react-emotion';
+import { withTheme } from 'emotion-theming';
+
+import Card from '../Card';
+import { childrenPropType, themePropType } from '../../util/shared-prop-types';
+import { mapValues } from '../../util/fp';
+
+export const TRANSITION_DURATION = 200;
+const TOP_MARGIN = '10vh';
+const TRANSFORM_Y_FLOATING = '10vh';
+const FLOATING_TRANSITION = `${TRANSITION_DURATION}ms ease-in-out`;
+// eslint-disable-next-line max-len
+const FIXED_TRANSITION = `${TRANSITION_DURATION}ms cubic-bezier(0, 0.37, 0.64, 1)`;
+
+/**
+ * React Modal styles.
+ * Documentation: http://reactcommunity.org/react-modal/styles/classes.html
+ */
+
+const cardStyles = ({ theme }) => css`
+  width: 100%;
+
+  ${theme.mq.untilMedium`
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    min-width: initial;
+    position: relative;
+  `};
+`;
+
+const modalClassName = {
+  base: ({ theme }) => css`
+    outline: none;
+
+    ${theme.mq.untilMedium`
+      bottom: 0;
+      max-height: 80vh;
+      -webkit-overflow-scrolling: touch;
+      overflow-y: auto;
+      position: fixed;
+      transform: translateY(100%);
+      transition: transform ${FIXED_TRANSITION};
+      width: 100%;
+      width: 100vw;
+    `};
+
+    ${theme.mq.medium`
+      transition: transform ${FLOATING_TRANSITION},
+        opacity ${FLOATING_TRANSITION};
+      margin: ${TOP_MARGIN} auto auto;
+      max-height: 90vh;
+      max-width: 90%;
+      min-width: 450px;
+      opacity: 0;
+      position: relative;
+      transform: translateY(${TRANSFORM_Y_FLOATING});
+    `};
+
+    ${theme.mq.big`
+      max-width: 750px;
+    `};
+
+    ${theme.mq.huge`
+      max-width: 850px;
+    `};
+  `,
+  afterOpen: ({ theme }) => css`
+    ${theme.mq.untilMedium`
+      transform: translateY(0);
+    `};
+
+    ${theme.mq.medium`
+      opacity: 1;
+      transform: translateY(0);
+    `};
+  `,
+  /* eslint-disable max-len */
+  beforeClose: ({ theme }) => css`
+    ${theme.mq.untilMedium`
+       transform: translateY(100%);
+    `};
+
+    ${theme.mq.medium`
+       opacity: 0;
+       transform: translateY(${TRANSFORM_Y_FLOATING});
+    `};
+  `
+  /* eslint-enable max-len */
+};
+
+const overlayClassName = {
+  base: ({ theme }) => css`
+    background: rgba(61, 66, 76, 0.25);
+    bottom: 0;
+    left: 0;
+    opacity: 0;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transition: opacity 200ms ease-in-out;
+    z-index: 1000;
+
+    ${theme.mq.medium`
+      -webkit-overflow-scrolling: touch;
+      overflow-y: auto;
+    `};
+  `,
+  afterOpen: () => css`
+    opacity: 1;
+  `,
+  beforeClose: () => css`
+    opacity: 0;
+  `
+};
+
+/**
+ * Global body styles
+ */
+
+/* eslint-disable no-unused-expressions */
+injectGlobal`
+   /* Remove scroll on the body when react-modal is open */
+  .ReactModal__Body--open {
+    height: 100%;
+    overflow: hidden;
+    -webkit-overflow-scrolling: auto;
+    width: 100vw;
+  }
+
+  /*
+   * This is a fix for IOS browsers which doesn't respect
+   * 'overflow: hidden' on body it makes the body scrollable.
+   *
+   * Related issue: https://bugs.webkit.org/show_bug.cgi?id=153852
+   */
+  .ReactModal__Body-ios.ReactModal__Body--open {
+    position: fixed;
+  }
+`;
+/* eslint-enable no-unused-expressions */
+
+/**
+ * Circuit UI's wrapper component for ReactModal.
+ */
+// TODO:
+// - implement Safari fix scroll position.
+const Modal = ({
+  children,
+  title,
+  onClose,
+  contentLabel,
+  theme,
+  ...otherProps
+}) => {
+  // TODO: can we do this better?
+  ReactModal.setAppElement(document.body);
+  const getClassValues = mapValues(styleFn => styleFn({ theme }));
+  const reactModalProps = {
+    ...otherProps,
+    className: getClassValues(modalClassName),
+    overlayClassName: getClassValues(overlayClassName),
+    contentLabel,
+    onRequestClose: onClose,
+    closeTimeoutMS: TRANSITION_DURATION,
+    children: <Card className={cardStyles({ theme })}>{children()}</Card>
+  };
+
+  return <ReactModal {...reactModalProps} />;
+};
+
+Modal.propTypes = {
+  children: childrenPropType.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  theme: themePropType.isRequired,
+  title: PropTypes.string.isRequired,
+  contentLabel: PropTypes.string,
+  noCloseIcon: PropTypes.bool
+};
+
+Modal.defaultProps = {
+  contentLabel: 'Modal',
+  noCloseIcon: false
+};
+
+/**
+ * @component
+ */
+export default withTheme(Modal);

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -36,6 +36,7 @@ const cardStyles = ({ theme }) => css`
 
 const modalClassName = {
   base: ({ theme }) => css`
+    label: modal;
     outline: none;
 
     ${theme.mq.untilMedium`
@@ -71,6 +72,7 @@ const modalClassName = {
     `};
   `,
   afterOpen: ({ theme }) => css`
+    label: modal--after-open;
     ${theme.mq.untilMedium`
       transform: translateY(0);
     `};
@@ -82,6 +84,7 @@ const modalClassName = {
   `,
   /* eslint-disable max-len */
   beforeClose: ({ theme }) => css`
+    label: modal--before-close;
     ${theme.mq.untilMedium`
        transform: translateY(100%);
     `};
@@ -96,6 +99,7 @@ const modalClassName = {
 
 const overlayClassName = {
   base: ({ theme }) => css`
+    label: modal__overlay;
     background: ${transparentize(0.84, theme.colors.shadow)};
     bottom: 0;
     left: 0;
@@ -112,9 +116,11 @@ const overlayClassName = {
     `};
   `,
   afterOpen: () => css`
+    label: modal__overlay--after-open;
     opacity: 1;
   `,
   beforeClose: () => css`
+    label: modal__overlay--before-close;
     opacity: 0;
   `
 };

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -165,10 +165,10 @@ const Modal = ({
   title,
   hasCloseButton,
   buttons,
+  appElement,
   ...otherProps
 }) => {
   // TODO: can we do this better?
-  ReactModal.setAppElement(document.body);
   const getClassValues = mapValues(styleFn => styleFn({ theme }));
   const reactModalProps = {
     ...otherProps,
@@ -182,9 +182,9 @@ const Modal = ({
         className={cx(cardStyles({ theme }), className)}
         shadow={Card.TRIPLE}
       >
-        {(title.length || hasCloseButton) && (
+        {(title || hasCloseButton) && (
           <CardHeader onClose={hasCloseButton ? onClose : null}>
-            {!!title.length && (
+            {title && (
               <Heading size={Heading.KILO} noMargin>
                 {title}
               </Heading>
@@ -204,7 +204,7 @@ Modal.propTypes = {
   /**
    * Render prop for the content of the Modal.
    */
-  children: childrenPropType.isRequired,
+  children: PropTypes.func.isRequired,
   /**
    * Determines if the modal is visible or not.
    */
@@ -240,15 +240,17 @@ Modal.propTypes = {
   /**
    * React Modal's accessibility string.
    */
-  contentLabel: PropTypes.string
+  contentLabel: PropTypes.string,
+  appElement: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
 };
 
 Modal.defaultProps = {
   className: '',
   contentLabel: 'Modal',
-  title: '',
+  title: null,
   hasCloseButton: true,
-  buttons: null
+  buttons: null,
+  appElement: '#root'
 };
 
 /**

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -176,8 +176,7 @@ Modal.propTypes = {
 };
 
 Modal.defaultProps = {
-  contentLabel: 'Modal',
-  noCloseIcon: false
+  contentLabel: 'Modal'
 };
 
 /**

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -5,7 +5,8 @@ import { injectGlobal, css, cx } from 'react-emotion';
 import { withTheme } from 'emotion-theming';
 import { transparentize } from 'polished';
 
-import Card from '../Card';
+import Card, { CardHeader, CardFooter } from '../Card';
+import Heading from '../Heading';
 import { childrenPropType, themePropType } from '../../util/shared-prop-types';
 import { mapValues } from '../../util/fp';
 import IS_IOS from '../../util/ios';
@@ -155,6 +156,9 @@ const Modal = ({
   onClose,
   contentLabel,
   theme,
+  title,
+  hasCloseButton,
+  buttons,
   ...otherProps
 }) => {
   // TODO: can we do this better?
@@ -172,7 +176,17 @@ const Modal = ({
         className={cx(cardStyles({ theme }), className)}
         shadow={Card.TRIPLE}
       >
+        {(title.length || hasCloseButton) && (
+          <CardHeader onClose={hasCloseButton ? onClose : null}>
+            {!!title.length && (
+              <Heading size={Heading.KILO} noMargin>
+                {title}
+              </Heading>
+            )}
+          </CardHeader>
+        )}
         {children ? children({ onClose }) : null}
+        {buttons && <CardFooter>{buttons({ onClose })}</CardFooter>}
       </Card>
     )
   };
@@ -198,6 +212,19 @@ Modal.propTypes = {
    * The Circuit UI theme.
    */
   theme: themePropType.isRequired,
+  /*
+   * Heading to be shown at the top of the modal.
+   */
+  title: PropTypes.string,
+  /*
+   * A render prop rendering buttons. If you use multiple buttons,
+   * wrap them in a ButtonGroup.
+   */
+  buttons: PropTypes.func,
+  /*
+   * Whether a close button (x) should be shown in the top right.
+   */
+  hasCloseButton: PropTypes.bool,
   /**
    * Class name string to overwrite the default
    * Card styles. Useful for removing padding from
@@ -212,7 +239,10 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   className: '',
-  contentLabel: 'Modal'
+  contentLabel: 'Modal',
+  title: '',
+  hasCloseButton: true,
+  buttons: null
 };
 
 /**

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -168,7 +168,7 @@ const Modal = ({
   appElement,
   ...otherProps
 }) => {
-  // TODO: can we do this better?
+  ReactModal.setAppElement(appElement);
   const getClassValues = mapValues(styleFn => styleFn({ theme }));
   const reactModalProps = {
     ...otherProps,
@@ -241,6 +241,11 @@ Modal.propTypes = {
    * React Modal's accessibility string.
    */
   contentLabel: PropTypes.string,
+  /**
+   * The element that should be used as root for the
+   * React portal used to display the modal. See
+   * http://reactcommunity.org/react-modal/accessibility/#app-element
+   */
   appElement: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
 };
 

--- a/src/components/Modal/Modal.spec.js
+++ b/src/components/Modal/Modal.spec.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import Modal, { ModalProvider } from '.';
 import Button from '../Button';

--- a/src/components/Modal/Modal.spec.js
+++ b/src/components/Modal/Modal.spec.js
@@ -20,7 +20,10 @@ describe('Modal', () => {
             <Button
               type="button"
               onClick={() => {
-                setModal(modal);
+                setModal({
+                  ...modal,
+                  appElement: document.getElementById('root')
+                });
               }}
             >
               Open modal

--- a/src/components/Modal/Modal.spec.js
+++ b/src/components/Modal/Modal.spec.js
@@ -68,6 +68,10 @@ describe('Modal', () => {
     const wrapper = openModal(defaultModal);
     const closeButton = wrapper.find('SvgButton').find('button');
     closeButton.simulate('click');
+    /**
+     * Tried using jest's runAllTimers to force the ModalProvider
+     * to update state, but this didn't work. Somehow, this hack does.
+     */
     await new Promise(resolve => {
       setTimeout(() => resolve());
     });

--- a/src/components/Modal/Modal.spec.js
+++ b/src/components/Modal/Modal.spec.js
@@ -1,7 +1,114 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
-import Modal from '.';
+import Modal, { ModalProvider } from '.';
+import Button from '../Button';
+import ButtonGroup from '../ButtonGroup';
+
+import * as MockedModal from './Modal';
 
 describe('Modal', () => {
-  it.skip('should', () => {});
+  beforeEach(() => {
+    MockedModal.TRANSITION_DURATION = 0;
+  });
+
+  // eslint-disable-next-line react/prop-types
+  const PageWithModal = ({ modal }) => (
+    <div id="root">
+      <ModalProvider>
+        <Modal>
+          {({ setModal }) => (
+            <Button
+              type="button"
+              onClick={() => {
+                setModal(modal);
+              }}
+            >
+              Open modal
+            </Button>
+          )}
+        </Modal>
+      </ModalProvider>
+    </div>
+  );
+
+  const defaultModal = {
+    // eslint-disable-next-line react/prop-types, no-unused-vars
+    children: () => <div>Hello World!</div>,
+    // Disables the need for a wrapper. I couldn't get the Modal to work
+    // with the wrapper enabled. Here's an issue describing that it
+    // should work:
+    // https://github.com/reactjs/react-modal/issues/563
+    // Here are the docs for setting the app element:
+    // http://reactcommunity.org/react-modal/accessibility/#app-element
+    ariaHideApp: false,
+    onClose: jest.fn()
+  };
+
+  const openModal = modal => {
+    const wrapper = mount(<PageWithModal modal={modal} />);
+    const button = wrapper.find('Button');
+    button.simulate('click');
+    wrapper.update();
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should open', () => {
+    const wrapper = openModal(defaultModal);
+    expect(wrapper.find('Card')).toHaveLength(1);
+  });
+
+  it('should close', async () => {
+    const wrapper = openModal(defaultModal);
+    const closeButton = wrapper.find('SvgButton').find('button');
+    closeButton.simulate('click');
+    await new Promise(resolve => {
+      setTimeout(() => resolve());
+    });
+    wrapper.update();
+    expect(defaultModal.onClose).toHaveBeenCalled();
+    expect(wrapper.find('Card')).toHaveLength(0);
+  });
+
+  it('should render the children render prop', () => {
+    const wrapper = openModal(defaultModal);
+    expect(wrapper.find('Card').html()).toContain('Hello World!');
+  });
+
+  it('should have a title, when the title prop is set', () => {
+    const titleModal = { ...defaultModal, title: 'Some title' };
+    const wrapper = openModal(titleModal);
+    expect(wrapper.find('Heading')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('Heading')
+        .first()
+        .text()
+    ).toBe(titleModal.title);
+  });
+
+  it('should show buttons when the buttons render prop is provided', () => {
+    const buttonModal = {
+      ...defaultModal,
+      // eslint-disable-next-line react/prop-types
+      buttons: ({ onClose }) => (
+        <ButtonGroup>
+          <Button key="confirm" onClick={onClose} data-test="confirm-button">
+            Confirm Button
+          </Button>
+          <Button key="cancel" onClick={onClose} data-test="cancel-button">
+            Cancel Button
+          </Button>
+        </ButtonGroup>
+      )
+    };
+    const wrapper = openModal(buttonModal);
+    const closeButton = wrapper.find('button[data-test="cancel-button"]');
+    expect(closeButton).toHaveLength(1);
+    closeButton.simulate('click');
+    expect(buttonModal.onClose).toHaveBeenCalled();
+  });
 });

--- a/src/components/Modal/Modal.spec.js
+++ b/src/components/Modal/Modal.spec.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import Modal from '.';
+
+describe('Modal', () => {
+  it.skip('should', () => {});
+});

--- a/src/components/Modal/Modal.story.js
+++ b/src/components/Modal/Modal.story.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
@@ -7,8 +7,6 @@ import styled, { css } from 'react-emotion';
 import withTests from '../../util/withTests';
 import Modal, { ModalProvider } from '.';
 import Button from '../Button';
-import Heading from '../Heading';
-import { CardHeader, CardFooter } from '../Card';
 import ButtonGroup from '../ButtonGroup';
 import Text from '../Text';
 
@@ -46,37 +44,20 @@ storiesOf('Modal', module)
     withInfo()(() => {
       const modalWithTitle = {
         ...defaultModal,
-        children: () => (
-          <Fragment>
-            <CardHeader>
-              <Heading size={Heading.KILO} noMargin>
-                Modal title
-              </Heading>
-            </CardHeader>
-            <Text>Some text in the modal body.</Text>
-          </Fragment>
-        )
+        title: 'A modal',
+        children: () => <Text>Some text in the modal body.</Text>
       };
       return <PageWithModal modal={modalWithTitle} />;
     })
   )
   .add(
-    'Modal with close button',
+    'Modal without close button',
     withInfo()(() => {
       const modalWithTitleAndCloser = {
         ...defaultModal,
+        hasCloseButton: false,
         // eslint-disable-next-line react/prop-types
-        children: ({ onClose }) => (
-          <Fragment>
-            <CardHeader
-              onClose={e => {
-                action('Close button pressed')(e);
-                onClose(e);
-              }}
-            />
-            <Text>Some text in the modal body.</Text>
-          </Fragment>
-        )
+        children: () => <Text>Some text in the modal body.</Text>
       };
       return <PageWithModal modal={modalWithTitleAndCloser} />;
     })
@@ -86,22 +67,9 @@ storiesOf('Modal', module)
     withInfo()(() => {
       const modalWithTitle = {
         ...defaultModal,
+        title: 'A modal',
         // eslint-disable-next-line react/prop-types
-        children: ({ onClose }) => (
-          <Fragment>
-            <CardHeader
-              onClose={e => {
-                action('Close button pressed')(e);
-                onClose(e);
-              }}
-            >
-              <Heading size={Heading.KILO} noMargin>
-                Modal title
-              </Heading>
-            </CardHeader>
-            <Text>Some text in the modal body.</Text>
-          </Fragment>
-        )
+        children: () => <Text>Some text in the modal body.</Text>
       };
       return <PageWithModal modal={modalWithTitle} />;
     })
@@ -111,44 +79,31 @@ storiesOf('Modal', module)
     withInfo()(() => {
       const modalWithTitle = {
         ...defaultModal,
+        title: 'A modal',
         // eslint-disable-next-line react/prop-types
-        children: ({ onClose }) => (
-          <Fragment>
-            <CardHeader
-              onClose={e => {
-                action('Close button pressed')(e);
+        buttons: ({ onClose }) => (
+          <ButtonGroup>
+            <Button
+              secondary
+              onClick={e => {
+                action('Cancel button clicked')(e);
                 onClose(e);
               }}
             >
-              <Heading size={Heading.KILO} noMargin>
-                Modal title
-              </Heading>
-            </CardHeader>
-            <Text>Some text in the modal body.</Text>
-            <CardFooter>
-              <ButtonGroup>
-                <Button
-                  secondary
-                  onClick={e => {
-                    action('Cancel button clicked')(e);
-                    onClose(e);
-                  }}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  primary
-                  onClick={e => {
-                    action('Confirm button clicked')(e);
-                    onClose(e);
-                  }}
-                >
-                  Confirm
-                </Button>
-              </ButtonGroup>
-            </CardFooter>
-          </Fragment>
-        )
+              Cancel
+            </Button>
+            <Button
+              primary
+              onClick={e => {
+                action('Confirm button clicked')(e);
+                onClose(e);
+              }}
+            >
+              Confirm
+            </Button>
+          </ButtonGroup>
+        ),
+        children: () => <Text>Some text in the modal body.</Text>
       };
       return <PageWithModal modal={modalWithTitle} />;
     })
@@ -186,6 +141,7 @@ storiesOf('Modal', module)
       const modalWithTitle = {
         ...defaultModal,
         className: cardClassName,
+        hasCloseButton: false,
         children: () => (
           <Container>
             <LeftColumn>

--- a/src/components/Modal/Modal.story.js
+++ b/src/components/Modal/Modal.story.js
@@ -8,6 +8,7 @@ import Modal, { ModalProvider } from '.';
 import Button from '../Button';
 import Heading from '../Heading';
 import { CardHeader, CardFooter } from '../Card';
+import ButtonGroup from '../ButtonGroup';
 import Text from '../Text';
 
 // eslint-disable-next-line react/prop-types
@@ -98,6 +99,52 @@ storiesOf('Modal', module)
               </Heading>
             </CardHeader>
             <Text>Some text in the modal body.</Text>
+          </Fragment>
+        )
+      };
+      return <PageWithModal modal={modalWithTitle} />;
+    })
+  )
+  .add(
+    'Modal with footer buttons',
+    withInfo()(() => {
+      const modalWithTitle = {
+        ...defaultModal,
+        // eslint-disable-next-line react/prop-types
+        children: ({ onClose }) => (
+          <Fragment>
+            <CardHeader
+              onClose={e => {
+                action('Close button pressed')(e);
+                onClose(e);
+              }}
+            >
+              <Heading size={Heading.KILO} noMargin>
+                Modal title
+              </Heading>
+            </CardHeader>
+            <Text>Some text in the modal body.</Text>
+            <CardFooter>
+              <ButtonGroup>
+                <Button
+                  onClick={e => {
+                    action('Cancel button clicked')(e);
+                    onClose(e);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  primary
+                  onClick={e => {
+                    action('Confirm button clicked')(e);
+                    onClose(e);
+                  }}
+                >
+                  Confirm
+                </Button>
+              </ButtonGroup>
+            </CardFooter>
           </Fragment>
         )
       };

--- a/src/components/Modal/Modal.story.js
+++ b/src/components/Modal/Modal.story.js
@@ -1,0 +1,40 @@
+import React, { Fragment } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import withTests from '../../util/withTests';
+import ModalConsumer, { ModalProvider } from '.';
+import Button from '../Button';
+
+const modalConfig = {
+  // eslint-disable-next-line react/prop-types, no-unused-vars
+  children: ({ onClose }) => <div>Hello World!</div>,
+  onClose: () => {
+    // eslint-disable-next-line
+    console.log('Modal closed');
+  }
+};
+
+const PageWithModal = () => (
+  <ModalProvider>
+    <ModalConsumer>
+      {({ setModal }) => (
+        <Fragment>
+          <div>This page can open a modal!</div>
+          <Button
+            type="button"
+            onClick={() => {
+              setModal(modalConfig);
+            }}
+          >
+            Open modal
+          </Button>
+        </Fragment>
+      )}
+    </ModalConsumer>
+  </ModalProvider>
+);
+
+storiesOf('Modal', module)
+  .addDecorator(withTests('Modal'))
+  .add('Default Modal', withInfo()(() => <PageWithModal />));

--- a/src/components/Modal/Modal.story.js
+++ b/src/components/Modal/Modal.story.js
@@ -128,6 +128,7 @@ storiesOf('Modal', module)
             <CardFooter>
               <ButtonGroup>
                 <Button
+                  secondary
                   onClick={e => {
                     action('Cancel button clicked')(e);
                     onClose(e);

--- a/src/components/Modal/Modal.story.js
+++ b/src/components/Modal/Modal.story.js
@@ -1,40 +1,106 @@
 import React, { Fragment } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
 
 import withTests from '../../util/withTests';
 import ModalConsumer, { ModalProvider } from '.';
 import Button from '../Button';
+import Heading from '../Heading';
+import { CardHeader, CardFooter } from '../Card';
+import Text from '../Text';
 
-const modalConfig = {
-  // eslint-disable-next-line react/prop-types, no-unused-vars
-  children: ({ onClose }) => <div>Hello World!</div>,
-  onClose: () => {
-    // eslint-disable-next-line
-    console.log('Modal closed');
-  }
-};
-
-const PageWithModal = () => (
+// eslint-disable-next-line react/prop-types
+const PageWithModal = ({ modal }) => (
   <ModalProvider>
     <ModalConsumer>
       {({ setModal }) => (
-        <Fragment>
-          <div>This page can open a modal!</div>
-          <Button
-            type="button"
-            onClick={() => {
-              setModal(modalConfig);
-            }}
-          >
-            Open modal
-          </Button>
-        </Fragment>
+        <Button
+          type="button"
+          onClick={() => {
+            setModal(modal);
+          }}
+        >
+          Open modal
+        </Button>
       )}
     </ModalConsumer>
   </ModalProvider>
 );
 
+const defaultModal = {
+  // eslint-disable-next-line react/prop-types, no-unused-vars
+  children: () => <div>Hello World!</div>,
+  onClose: e => {
+    action('Modal closed')(e);
+  }
+};
+
 storiesOf('Modal', module)
   .addDecorator(withTests('Modal'))
-  .add('Default Modal', withInfo()(() => <PageWithModal />));
+  .add('Modal', withInfo()(() => <PageWithModal modal={defaultModal} />))
+  .add(
+    'Modal with title',
+    withInfo()(() => {
+      const modalWithTitle = {
+        ...defaultModal,
+        children: () => (
+          <Fragment>
+            <CardHeader>
+              <Heading size={Heading.KILO} noMargin>
+                Modal title
+              </Heading>
+            </CardHeader>
+            <Text>Some text in the modal body.</Text>
+          </Fragment>
+        )
+      };
+      return <PageWithModal modal={modalWithTitle} />;
+    })
+  )
+  .add(
+    'Modal with close button',
+    withInfo()(() => {
+      const modalWithTitleAndCloser = {
+        ...defaultModal,
+        // eslint-disable-next-line react/prop-types
+        children: ({ onClose }) => (
+          <Fragment>
+            <CardHeader
+              onClose={e => {
+                action('Close button pressed')(e);
+                onClose(e);
+              }}
+            />
+            <Text>Some text in the modal body.</Text>
+          </Fragment>
+        )
+      };
+      return <PageWithModal modal={modalWithTitleAndCloser} />;
+    })
+  )
+  .add(
+    'Modal with title and close button',
+    withInfo()(() => {
+      const modalWithTitle = {
+        ...defaultModal,
+        // eslint-disable-next-line react/prop-types
+        children: ({ onClose }) => (
+          <Fragment>
+            <CardHeader
+              onClose={e => {
+                action('Close button pressed')(e);
+                onClose(e);
+              }}
+            >
+              <Heading size={Heading.KILO} noMargin>
+                Modal title
+              </Heading>
+            </CardHeader>
+            <Text>Some text in the modal body.</Text>
+          </Fragment>
+        )
+      };
+      return <PageWithModal modal={modalWithTitle} />;
+    })
+  );

--- a/src/components/Modal/Modal.story.js
+++ b/src/components/Modal/Modal.story.js
@@ -4,7 +4,7 @@ import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
 
 import withTests from '../../util/withTests';
-import ModalConsumer, { ModalProvider } from '.';
+import Modal, { ModalProvider } from '.';
 import Button from '../Button';
 import Heading from '../Heading';
 import { CardHeader, CardFooter } from '../Card';
@@ -13,7 +13,7 @@ import Text from '../Text';
 // eslint-disable-next-line react/prop-types
 const PageWithModal = ({ modal }) => (
   <ModalProvider>
-    <ModalConsumer>
+    <Modal>
       {({ setModal }) => (
         <Button
           type="button"
@@ -24,7 +24,7 @@ const PageWithModal = ({ modal }) => (
           Open modal
         </Button>
       )}
-    </ModalConsumer>
+    </Modal>
   </ModalProvider>
 );
 

--- a/src/components/Modal/Modal.story.js
+++ b/src/components/Modal/Modal.story.js
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
+import styled, { css } from 'react-emotion';
 
 import withTests from '../../util/withTests';
 import Modal, { ModalProvider } from '.';
@@ -146,6 +147,51 @@ storiesOf('Modal', module)
               </ButtonGroup>
             </CardFooter>
           </Fragment>
+        )
+      };
+      return <PageWithModal modal={modalWithTitle} />;
+    })
+  )
+  .add(
+    'Modal with Card styles override',
+    withInfo()(() => {
+      const Container = styled('div')`
+        display: flex;
+        justify-content: stretch;
+        align-items: stretch;
+        flex-wrap: nowrap;
+        height: 100%;
+      `;
+
+      const LeftColumn = styled('div')`
+        display: flex;
+        align-items: center;
+        width: 50%;
+        justify-content: center;
+        padding: 24px 18px;
+      `;
+
+      const RightColumn = styled('div')`
+        height: 100%;
+        width: 50%;
+        background: no-repeat center / cover
+          url('https://source.unsplash.com/random');
+      `;
+
+      const cardClassName = css`
+        padding: 0;
+        height: 50vh;
+      `;
+      const modalWithTitle = {
+        ...defaultModal,
+        className: cardClassName,
+        children: () => (
+          <Container>
+            <LeftColumn>
+              <Text>A nice custom modal for special cases.</Text>
+            </LeftColumn>
+            <RightColumn />
+          </Container>
         )
       };
       return <PageWithModal modal={modalWithTitle} />;

--- a/src/components/Modal/ModalProvider.js
+++ b/src/components/Modal/ModalProvider.js
@@ -55,7 +55,7 @@ export class ModalProvider extends Component {
 
   render() {
     const { modal, isOpen } = this.state;
-    const { onClose = noop, children, body, ...otherProps } = modal || {};
+    const { onClose = noop, children, ...otherProps } = modal || {};
     const handleClose = () => {
       onClose();
       this.closeModal();
@@ -67,11 +67,11 @@ export class ModalProvider extends Component {
           children: () => children({ onClose: handleClose }),
           onClose: handleClose
         }
-      : { isOpen, children: () => null };
+      : { isOpen, onClose, children: () => null };
     return (
       <ContextProvider value={this.contextValue}>
         {this.props.children}
-        <Modal {...modalProps} />
+        {modal && <Modal {...modalProps} />}
       </ContextProvider>
     );
   }

--- a/src/components/Modal/ModalProvider.js
+++ b/src/components/Modal/ModalProvider.js
@@ -1,0 +1,78 @@
+import React, { Component } from 'react';
+import { noop } from 'lodash/fp';
+import createReactContext from 'create-react-context';
+
+import Modal, { TRANSITION_DURATION } from './Modal';
+import { childrenPropType } from '../../util/shared-prop-types';
+
+const { Provider: ContextProvider, Consumer } = createReactContext({
+  setModal: noop,
+  getModal: noop
+});
+
+export { Consumer as ModalConsumer };
+
+export class ModalProvider extends Component {
+  static propTypes = {
+    children: childrenPropType.isRequired
+  };
+
+  state = {
+    modal: null,
+    isOpen: false
+  };
+
+  componentDidUpdate(prevProps, { isOpen: prevIsOpen }) {
+    const { isOpen } = this.state;
+    if (!isOpen && prevIsOpen) {
+      setTimeout(() => {
+        this.setState(prevState => ({ ...prevState, modal: null }));
+      }, TRANSITION_DURATION);
+    }
+  }
+
+  setModal = config => {
+    window.onpopstate = this.closeModal;
+    this.setState(prevState => ({
+      ...prevState,
+      modal: { ...prevState.modal, ...config },
+      isOpen: true
+    }));
+  };
+
+  closeModal = () => {
+    window.onpopstate = null;
+    this.setState(prevState => ({
+      ...prevState,
+      isOpen: false
+    }));
+  };
+
+  contextValue = {
+    setModal: this.setModal,
+    getModal: () => this.state.modal
+  };
+
+  render() {
+    const { modal, isOpen } = this.state;
+    const { onClose = noop, children, body, ...otherProps } = modal || {};
+    const handleClose = () => {
+      onClose();
+      this.closeModal();
+    };
+    const modalProps = modal
+      ? {
+          isOpen,
+          ...otherProps,
+          children: () => children({ onClose: handleClose }),
+          onClose: handleClose
+        }
+      : { isOpen, children: () => null };
+    return (
+      <ContextProvider value={this.contextValue}>
+        {this.props.children}
+        <Modal {...modalProps} />
+      </ContextProvider>
+    );
+  }
+}

--- a/src/components/Modal/ModalProvider.js
+++ b/src/components/Modal/ModalProvider.js
@@ -1,16 +1,18 @@
 import React, { Component } from 'react';
-import { noop } from 'lodash/fp';
 import createReactContext from 'create-react-context';
 
 import Modal, { TRANSITION_DURATION } from './Modal';
 import { childrenPropType } from '../../util/shared-prop-types';
 
-const { Provider: ContextProvider, Consumer } = createReactContext({
-  setModal: noop,
-  getModal: noop
+const {
+  Provider: ContextProvider,
+  Consumer: ModalConsumer
+} = createReactContext({
+  setModal: () => {},
+  getModal: () => {}
 });
 
-export { Consumer as ModalConsumer };
+export { ModalConsumer };
 
 export class ModalProvider extends Component {
   static propTypes = {
@@ -55,7 +57,7 @@ export class ModalProvider extends Component {
 
   render() {
     const { modal, isOpen } = this.state;
-    const { onClose = noop, children, ...otherProps } = modal || {};
+    const { onClose = () => {}, children, ...otherProps } = modal || {};
     const handleClose = () => {
       onClose();
       this.closeModal();

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,5 +1,5 @@
-import { ModalProvider, ModalConsumer } from './ModalProvider';
+import { ModalProvider, ModalConsumer as Modal } from './ModalProvider';
 
 export { ModalProvider };
 
-export default ModalConsumer;
+export default Modal;

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,0 +1,5 @@
+import { ModalProvider, ModalConsumer } from './ModalProvider';
+
+export { ModalProvider };
+
+export default ModalConsumer;

--- a/src/components/NotificationList/__snapshots__/NotificationList.spec.js.snap
+++ b/src/components/NotificationList/__snapshots__/NotificationList.spec.js.snap
@@ -37,6 +37,7 @@ exports[`NotificationList should render with default styles 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   min-width: 400px;
+  overflow: hidden;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06), 0 4px 4px 0 rgba(12,15,20,0.06);
   padding: 16px 16px;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ export { default as Image } from './components/Image';
 export { default as LoadingBar } from './components/LoadingBar';
 export { default as Tag } from './components/Tag';
 export { default as Tooltip } from './components/Tooltip';
+export { default as Modal, ModalProvider } from './components/Modal';
 
 // Helpers
 export { default as State } from './components/State';

--- a/src/styles/style-helpers.js
+++ b/src/styles/style-helpers.js
@@ -1,4 +1,5 @@
 import { size, stripUnit, transparentize } from 'polished';
+import { mapValues } from '../util/fp';
 
 /**
  * Shadows
@@ -110,3 +111,12 @@ export const addUnit = (...args) => transformUnit(args, add);
 export const subtractUnit = (...args) => transformUnit(args, subtract);
 export const multiplyUnit = (...args) => transformUnit(args, multiply, false);
 export const divideUnit = (...args) => transformUnit(args, divide, false);
+
+export const createMediaQueries = mapValues(mediaExpression => {
+  const { prefix = '', suffix = '' } =
+    typeof mediaExpression === 'string'
+      ? {}
+      : { prefix: 'min-width: ', suffix: 'px' };
+  const enhancedExpression = prefix + mediaExpression + suffix;
+  return css => `@media (${enhancedExpression}) {${css}}`;
+});

--- a/src/styles/style-helpers.js
+++ b/src/styles/style-helpers.js
@@ -1,4 +1,6 @@
+import { css } from 'react-emotion';
 import { size, stripUnit, transparentize } from 'polished';
+
 import { mapValues } from '../util/fp';
 
 /**
@@ -116,7 +118,7 @@ export const createMediaQueries = mapValues(mediaExpression => {
   const { prefix = '', suffix = '' } =
     typeof mediaExpression === 'string'
       ? {}
-      : { prefix: 'min-width: ', suffix: 'px' };
+      : { prefix: '(min-width: ', suffix: 'px)' };
   const enhancedExpression = prefix + mediaExpression + suffix;
-  return css => `@media (${enhancedExpression}) {${css}}`;
+  return (...args) => css`@media ${enhancedExpression} {${css(...args)}}`;
 });

--- a/src/styles/style-helpers.spec.js
+++ b/src/styles/style-helpers.spec.js
@@ -51,6 +51,7 @@ describe('Style helpers', () => {
   });
 
   describe('media queries', () => {
+    const CLASS_REGEXP = /css-\w+-createMediaQueries/;
     const queries = {
       breakpoint: 1024,
       mediaExpression: '(max-width: 360px) and (min-height: 740px)'
@@ -62,29 +63,27 @@ describe('Style helpers', () => {
       };
 
       const actual = StyleHelpers.createMediaQueries(input).anExpression;
-      expect(typeof actual).toBe('function');
+      expect(typeof actual).toMatch('function');
     });
 
     it('should create a min-width query with pixels, when provided an integer value', () => {
       const { breakpoint } = queries;
-      const mediaQuery = StyleHelpers.createMediaQueries({ breakpoint })
-        .breakpoint;
-      const actual = mediaQuery(`
+      const mq = StyleHelpers.createMediaQueries({ breakpoint });
+      const actual = mq.breakpoint`
         font-size: 12px;
         line-height: 14px;
-      `);
-      expect(actual).toMatchSnapshot();
+      `;
+      expect(actual).toMatch(CLASS_REGEXP);
     });
 
     it('should take the media expression as is, when provided a string value', () => {
       const { mediaExpression } = queries;
-      const mediaQuery = StyleHelpers.createMediaQueries({ mediaExpression })
-        .mediaExpression;
-      const actual = mediaQuery(`
+      const mq = StyleHelpers.createMediaQueries({ mediaExpression });
+      const actual = mq.mediaExpression`
         font-size: 12px;
         line-height: 14px;
-      `);
-      expect(actual).toMatchSnapshot();
+      `;
+      expect(actual).toMatch(CLASS_REGEXP);
     });
   });
 });

--- a/src/styles/style-helpers.spec.js
+++ b/src/styles/style-helpers.spec.js
@@ -1,44 +1,90 @@
 import * as StyleHelpers from './style-helpers';
 
 describe('Style helpers', () => {
-  const a = '25px';
-  const b = '5px';
-  const c = 5;
-  const d = '2rem';
+  describe('CSS unit calculations', () => {
+    const a = '25px';
+    const b = '5px';
+    const c = 5;
+    const d = '2rem';
 
-  it('should add values of the same unit', () => {
-    const actual = StyleHelpers.addUnit(a, b, c);
-    const expected = '35px';
-    expect(actual).toBe(expected);
+    it('should add values of the same unit', () => {
+      const actual = StyleHelpers.addUnit(a, b, c);
+      const expected = '35px';
+      expect(actual).toBe(expected);
+    });
+
+    it('should subtract values of the same unit', () => {
+      const actual = StyleHelpers.subtractUnit(a, b, c);
+      const expected = '15px';
+      expect(actual).toBe(expected);
+    });
+
+    it('should multiply values of the same unit', () => {
+      const actual = StyleHelpers.multiplyUnit(a, c);
+      const expected = '125px';
+      expect(actual).toBe(expected);
+    });
+
+    it('should divide values of the same unit', () => {
+      const actual = StyleHelpers.divideUnit(a, c);
+      const expected = '5px';
+      expect(actual).toBe(expected);
+    });
+
+    it('should add values without a unit', () => {
+      const actual = StyleHelpers.addUnit(a, b, c);
+      const expected = '35px';
+      expect(actual).toBe(expected);
+    });
+
+    it('should return undefined when values do not have the same unit', () => {
+      const actual = StyleHelpers.addUnit(a, b, d);
+      const expected = '32undefined';
+      expect(actual).toBe(expected);
+    });
+
+    it('should return undefined when multiple values have a unit', () => {
+      const actual = StyleHelpers.multiplyUnit(a, b);
+      const expected = '125undefined';
+      expect(actual).toBe(expected);
+    });
   });
-  it('should subtract values of the same unit', () => {
-    const actual = StyleHelpers.subtractUnit(a, b, c);
-    const expected = '15px';
-    expect(actual).toBe(expected);
-  });
-  it('should multiply values of the same unit', () => {
-    const actual = StyleHelpers.multiplyUnit(a, c);
-    const expected = '125px';
-    expect(actual).toBe(expected);
-  });
-  it('should divide values of the same unit', () => {
-    const actual = StyleHelpers.divideUnit(a, c);
-    const expected = '5px';
-    expect(actual).toBe(expected);
-  });
-  it('should add values without a unit', () => {
-    const actual = StyleHelpers.addUnit(a, b, c);
-    const expected = '35px';
-    expect(actual).toBe(expected);
-  });
-  it('should return undefined when values do not have the same unit', () => {
-    const actual = StyleHelpers.addUnit(a, b, d);
-    const expected = '32undefined';
-    expect(actual).toBe(expected);
-  });
-  it('should return undefined when multiple values have a unit', () => {
-    const actual = StyleHelpers.multiplyUnit(a, b);
-    const expected = '125undefined';
-    expect(actual).toBe(expected);
+
+  describe('media queries', () => {
+    const queries = {
+      breakpoint: 1024,
+      mediaExpression: '(max-width: 360px) and (min-height: 740px)'
+    };
+
+    it('should create an object of media query functions', () => {
+      const input = {
+        anExpression: ''
+      };
+
+      const actual = StyleHelpers.createMediaQueries(input).anExpression;
+      expect(typeof actual).toBe('function');
+    });
+
+    it('should create a min-width query with pixels, when provided an integer value', () => {
+      const { breakpoint } = queries;
+      const mediaQuery = StyleHelpers.createMediaQueries({ breakpoint })
+        .breakpoint;
+      const actual = mediaQuery(`
+        font-size: 12px;
+        line-height: 14px;
+      `);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should take the media expression as is, when provided a string value', () => {
+      const { mediaExpression } = queries;
+      const mediaQuery = StyleHelpers.createMediaQueries({ mediaExpression })
+        .mediaExpression;
+      const actual = mediaQuery(`
+        font-size: 12px;
+        line-height: 14px;
+      `);
+      expect(actual).toMatchSnapshot();
+    });
   });
 });

--- a/src/themes/default.js
+++ b/src/themes/default.js
@@ -160,8 +160,11 @@ export const fontWeight = {
 };
 
 export const breakpoints = {
+  untilMedium: '(max-width: 450px)',
   medium: 451,
+  mediumToBig: '(min-width: 451px) and (max-width: 450px)',
   big: 801,
+  bigToHuge: '(min-width: 451px) and (max-width: 450px)',
   huge: 1401
 };
 

--- a/src/themes/default.js
+++ b/src/themes/default.js
@@ -1,3 +1,5 @@
+import { createMediaQueries } from '../styles/style-helpers';
+
 const white = '#FFFFFF';
 const black = '#0F131A';
 
@@ -162,3 +164,5 @@ export const breakpoints = {
   big: 801,
   huge: 1401
 };
+
+export const mq = createMediaQueries(breakpoints);

--- a/src/util/fp.js
+++ b/src/util/fp.js
@@ -1,4 +1,14 @@
-// Requires a polyfill.
+/**
+ * TODO:
+ * - Replace lodash functions with own implementations.
+ * - Add polyfills.
+ */
+
+import { curry } from 'lodash/fp';
+
+export { flow, compose } from 'lodash/fp';
+
+// Requires polyfill
 export const values = obj => Object.values(obj);
 
 export const keys = obj => Object.keys(obj);
@@ -7,4 +17,35 @@ export const toPairs = obj => Object.entries(obj);
 
 // This only works with an array. Might implement iterator
 // approach.
-export const map = iteratee => arr => arr.map(iteratee);
+export const map = curry((iteratee, arr) => arr.map(iteratee));
+
+export const mapValues = curry((iteratee, obj) =>
+  Object.keys(obj).reduce(
+    (acc, key) => ({ ...acc, [key]: iteratee(obj[key]) }),
+    {}
+  )
+);
+
+export const mapKeys = curry((iteratee, obj) =>
+  Object.keys(obj).reduce((acc, key) => {
+    const newKey = iteratee[key];
+    return { ...acc, [newKey]: obj[key] };
+  })
+);
+
+export const find = curry((predicate, arr) => arr.find(predicate));
+
+export const reduce = curry((iteratee, acc, arr) => arr.reduce(iteratee, acc));
+
+export const filter = curry((predicate, arr) => arr.filter(predicate));
+
+// Requires polyfill
+export const includes = curry((val, arr) => arr.includes(val));
+
+export const defaultTo = curry((defaultVal, val) => val || defaultVal);
+
+export const concat = curry((first, ...args) => first.concat(...args));
+
+export const slice = curry((start, end, arr) => arr.slice(start, end));
+
+export const toBool = val => !!val;

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -2,7 +2,6 @@ import * as id from './id';
 import * as numbers from './numbers';
 import * as currency from './currency';
 import * as sharedPropTypes from './shared-prop-types';
-import * as sizes from './sizes';
 import * as typeCheck from './type-check';
 
-export { id, numbers, currency, sharedPropTypes, sizes, typeCheck };
+export { id, numbers, currency, sharedPropTypes, typeCheck };

--- a/src/util/ios.js
+++ b/src/util/ios.js
@@ -1,0 +1,5 @@
+const { platform } = navigator || {};
+
+const isIos = !!platform && /iPad|iPhone|iPod/.test(platform);
+
+export default isIos;

--- a/src/util/shared-prop-types.js
+++ b/src/util/shared-prop-types.js
@@ -88,8 +88,7 @@ export const themePropType = PropTypes.shape({
     // Misc
     shadow: PropTypes.string.isRequired,
     bodyBg: PropTypes.string.isRequired,
-    bodyColor: PropTypes.string.isRequired,
-    buttonColor: PropTypes.string.isRequired
+    bodyColor: PropTypes.string.isRequired
   }).isRequired,
   spacings: PropTypes.shape({
     bit: PropTypes.string.isRequired,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2448,6 +2448,13 @@ create-react-class@^15.5.2, create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.1.tgz#425a3d96f4b7690c2fbf20aed5aeae2e2007a959"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0, cross-spawn@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3591,7 +3598,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -4002,6 +4009,10 @@ graceful-fs@4.1.11, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 handlebars@^4.0.3:
   version "4.0.11"
@@ -7165,6 +7176,14 @@ react-inspector@^2.2.2:
 react-modal@^3.1.10:
   version "3.1.13"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.13.tgz#9b27e7774e6ecdc255f489487f518eb4361716ab"
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    warning "^3.0.0"
+
+react-modal@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.3.2.tgz#b13da9490653a7c76bc0e9600323eb1079c620e7"
   dependencies:
     exenv "^1.2.0"
     prop-types "^15.5.10"


### PR DESCRIPTION
##### Changes

- Adds support for media queries
- Adds a Modal implementation. Right now this requires a provider to sit at the top of the tree. I kept that implementation because in the past there was a requirement which forced us to use it like this. If we can, I would look to go to a simpler implementation.
- Bug fixes and improvements
  - Fixes `CardHeader` layout when no title is provided but a closing button is required.
  - Removes margin from `Heading` in a Card story.
  - Adds `noMargin` prop to blacklist of `HtmlElement` in `Heading` component.
  - Adds `primary` prop to blacklist of `HtmlElement` in `Button` component.
  - Removes a broken export of a `sizes` module from `utils`.

##### Usage

- `ModalProvider` has to sit on top of the component tree.
- Consumer, exported as `Modal` from the `Modal/index.js`, provides a `set` and a `get` function to its render prop.
- create modal by passing a modal config with the props `children` and `onClose` to the `set` function. 
- Modal already comes with `Card` as wrapper.
- `children` render prop is used as content of the card.
- Provide title via prop.
- Provide buttons via `buttons` render prop. Use `ButtonGroup` for this.

```javascript
      const modal = {
        onClose: console.log,
        title: 'My cool modal',
        children: () => (
            <Text>Some text in the modal body.</Text>
        ),
        buttons: ({ onClose }) => (
          <ButtonGroup>
            <Button key="confirm" onClick={onClose} data-test="confirm-button">
              Confirm Button
            </Button>
            <Button key="cancel" onClick={onClose} data-test="cancel-button">
              Cancel Button
            </Button>
          </ButtonGroup>
        )
      };
      return <PageWithModal modal={modalWithTitle} />;
    }

  <ModalProvider>
    <Modal>
      {({ setModal }) => (
        <Button
          type="button"
          onClick={() => {
            setModal(modal);
          }}
        >
          Open modal
        </Button>
      )}
    </Modal>
  </ModalProvider>
```

##### Demos

###### Desktop
![desktop-modals](https://user-images.githubusercontent.com/265947/38095713-64714218-3371-11e8-8364-aa2421639fd1.gif)

###### Mobile
![mobile-modals](https://user-images.githubusercontent.com/265947/38095820-a03b8402-3371-11e8-8d2b-6c4d4fa28bad.gif)
