### PR TITLE
Fix currency input mask localization

### DIFF
--- a/src/components/CurrencyInput/CurrencyInputService.js
+++ b/src/components/CurrencyInput/CurrencyInputService.js
@@ -26,8 +26,8 @@ export const normalizeAmount = value => {
 
 export const createCurrencyMask = (currency, locale, options = {}) => {
   const {
-    decimal: decimalSymbol = '.',
-    thousand: thousandsSeparatorSymbol = ',',
+    decimalSep: decimalSymbol = '.',
+    thousandSep: thousandsSeparatorSymbol = ',',
     currencyPrecision: decimalLimit
   } = getCurrencyFormat(currency, locale);
 

--- a/src/components/CurrencyInput/CurrencyInputService.spec.js
+++ b/src/components/CurrencyInput/CurrencyInputService.spec.js
@@ -103,7 +103,7 @@ describe('CurrencyInputService', () => {
       expect(actualDecimalLimit).toEqual(expectedDecimalLimit);
     });
 
-    it('should support decimal period and thousands comma separators', () => {
+    it('should handle currency/locale pairs with decimal period and thousands comma separators', () => {
       const currency = 'USD';
       const locale = 'en-US';
       const expectedDecimalSymbol = '.';
@@ -118,7 +118,7 @@ describe('CurrencyInputService', () => {
       );
     });
 
-    it('should support decimal comma and thousands period separators', () => {
+    it('should handle currency/locale pairs with decimal comma and thousands period separators', () => {
       const currency = 'EUR';
       const locale = 'de-DE';
       const expectedDecimalSymbol = ',';

--- a/src/components/CurrencyInput/CurrencyInputService.spec.js
+++ b/src/components/CurrencyInput/CurrencyInputService.spec.js
@@ -102,6 +102,36 @@ describe('CurrencyInputService', () => {
       expect(actualAllowDecimal).toEqual(expectedAllowDecimal);
       expect(actualDecimalLimit).toEqual(expectedDecimalLimit);
     });
+
+    it('should support decimal period and thousands comma separators', () => {
+      const currency = 'USD';
+      const locale = 'en-US';
+      const expectedDecimalSymbol = '.';
+      const expectedThousandsSeparatorSymbol = ',';
+      createCurrencyMask(currency, locale);
+      const options = createNumberMask.mock.calls[0][0];
+      const actualDecimalSymbol = options.decimalSymbol;
+      const actualThousandsSeparatorSymbol = options.thousandsSeparatorSymbol;
+      expect(actualDecimalSymbol).toEqual(expectedDecimalSymbol);
+      expect(actualThousandsSeparatorSymbol).toEqual(
+        expectedThousandsSeparatorSymbol
+      );
+    });
+
+    it('should support decimal comma and thousands period separators', () => {
+      const currency = 'EUR';
+      const locale = 'de-DE';
+      const expectedDecimalSymbol = ',';
+      const expectedThousandsSeparatorSymbol = '.';
+      createCurrencyMask(currency, locale);
+      const options = createNumberMask.mock.calls[0][0];
+      const actualDecimalSymbol = options.decimalSymbol;
+      const actualThousandsSeparatorSymbol = options.thousandsSeparatorSymbol;
+      expect(actualDecimalSymbol).toEqual(expectedDecimalSymbol);
+      expect(actualThousandsSeparatorSymbol).toEqual(
+        expectedThousandsSeparatorSymbol
+      );
+    });
   });
 
   it('should allow specifying options', () => {


### PR DESCRIPTION
The destructuring of the return values from `getCurrencyFormat` was incorrect, so we always ended up with the default values. There was no unit test for this, so we didn't notice. Added unit tests for two cases, to ensure we use the function correctly. `getCurrencyFormat` itself is unit tested for all currencies so this should be robust.