### PR TITLE
Fix the toggle getting too small when label is long

### DIFF
--- a/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
@@ -20,6 +20,9 @@ exports[`Toggle should render with default styles 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  -webkit-flex: 0 0 40px;
+  -ms-flex: 0 0 40px;
+  flex: 0 0 40px;
   background-color: #D8DDE1;
   border-radius: 24px;
   position: relative;
@@ -95,6 +98,9 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  -webkit-flex: 0 0 40px;
+  -ms-flex: 0 0 40px;
+  flex: 0 0 40px;
   background-color: #D8DDE1;
   border-radius: 24px;
   position: relative;

--- a/src/components/Toggle/components/Switch/Switch.js
+++ b/src/components/Toggle/components/Switch/Switch.js
@@ -17,6 +17,7 @@ const trackBaseStyles = ({ theme }) => css`
   border: 0;
   outline: 0;
   appearance: none;
+  flex: 0 0 ${TRACK_WIDTH}px;
   background-color: ${theme.colors.n300};
   border-radius: ${TRACK_HEIGHT}px;
   position: relative;

--- a/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
+++ b/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
@@ -9,6 +9,9 @@ exports[`Switch should have the correct default styles 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  -webkit-flex: 0 0 40px;
+  -ms-flex: 0 0 40px;
+  flex: 0 0 40px;
   background-color: #D8DDE1;
   border-radius: 24px;
   position: relative;
@@ -95,6 +98,9 @@ exports[`Switch should have the correct on styles 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  -webkit-flex: 0 0 40px;
+  -ms-flex: 0 0 40px;
+  flex: 0 0 40px;
   background-color: #D8DDE1;
   border-radius: 24px;
   position: relative;


### PR DESCRIPTION
Addresses  #140. It doesn't handle with long labels and SUUUPER narrow views, but it should be narrow enough to handle standard phone views.