### PR TITLE
Force MaskedInput to be controlled

### DIFF
--- a/src/components/MaskedInput/MaskedInput.js
+++ b/src/components/MaskedInput/MaskedInput.js
@@ -8,12 +8,24 @@ import Input from '../Input';
  * the input value. Refer to the
  * [README](https://github.com/text-mask/text-mask/tree/master/react#readme)
  * of text-mask for details regarding usage.
+ *
+ * React Text Mask uses `defaultValue` instead of `value`, which
+ * causes issues with controlled inputs. We remap it to make it
+ * work more nicely with Final Form.
+ * This might cause issues with IE10 (https://github.com/text-mask/text-mask/issues/349#issuecomment-282612339).
+ * There are some more discussions around this problem (https://github.com/text-mask/text-mask/issues/530).
  */
 const MaskedInput = props => (
   <TextMaskInput
     guide={false}
     {...props}
-    render={(ref, renderProps) => <Input {...renderProps} deepRef={ref} />}
+    render={(ref, { defaultValue, ...renderProps }) => (
+      <Input
+        value={defaultValue}
+        {...renderProps}
+        deepRef={ref}
+      />
+    )}
   />
 );
 

--- a/src/components/MaskedInput/MaskedInput.js
+++ b/src/components/MaskedInput/MaskedInput.js
@@ -20,11 +20,7 @@ const MaskedInput = props => (
     guide={false}
     {...props}
     render={(ref, { defaultValue, ...renderProps }) => (
-      <Input
-        value={defaultValue}
-        {...renderProps}
-        deepRef={ref}
-      />
+      <Input value={defaultValue} {...renderProps} deepRef={ref} />
     )}
   />
 );


### PR DESCRIPTION
react-text-mask uses uncontrolled inputs and converts the `value` prop to `defaultValue`. This apparently [goes back to a bug in IE10](https://github.com/text-mask/text-mask/issues/349#issuecomment-282612339).

Using uncontrolled inputs makes it impossible to reset a form programmatically (for example by calling React Final Form's `reset` function). Since we don't officially support IE10, this PR enables controlled inputs by mapping the `defaultValue` prop back to `value`.