### PR TITLE
Adjustments to margin behavior on Text component

### DIFF
--- a/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Markdown should override HTML tags with React components 1`] = `
 .circuit-0 {
+  margin-top: 0;
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 15px;
@@ -29,7 +30,6 @@ exports[`Markdown should override HTML tags with React components 1`] = `
   </h2>
   <p
     className="circuit-0 circuit-1"
-    noMargin={false}
     size="mega"
   >
     Lorem markdownum vultusque eligit significent sinistro, et virgis, inter!
@@ -49,7 +49,6 @@ et magnis prorumpit flere? Dura quantum.
   </h3>
   <p
     className="circuit-0 circuit-1"
-    noMargin={false}
     size="mega"
   >
     Mediis monstravit inmunis Troes non leonis 
@@ -75,7 +74,6 @@ praecordiaque velut totosque norant alipedi candida electae est vestis, posse.
   >
     <p
       className="circuit-0 circuit-1"
-      noMargin={false}
       size="mega"
     >
       Adstat Procnes et, in tempora Maenalon moles in nocte relicta, membra nec
@@ -114,7 +112,6 @@ terraeque gratus quaque, liquidumque quod: magnum mixta;
   </h3>
   <p
     className="circuit-0 circuit-1"
-    noMargin={false}
     size="mega"
   >
     Mundus pugno, geniti sic muros Notum tu ad motis; nobis mihi tangi dextra?
@@ -148,7 +145,6 @@ teneo
   </h3>
   <p
     className="circuit-0 circuit-1"
-    noMargin={false}
     size="mega"
   >
     Conceperat depositae si manibus utiliter resonare vitat ima mortis ecce. Huic
@@ -181,7 +177,6 @@ leni agat pro! Fuit relinque.
   </h2>
   <p
     className="circuit-0 circuit-1"
-    noMargin={false}
     size="mega"
   >
     <img
@@ -193,7 +188,6 @@ leni agat pro! Fuit relinque.
   </p>
   <p
     className="circuit-0 circuit-1"
-    noMargin={false}
     size="mega"
   >
     Parte quam aequore, nebulas demisere. Iurgia venit finxit nec manibus tamen

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -10,6 +10,7 @@ const { KILO, MEGA, GIGA } = sizes;
 
 const baseStyles = ({ theme }) => css`
   label: text;
+  margin-top: 0;
   font-weight: ${theme.fontWeight.regular};
   margin-bottom: ${theme.spacings.mega};
 `;
@@ -36,7 +37,7 @@ const TextElement = styled(
  * <p>, <div>, <article>, or <section> elements. Capable of rendering
  * using different HTML tags.
  */
-const Text = props => <TextElement {...props} blacklist={{ margin: true }} />;
+const Text = props => <TextElement {...props} blacklist={{ noMargin: true }} />;
 
 Text.KILO = KILO;
 Text.MEGA = MEGA;

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Text should render as article element, when passed "article" for the element prop 1`] = `
 .circuit-0 {
+  margin-top: 0;
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 15px;
@@ -10,7 +11,6 @@ exports[`Text should render as article element, when passed "article" for the el
 
 <article
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="mega"
 >
   ARTICLE heading
@@ -19,6 +19,7 @@ exports[`Text should render as article element, when passed "article" for the el
 
 exports[`Text should render as div element, when passed "div" for the element prop 1`] = `
 .circuit-0 {
+  margin-top: 0;
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 15px;
@@ -27,7 +28,6 @@ exports[`Text should render as div element, when passed "div" for the element pr
 
 <div
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="mega"
 >
   DIV heading
@@ -36,6 +36,7 @@ exports[`Text should render as div element, when passed "div" for the element pr
 
 exports[`Text should render as p element, when passed "p" for the element prop 1`] = `
 .circuit-0 {
+  margin-top: 0;
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 15px;
@@ -44,7 +45,6 @@ exports[`Text should render as p element, when passed "p" for the element prop 1
 
 <p
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="mega"
 >
   P heading
@@ -53,6 +53,7 @@ exports[`Text should render as p element, when passed "p" for the element prop 1
 
 exports[`Text should render with no margin styles when passed the noMargin prop 1`] = `
 .circuit-0 {
+  margin-top: 0;
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 15px;
@@ -62,13 +63,13 @@ exports[`Text should render with no margin styles when passed the noMargin prop 
 
 <p
   className="circuit-0 circuit-1"
-  noMargin={true}
   size="mega"
 />
 `;
 
 exports[`Text should render with size giga, when passed "giga" for the size prop 1`] = `
 .circuit-0 {
+  margin-top: 0;
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 18px;
@@ -77,7 +78,6 @@ exports[`Text should render with size giga, when passed "giga" for the size prop
 
 <p
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="giga"
 >
   giga heading
@@ -86,6 +86,7 @@ exports[`Text should render with size giga, when passed "giga" for the size prop
 
 exports[`Text should render with size kilo, when passed "kilo" for the size prop 1`] = `
 .circuit-0 {
+  margin-top: 0;
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 13px;
@@ -94,7 +95,6 @@ exports[`Text should render with size kilo, when passed "kilo" for the size prop
 
 <p
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="kilo"
 >
   kilo heading
@@ -103,6 +103,7 @@ exports[`Text should render with size kilo, when passed "kilo" for the size prop
 
 exports[`Text should render with size mega, when passed "mega" for the size prop 1`] = `
 .circuit-0 {
+  margin-top: 0;
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 15px;
@@ -111,7 +112,6 @@ exports[`Text should render with size mega, when passed "mega" for the size prop
 
 <p
   className="circuit-0 circuit-1"
-  noMargin={false}
   size="mega"
 >
   mega heading


### PR DESCRIPTION
Changes:

* Add `noMargin` to the blacklist for the Text component (was an outdated `margin` component)
* Set a `margin:0` on the text component by default, since default HTML element is a `<p>` and Chrome is automatically adding a top margin to that -- which causes things to be misaligned (e.g. in the Toggle component) when using circuit in the Dashboard.