### PR TITLE
Ensure masks are overwritable in CC components

### DIFF
--- a/src/components/CreditCardDetails/components/CardNumberInput/CardNumberInput.js
+++ b/src/components/CreditCardDetails/components/CardNumberInput/CardNumberInput.js
@@ -143,7 +143,6 @@ const CardNumberInput = ({
         id={id}
         autoComplete="cc-number"
         placeholder="•••• •••• •••• ••••"
-        {...props}
         wrapperClassName={inputLongStyles({
           theme,
           acceptedCardSchemes,
@@ -151,6 +150,7 @@ const CardNumberInput = ({
         })}
         guide={false}
         mask={CARD_NUMBER_MASK}
+        {...props}
       >
         <SchemeList {...{ acceptedCardSchemes }} aria-hidden="true">
           {flow(

--- a/src/components/CreditCardDetails/components/ExpiryDateInput/ExpiryDateInput.js
+++ b/src/components/CreditCardDetails/components/ExpiryDateInput/ExpiryDateInput.js
@@ -17,11 +17,11 @@ const ExpiryDateInput = ({ label, id, ...props }) => (
     <MaskedInput
       autoComplete="cc-exp"
       type="tel"
-      {...{ ...props, id }}
       mask={[/\d/, /\d/, '/', /\d/, /\d/]}
       guide={false}
       keepCharPositions={true}
       pipe={datePipe}
+      {...{ ...props, id }}
     />
   </Fragment>
 );


### PR DESCRIPTION
Changes the order how props are passed/spread onto `CardNumberInput` and `ExpiryDateInput`, so `mask` can be set to `false` to disable any text masking.