### PR TITLE
Remove syntax-dynamic-imports from .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "lodash",
-    "syntax-dynamic-import",
     "transform-es2015-modules-commonjs",
     "transform-object-rest-spread",
     "transform-class-properties",


### PR DESCRIPTION
This one is a quickie.

Removing `syntax-dynamic-import`. It is an artifact left from the dashboard's .bashrc. It it not used, but it breaks the dashboard's build after we fixed it.