### PR TITLE
Fix caret position on Android

### DIFF
--- a/src/components/CreditCardDetails/components/CardNumberInput/CardNumberInput.js
+++ b/src/components/CreditCardDetails/components/CardNumberInput/CardNumberInput.js
@@ -109,7 +109,7 @@ const SchemeIconWrapper = styled('li')`
 `;
 
 /**
- * Describe your component here.
+ * A credit card number input.
  */
 const CardNumberInput = ({
   acceptedCardSchemes,

--- a/src/components/CreditCardDetails/components/CardNumberInput/CardNumberInput.js
+++ b/src/components/CreditCardDetails/components/CardNumberInput/CardNumberInput.js
@@ -14,6 +14,9 @@ import {
 } from './CardNumberInputService';
 import { disableVisually } from '../../../../styles/style-helpers';
 
+// FIXME: remove this once we move to a proper solution.
+const isAndroid = /Android/i.test(navigator && navigator.userAgent);
+
 const schemeListStyles = ({ theme }) => css`
   label: card-number-input__scheme-list;
   bottom: 100%;
@@ -119,6 +122,7 @@ const CardNumberInput = ({
   theme,
   supportedSchemesLabel,
   detectedSchemeLabel,
+  onChange,
   ...props
 }) => {
   const supportedSchemesText = `${supportedSchemesLabel}: ${keys(
@@ -142,6 +146,21 @@ const CardNumberInput = ({
         id={id}
         autoComplete="cc-number"
         placeholder="•••• •••• •••• ••••"
+        onChange={e => {
+          // FIXME: this is code to prevent an Android bug described
+          //        in this issue for the text-mask library:
+          //        https://github.com/text-mask/text-mask/issues/300
+          //        We should introduce a proper fix for this somewhere else,
+          //        potentially using text-mask for all inputs.
+          const { target } = e;
+          const { selectionEnd } = target;
+
+          if (isAndroid) {
+            target.setSelectionRange(selectionEnd, selectionEnd);
+          }
+
+          onChange(e);
+        }}
         {...props}
         wrapperClassName={inputLongStyles({
           theme,
@@ -176,6 +195,10 @@ CardNumberInput.propTypes = {
    * Card scheme icon components.
    */
   acceptedCardSchemes: PropTypes.objectOf(PropTypes.func).isRequired,
+  /**
+   * The change handler.
+   */
+  onChange: PropTypes.func.isRequired,
   /**
    * The detected card scheme.
    */


### PR DESCRIPTION
##### Description
This PR fixes an issue with the `CardNumberInput` component on Android. The Android virtual keyboard has a [documented](https://github.com/text-mask/text-mask/issues/300) "bug" where it sets the input selection start to the beginning of a word. This causes problems with inputs like ours that insert spaces for formatting purposes.

###### Current fix
The current fix is a dirty hack that should fix the behavior in the `CardNumberInput`.

###### Future fix
We now have multiple inputs that feature an input mask. For other SumUp products like the Dashboard we are likely going to have more. I think it would be a good idea to implement specialized masked inputs using the [React component of text-mask](https://github.com/text-mask/text-mask/tree/master/react#readme). It should work something like this:

```javascript
const CardNumberInput = ({
  acceptedCardSchemes,
  detectedCardScheme,
  value,
  className,
  id,
  label,
  // eslint-disable-next-line
  theme,
  supportedSchemesLabel,
  detectedSchemeLabel,
  onChange,
  ...props
}) => {
  const supportedSchemesText = `${supportedSchemesLabel}: ${keys(
    acceptedCardSchemes
  ).join(', ')}.`;
  const detectedSchemesText =
    hasDetectedScheme(detectedCardScheme) &&
    `${detectedSchemeLabel}: ${detectedCardScheme}`;
  return (
    <Fragment>
      <AccessibleCardSchemeInfo>
        {supportedSchemesText}
      </AccessibleCardSchemeInfo>
      <AccessibleCardSchemeInfo aria-live="polite">
        {detectedSchemesText}
      </AccessibleCardSchemeInfo>
      <Label htmlFor={id}>{label}</Label>
      <MaskedTextInput
        value={value}
        type="tel"
        id={id}
        autoComplete="cc-number"
        placeholder="•••• •••• •••• ••••"
        onChange={e => {
          // FIXME: this is code to prevent an Android bug described
          //        in this issue for the text-mask library:
          //        https://github.com/text-mask/text-mask/issues/300
          //        We should introduce a proper fix for this somewhere else,
          //        potentially using text-mask for all inputs.
          const { target } = e;
          const { selectionEnd } = target;

          if (isAndroid) {
            target.setSelectionRange(selectionEnd, selectionEnd);
          }

          onChange(e);
        }}
        {...props}
        wrapperClassName={inputLongStyles({
          theme,
          acceptedCardSchemes,
          className
        })}
        mask={[
          {/* This is an incorrect example of how to use the API for credit cards. We can do better. */}
          [/\d/, /\d/, /\d/, /\d/, ' ', /\d/, /\d/, /\d/, /\d/, ' ', /\d/, /\d/, /\d/, /\d/, ' ', /\d/, /\d/, /\d/, /\d/]
        ]}
        render={(ref, maskedProps) => (
          <Input innerRef={ref} {...maskedProps}>
            <SchemeList {...{ acceptedCardSchemes }} aria-hidden="true">
              {flow(
                toPairs,
                map(([cardScheme, IconComponent]) => (
                  <SchemeIconWrapper
                    disabled={isDisabledSchemeIcon(
                      value,
                      detectedCardScheme,
                      cardScheme
                    )}
                    key={cardScheme}
                  >
                    <IconComponent />
                  </SchemeIconWrapper>
                ))
              )(acceptedCardSchemes)}
            </SchemeList>
          </Input>
        )}
      />
    </Fragment>
  );
};
```