### PR TITLE
Don't set type="tel" on SimpleCurrencyInput

### DIFF
--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/SimpleCurrencyInput.js
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/SimpleCurrencyInput.js
@@ -117,7 +117,7 @@ const SimpleCurrencyInput = ({
           </CurrencyIcon>
         )
       }
-      type="tel"
+      type="text"
       mask={numberMask}
       {...{ ...props, hasWarning, invalid, disabled }}
     />

--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
@@ -77,7 +77,7 @@ exports[`SimpleCurrencyInput should adjust input padding and postfix width to ma
     aria-invalid="false"
     class="circuit-0 circuit-1"
     placeholder="123,45"
-    type="tel"
+    type="text"
   />
   <span
     class="circuit-2 circuit-3"
@@ -168,7 +168,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over error styles 1`] = 
     aria-invalid="true"
     class="circuit-0 circuit-1"
     disabled=""
-    type="tel"
+    type="text"
   />
   <span
     class="circuit-2 circuit-3"
@@ -301,7 +301,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over warning styles 1`] 
   <input
     aria-invalid="true"
     class="circuit-0 circuit-1"
-    type="tel"
+    type="text"
   />
   <span
     class="circuit-2 circuit-3"
@@ -385,7 +385,7 @@ exports[`SimpleCurrencyInput should render with default styles 1`] = `
   <input
     aria-invalid="false"
     class="circuit-0 circuit-1"
-    type="tel"
+    type="text"
   />
   <span
     class="circuit-2 circuit-3"
@@ -495,7 +495,7 @@ exports[`SimpleCurrencyInput should render with error styles 1`] = `
   <input
     aria-invalid="true"
     class="circuit-0 circuit-1"
-    type="tel"
+    type="text"
   />
   <span
     class="circuit-2 circuit-3"
@@ -605,7 +605,7 @@ exports[`SimpleCurrencyInput should render with warning styles 1`] = `
   <input
     aria-invalid="false"
     class="circuit-0 circuit-1"
-    type="tel"
+    type="text"
   />
   <span
     class="circuit-2 circuit-3"
@@ -697,7 +697,7 @@ exports[`SimpleCurrencyInput should support rendering symbols on the left 1`] = 
     aria-invalid="false"
     class="circuit-2 circuit-3"
     placeholder="123.45"
-    type="tel"
+    type="text"
   />
 </div>
 `;


### PR DESCRIPTION
Ideally, we'd get a better text mask that automatically inserts decimal digits from the start. For example, typing `1`, `2`, `3`, `4`, 5`, `6` should result in the following values:

1. `0.01`
2. `0.12`
3. `1.23`
4. `12.34`
5. `123.45`
6. `1,234.56`

##### Changes
- Sets the input type to `text` because mobile phones typically don't give you the option of a decimal separator for telephone keyboards.