### PR TITLE
Replace exports with implementations from lodash/fp

### DIFF
--- a/src/util/fp.js
+++ b/src/util/fp.js
@@ -8,12 +8,9 @@ import { flow, curry, compose, includes } from 'lodash/fp';
 
 export { flow, curry, compose, includes };
 
-// Requires polyfill
-export const values = obj => Object.values(obj);
+export { toPairs, values } from 'lodash/fp';
 
 export const keys = obj => Object.keys(obj);
-
-export const toPairs = obj => Object.entries(obj);
 
 // This only works with an array. Might implement iterator
 // approach.

--- a/src/util/fp.js
+++ b/src/util/fp.js
@@ -8,7 +8,7 @@ import { flow, curry, compose, includes } from 'lodash/fp';
 
 export { flow, curry, compose, includes };
 
-export { toPairs, values } from 'lodash/fp';
+export { toPairs, values, isArray } from 'lodash/fp';
 
 export const keys = obj => Object.keys(obj);
 


### PR DESCRIPTION
Decided to move to lodash versions of these functions now, because we have to update Circuit in Dashboard anyway.

Uses 

- `toPairs`,
- `values`, and
- `isArray`

from lodash/fp.