### PR TITLE
Correctly normalize amounts ending in "00"

### DIFF
--- a/src/components/CurrencyInput/CurrencyInputService.js
+++ b/src/components/CurrencyInput/CurrencyInputService.js
@@ -10,7 +10,7 @@ export const normalizeAmount = value => {
   }
 
   const matches = value.match(/[^\d](\d{1,2})$/) || [];
-  const [, decimals = '00'] = matches;
+  const [, decimals] = matches;
 
   const digits = value.replace(/[^\d]/g, '');
 
@@ -19,7 +19,7 @@ export const normalizeAmount = value => {
   }
 
   const integers =
-    decimals === '00' ? digits : digits.slice(0, -decimals.length);
+    decimals === undefined ? digits : digits.slice(0, -decimals.length);
   const numberString = `${integers}.${decimals}`;
   return parseFloat(numberString);
 };

--- a/src/components/CurrencyInput/CurrencyInputService.spec.js
+++ b/src/components/CurrencyInput/CurrencyInputService.spec.js
@@ -48,6 +48,16 @@ describe('CurrencyInputService', () => {
         expect(actual).toBe(expected);
       });
     });
+
+    it('should correctly normalize values ending in "00"', () => {
+      locales.forEach(locale => {
+        const { thousand, decimal } = NUMBER_SEPARATORS[locale];
+        const value = `1${thousand}000${decimal}00`;
+        const expected = 1000.0;
+        const actual = normalizeAmount(value);
+        expect(actual).toBe(expected);
+      });
+    });
   });
 
   describe('validating currency values', () => {


### PR DESCRIPTION
Previously, `normalizeAmount()` was treating amounts ending in `.00` just like amounts with no decimals. This was causing amounts like `123.00` to be treated just like `12300`.