### PR TITLE
Separate ci test from push test command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 install:
   yarn
 script:
-  yarn test-ci
+  yarn test:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 install:
   yarn
 script:
-  yarn test
+  yarn test-ci

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "fix:eslint": "eslint --fix --quiet src/**/**/*.js",
     "fix": "yarn fix:eslint",
     "test": "yarn test:lint-js && yarn test:unit",
-    "test-ci": "yarn test:lint-js && yarn test:unit --runInBand",
+    "test:ci": "yarn test:lint-js && yarn test:unit --runInBand",
     "test:lint-js": "eslint --cache --quiet src/**/**/*.js",
     "test:lint-js:watch": "onchange \"src/**/**/*.js\" -- yarn test:lint-js",
     "test:unit:verbose": "jest --coverage --no-cache",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "fix:eslint": "eslint --fix --quiet src/**/**/*.js",
     "fix": "yarn fix:eslint",
-    "test": "yarn test:lint-js && yarn test:unit --runInBand",
+    "test": "yarn test:lint-js && yarn test:unit",
+    "test-ci": "yarn test:lint-js && yarn test:unit --runInBand",
     "test:lint-js": "eslint --cache --quiet src/**/**/*.js",
     "test:lint-js:watch": "onchange \"src/**/**/*.js\" -- yarn test:lint-js",
     "test:unit:verbose": "jest --coverage --no-cache",


### PR DESCRIPTION
Adding `--runInBand` to the test was a great success for our ci running tests, but it is way slower when being used locally. This separates the test for ci and local usage.