### PR TITLE
Allow Unidentified key in Restricted input

### DIFF
--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
@@ -78,8 +78,22 @@ exports[`SimpleCurrencyInput should adjust input padding and postfix width to ma
     aria-invalid={false}
     className="circuit-0 circuit-1"
     disabled={false}
+    enabledKeys={
+      Array [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+      ]
+    }
     onFocus={[Function]}
-    onKeyDown={[Function]}
+    onKeyDown={undefined}
     onMouseUp={[Function]}
     placeholder="123,45"
     required={false}
@@ -175,8 +189,22 @@ exports[`SimpleCurrencyInput should prioritize disabled over error styles 1`] = 
     aria-invalid={true}
     className="circuit-0 circuit-1"
     disabled={true}
+    enabledKeys={
+      Array [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+      ]
+    }
     onFocus={[Function]}
-    onKeyDown={[Function]}
+    onKeyDown={undefined}
     onMouseUp={[Function]}
     required={false}
     type="tel"
@@ -314,8 +342,22 @@ exports[`SimpleCurrencyInput should prioritize disabled over warning styles 1`] 
     aria-invalid={true}
     className="circuit-0 circuit-1"
     disabled={false}
+    enabledKeys={
+      Array [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+      ]
+    }
     onFocus={[Function]}
-    onKeyDown={[Function]}
+    onKeyDown={undefined}
     onMouseUp={[Function]}
     required={false}
     type="tel"
@@ -405,8 +447,22 @@ exports[`SimpleCurrencyInput should render with default styles 1`] = `
     aria-invalid={false}
     className="circuit-0 circuit-1"
     disabled={false}
+    enabledKeys={
+      Array [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+      ]
+    }
     onFocus={[Function]}
-    onKeyDown={[Function]}
+    onKeyDown={undefined}
     onMouseUp={[Function]}
     required={false}
     type="tel"
@@ -522,8 +578,22 @@ exports[`SimpleCurrencyInput should render with error styles 1`] = `
     aria-invalid={true}
     className="circuit-0 circuit-1"
     disabled={false}
+    enabledKeys={
+      Array [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+      ]
+    }
     onFocus={[Function]}
-    onKeyDown={[Function]}
+    onKeyDown={undefined}
     onMouseUp={[Function]}
     required={false}
     type="tel"
@@ -639,8 +709,22 @@ exports[`SimpleCurrencyInput should render with warning styles 1`] = `
     aria-invalid={false}
     className="circuit-0 circuit-1"
     disabled={false}
+    enabledKeys={
+      Array [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+      ]
+    }
     onFocus={[Function]}
-    onKeyDown={[Function]}
+    onKeyDown={undefined}
     onMouseUp={[Function]}
     required={false}
     type="tel"
@@ -738,8 +822,22 @@ exports[`SimpleCurrencyInput should support rendering symbols on the left 1`] = 
     aria-invalid={false}
     className="circuit-2 circuit-3"
     disabled={false}
+    enabledKeys={
+      Array [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+      ]
+    }
     onFocus={[Function]}
-    onKeyDown={[Function]}
+    onKeyDown={undefined}
     onMouseUp={[Function]}
     placeholder="123.45"
     required={false}

--- a/src/components/RestrictedInput/RestrictedInput.js
+++ b/src/components/RestrictedInput/RestrictedInput.js
@@ -15,7 +15,7 @@ import { handleKeyDown, handleCarretPosition } from './RestrictedInputService';
  * input at all times.
  */
 const RestrictedInput = ({
-  enabledKeys,
+  filteredKeys,
   onFocus,
   onMouseUp,
   alignCarretLeft,
@@ -23,7 +23,7 @@ const RestrictedInput = ({
 }) => (
   <Input
     {...props}
-    onKeyDown={handleKeyDown(enabledKeys)}
+    onKeyDown={handleKeyDown(filteredKeys)}
     onFocus={handleCarretPosition(onFocus, alignCarretLeft)}
     onMouseUp={handleCarretPosition(onMouseUp, alignCarretLeft)}
   />
@@ -37,7 +37,7 @@ RestrictedInput.propTypes = {
    * An array of keys that shold register with the input. All
    * other keys will be ignored.
    */
-  enabledKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+  filteredKeys: PropTypes.arrayOf(PropTypes.string),
   /**
    * An array of keys that shold register with the input. All
    * other keys will be ignored.
@@ -58,7 +58,8 @@ RestrictedInput.propTypes = {
 RestrictedInput.defaultProps = {
   alignCarretLeft: false,
   onFocus: null,
-  onMouseUp: null
+  onMouseUp: null,
+  filteredKeys: []
 };
 
 /**

--- a/src/components/RestrictedInput/RestrictedInput.spec.js
+++ b/src/components/RestrictedInput/RestrictedInput.spec.js
@@ -4,27 +4,27 @@ import RestrictedInput from '.';
 
 describe('RestrictedInput', () => {
   it('should render an Input', () => {
-    const wrapper = shallow(<RestrictedInput enabledKeys={[]} />);
+    const wrapper = shallow(<RestrictedInput />);
     const themedInput = wrapper.find('WithTheme(Input)');
     expect(themedInput).toHaveLength(1);
   });
 
-  it('should overwrite the keyDown handler on the Input', () => {
-    const wrapper = shallow(<RestrictedInput enabledKeys={[]} />);
+  it('should overwrite the keyDown handler on the Input, when filtered keys are provided', () => {
+    const wrapper = shallow(<RestrictedInput filteredKeys={['e']} />);
     const themedInput = wrapper.find('WithTheme(Input)');
     const actual = themedInput.props('onKeyDown');
     expect(actual).toBeTruthy();
   });
 
   it('should overwrite the focus handler on the input', () => {
-    const wrapper = shallow(<RestrictedInput enabledKeys={[]} />);
+    const wrapper = shallow(<RestrictedInput />);
     const themedInput = wrapper.find('WithTheme(Input)');
     const actual = themedInput.props('onFocus');
     expect(actual).toBeTruthy();
   });
 
   it('should overwrite the mouseUp handler on the Input', () => {
-    const wrapper = shallow(<RestrictedInput enabledKeys={[]} />);
+    const wrapper = shallow(<RestrictedInput />);
     const themedInput = wrapper.find('WithTheme(Input)');
     const actual = themedInput.props('onMouseUp');
     expect(actual).toBeTruthy();

--- a/src/components/RestrictedInput/RestrictedInputService.js
+++ b/src/components/RestrictedInput/RestrictedInputService.js
@@ -8,7 +8,8 @@ const DEFAULT_KEYS = [
   'Meta',
   'Control',
   'Alt',
-  'F5'
+  'F5',
+  'Unidentified' // This is here because legacy Chrome on XP sends it.
 ];
 
 export const handleKeyDown = userEnabledKeys => {

--- a/src/components/RestrictedInput/RestrictedInputService.js
+++ b/src/components/RestrictedInput/RestrictedInputService.js
@@ -1,4 +1,4 @@
-import { includes } from '../../util/fp';
+import { includes, isArray } from '../../util/fp';
 
 const DEFAULT_KEYS = [
   'Tab',
@@ -12,11 +12,14 @@ const DEFAULT_KEYS = [
   'Unidentified' // This is here because legacy Chrome on XP sends it.
 ];
 
-export const handleKeyDown = userEnabledKeys => {
-  const enabledKeys = [...DEFAULT_KEYS, ...userEnabledKeys];
+export const handleKeyDown = userFilteredKeys => {
+  if (!isArray(userFilteredKeys) || !userFilteredKeys.length) {
+    return undefined;
+  }
+  const filteredKeys = [...DEFAULT_KEYS, ...userFilteredKeys];
   return e => {
     // TODO: think about replacing this with a regex.
-    if (!includes(e.key, enabledKeys)) {
+    if (e.key !== undefined && !includes(e.key, filteredKeys)) {
       e.preventDefault();
     }
   };

--- a/src/components/RestrictedInput/RestrictedInputService.spec.js
+++ b/src/components/RestrictedInput/RestrictedInputService.spec.js
@@ -20,14 +20,14 @@ describe('RestrictedInputService', () => {
       expect(keyEvent.preventDefault).toHaveBeenCalled();
     });
 
-    it('should register enabled keys', () => {
+    it('should register filtered keys', () => {
       const userEnabledKeys = ['e'];
       const keyEvent = { ...baseEvent, key: 'e' };
       handleKeyDown(userEnabledKeys)(keyEvent);
       expect(keyEvent.preventDefault).not.toHaveBeenCalled();
     });
 
-    it('should register keys enabled by default', () => {
+    it('should register keys from the default filter', () => {
       const userEnabledKeys = [];
       const handler = handleKeyDown(userEnabledKeys);
       const defaultKeys = [
@@ -38,7 +38,8 @@ describe('RestrictedInputService', () => {
         'Meta',
         'Control',
         'Alt',
-        'F5'
+        'F5',
+        'Unidentified'
       ];
 
       defaultKeys.forEach(key => {
@@ -46,6 +47,15 @@ describe('RestrictedInputService', () => {
         handler(keyEvent);
         expect(keyEvent.preventDefault).not.toHaveBeenCalled();
       });
+    });
+
+    it("should register keys when the event's `key` property is undefined", () => {
+      const userEnabledKeys = [];
+      const handler = handleKeyDown(userEnabledKeys);
+      const keyEvent = { ...baseEvent, key: undefined };
+
+      handler(keyEvent);
+      expect(keyEvent.preventDefault).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/RestrictedInput/RestrictedInputService.spec.js
+++ b/src/components/RestrictedInput/RestrictedInputService.spec.js
@@ -13,11 +13,10 @@ describe('RestrictedInputService', () => {
   });
 
   describe('filtering key events', () => {
-    it('should only register enabled keys', () => {
-      const userEnabledKeys = [];
-      const keyEvent = { ...baseEvent, key: 'e' };
-      handleKeyDown(userEnabledKeys)(keyEvent);
-      expect(keyEvent.preventDefault).toHaveBeenCalled();
+    it('should not return a handler when passed an empty set of keys', () => {
+      const userFilteredKeys = [];
+      const actual = handleKeyDown(userFilteredKeys);
+      expect(actual).toBeUndefined();
     });
 
     it('should register filtered keys', () => {
@@ -28,7 +27,7 @@ describe('RestrictedInputService', () => {
     });
 
     it('should register keys from the default filter', () => {
-      const userEnabledKeys = [];
+      const userEnabledKeys = ['1'];
       const handler = handleKeyDown(userEnabledKeys);
       const defaultKeys = [
         'Tab',
@@ -50,8 +49,8 @@ describe('RestrictedInputService', () => {
     });
 
     it("should register keys when the event's `key` property is undefined", () => {
-      const userEnabledKeys = [];
-      const handler = handleKeyDown(userEnabledKeys);
+      const userFilteredKeys = ['1'];
+      const handler = handleKeyDown(userFilteredKeys);
       const keyEvent = { ...baseEvent, key: undefined };
 
       handler(keyEvent);


### PR DESCRIPTION
##### Description

Fixes a bug in legacy Chrome versions on Windows XP that would prevent users from entering any key at all. The reason is that the `e.key` property has the value `Unidentified` in old versions of Chrome.

*Needs #150 to be merged first*

##### Changes

-  Don't filter keypresses when `e.key` is `Unidentified` or `undefined`.