### PR TITLE
[TOOL-56] Create Table component

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:unit:output":
       "jest --json --outputFile=jest-test-results.json --no-cache --silent",
     "prepush": "yarn test",
-    "start": "yarn test:unit:output && start-storybook -p 6006",
+    "start": "start-storybook -p 6006",
     "prebuild": "yarn test:unit:output",
     "build":
       "yarn build:stylesheet && yarn build:global-styles && yarn build:copy-global-styles && yarn build:storybook",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:unit:output":
       "jest --json --outputFile=jest-test-results.json --no-cache --silent",
     "prepush": "yarn test",
-    "start": "start-storybook -p 6006",
+    "start": "yarn test:unit:output && start-storybook -p 6006",
     "prebuild": "yarn test:unit:output",
     "build":
       "yarn build:stylesheet && yarn build:global-styles && yarn build:copy-global-styles && yarn build:storybook",

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -63,8 +63,12 @@ class Table extends Component {
   state = {
     rows: this.props.rows,
     sortedRow: null,
+    sortHover: null,
     sortDirection: null
   };
+
+  onSortEnter = i => this.setState({ sortHover: i });
+  onSortLeave = () => this.setState({ sortHover: null });
 
   defaultSortBy = i => {
     const { rows, sortedRow, sortDirection } = this.state;
@@ -81,18 +85,25 @@ class Table extends Component {
 
   render() {
     const { rowHeaders, headers } = this.props;
-    const { rows } = this.state;
+    const { rows, sortHover } = this.state;
 
     return (
       <Container>
         <ScrollContainer rowHeaders={rowHeaders}>
           <StyledTable rowHeaders={rowHeaders}>
             <TableHead
+              sortable
               sortBy={this.defaultSortBy}
+              onSortEnter={this.onSortEnter}
+              onSortLeave={this.onSortLeave}
               headers={headers}
               rowHeaders={rowHeaders}
             />
-            <TableBody rows={rows} rowHeaders={rowHeaders} />
+            <TableBody
+              rows={rows}
+              rowHeaders={rowHeaders}
+              sortHover={sortHover}
+            />
           </StyledTable>
         </ScrollContainer>
       </Container>

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -69,11 +69,13 @@ class Table extends Component {
   };
 
   componentDidMount() {
-    if (!this.scrollRef) {
+    const scrollRef = this.getScrollRef();
+
+    if (!scrollRef) {
       return;
     }
 
-    const { scrollWidth, clientWidth } = this.scrollRef;
+    const { scrollWidth, clientWidth } = scrollRef;
     const scrollable = scrollWidth > clientWidth;
 
     // eslint-disable-next-line react/no-did-mount-set-state
@@ -94,14 +96,16 @@ class Table extends Component {
       ? onSortBy(i, nextDirection, rows)
       : this.defaultSortBy(i, nextDirection, rows);
 
-    this.updateRows(i, nextDirection, nextRows);
+    this.updateSort(i, nextDirection, nextRows);
   };
 
-  getScrollRef = ref => {
+  getScrollRef = () => this.scrollRef;
+
+  setScrollRef = ref => {
     this.scrollRef = ref;
   };
 
-  updateRows = (i, nextDirection, rows) =>
+  updateSort = (i, nextDirection, rows) =>
     this.setState({
       rows,
       sortedRow: i,
@@ -109,7 +113,7 @@ class Table extends Component {
     });
 
   defaultSortBy = (i, nextDirection, rows) => {
-    const nextFn = nextDirection === ASCENDING ? descendingSort : ascendingSort;
+    const nextFn = nextDirection === ASCENDING ? ascendingSort : descendingSort;
 
     return [...rows].sort(nextFn(i));
   };
@@ -122,7 +126,7 @@ class Table extends Component {
       <Container>
         <ScrollContainer
           rowHeaders={rowHeaders}
-          innerRef={this.getScrollRef}
+          innerRef={this.setScrollRef}
           tabIndex={tabindex}
         >
           <StyledTable rowHeaders={rowHeaders}>

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -64,8 +64,23 @@ class Table extends Component {
     rows: this.props.rows,
     sortedRow: null,
     sortHover: null,
-    sortDirection: null
+    sortDirection: null,
+    tabindex: null
   };
+
+  componentDidMount() {
+    if (!this.scrollRef) {
+      return;
+    }
+
+    const { scrollWidth, clientWidth } = this.scrollRef;
+    const scrollable = scrollWidth > clientWidth;
+
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({
+      tabindex: scrollable ? '0' : null
+    });
+  }
 
   onSortEnter = i => this.setState({ sortHover: i });
   onSortLeave = () => this.setState({ sortHover: null });
@@ -80,6 +95,10 @@ class Table extends Component {
       : this.defaultSortBy(i, nextDirection, rows);
 
     this.updateRows(i, nextDirection, nextRows);
+  };
+
+  getScrollRef = ref => {
+    this.scrollRef = ref;
   };
 
   updateRows = (i, nextDirection, rows) =>
@@ -97,14 +116,17 @@ class Table extends Component {
 
   render() {
     const { rowHeaders, headers } = this.props;
-    const { rows, sortDirection, sortHover, sortedRow } = this.state;
+    const { rows, sortDirection, sortHover, sortedRow, tabindex } = this.state;
 
     return (
       <Container>
-        <ScrollContainer rowHeaders={rowHeaders}>
+        <ScrollContainer
+          rowHeaders={rowHeaders}
+          innerRef={this.getScrollRef}
+          tabIndex={tabindex}
+        >
           <StyledTable rowHeaders={rowHeaders}>
             <TableHead
-              sortable
               sortBy={this.onSortBy}
               sortDirection={sortDirection}
               sortedRow={sortedRow}

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+import { isString } from 'lodash/fp';
+
+import TableHeader from './components/TableHeader';
+import TableCell from './components/TableCell';
+import TableRow from './components/TableRow';
+import { shadowSingle } from '../../styles/style-helpers';
+import { childrenPropType } from '../../util/shared-prop-types';
+
+const baseStyles = ({ theme }) => css`
+  label: table;
+  background-color: ${theme.colors.white};
+  border-radius: ${theme.borderRadius.mega};
+  width: 100%;
+`;
+
+const responsiveStyles = ({ theme, rowHeaders }) =>
+  rowHeaders &&
+  css`
+    label: table--responsive;
+    ${theme.mq.untilMega`
+      margin-left: -145px;
+    `};
+  `;
+
+const StyledTable = styled.table`
+  ${baseStyles};
+  ${responsiveStyles};
+  ${shadowSingle};
+`;
+
+const containerStyles = ({ theme, rowHeaders }) =>
+  rowHeaders &&
+  css`
+    label: table-container;
+    ${theme.mq.untilMega`
+      margin-left: 145px;
+      overflow-x: auto;
+    `};
+  `;
+
+const StyledContainer = styled.div(containerStyles);
+
+const mapProps = props => (isString(props) ? { children: props } : props);
+
+const Table = ({ headers, rows, rowHeaders }) => (
+  <StyledContainer rowHeaders>
+    <StyledTable rowHeaders>
+      <tbody>
+        {!!headers.length && (
+          <TableRow header>
+            {headers.map(header => <TableHeader {...mapProps(header)} />)}
+          </TableRow>
+        )}
+        {rows.map(row => (
+          <TableRow>
+            {row.map(
+              (cell, i) =>
+                rowHeaders && i === 0 ? (
+                  <TableHeader scope={TableHeader.ROW} {...mapProps(cell)} />
+                ) : (
+                  <TableCell {...mapProps(cell)} />
+                )
+            )}
+          </TableRow>
+        ))}
+      </tbody>
+    </StyledTable>
+  </StyledContainer>
+);
+
+const ItemPropType = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.shape({
+    children: childrenPropType,
+    align: PropTypes.string
+  })
+]);
+
+Table.propTypes = {
+  headers: PropTypes.arrayOf(ItemPropType),
+  rows: PropTypes.arrayOf(PropTypes.arrayOf(ItemPropType)),
+  rowHeaders: PropTypes.bool
+};
+
+Table.defaultProps = {
+  headers: [],
+  rows: [],
+  rowHeaders: true
+};
+
+export default Table;

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -85,7 +85,7 @@ class Table extends Component {
 
   render() {
     const { rowHeaders, headers } = this.props;
-    const { rows, sortHover } = this.state;
+    const { rows, sortDirection, sortHover, sortedRow } = this.state;
 
     return (
       <Container>
@@ -94,6 +94,8 @@ class Table extends Component {
             <TableHead
               sortable
               sortBy={this.defaultSortBy}
+              sortDirection={sortDirection}
+              sortedRow={sortedRow}
               onSortEnter={this.onSortEnter}
               onSortLeave={this.onSortLeave}
               headers={headers}

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 import { isString } from 'lodash/fp';
@@ -12,7 +12,7 @@ import { childrenPropType } from '../../util/shared-prop-types';
 const baseStyles = ({ theme }) => css`
   label: table;
   background-color: ${theme.colors.white};
-  border-radius: ${theme.borderRadius.mega};
+  border-collapse: separate;
   width: 100%;
 `;
 
@@ -22,53 +22,92 @@ const responsiveStyles = ({ theme, rowHeaders }) =>
     label: table--responsive;
     ${theme.mq.untilMega`
       margin-left: -145px;
+      width: calc(100% + 145px);
+
+      &:after {
+        content: '';
+        background-image: linear-gradient(90deg,rgba(0,0,0,.12),transparent);
+        height: 100%;
+        left: 145px;
+        position: absolute;
+        top: 0;
+        width: 6px;
+      }
     `};
   `;
 
 const StyledTable = styled.table`
   ${baseStyles};
   ${responsiveStyles};
-  ${shadowSingle};
 `;
 
 const containerStyles = ({ theme, rowHeaders }) =>
   rowHeaders &&
   css`
     label: table-container;
+    border-radius: ${theme.borderRadius.mega};
     ${theme.mq.untilMega`
       margin-left: 145px;
       overflow-x: auto;
     `};
   `;
 
-const StyledContainer = styled.div(containerStyles);
+const ScrollContainer = styled.div(containerStyles);
+
+const Container = styled.div(shadowSingle);
 
 const mapProps = props => (isString(props) ? { children: props } : props);
+const getChildren = props => (isString(props) ? props : props.children);
 
 const Table = ({ headers, rows, rowHeaders }) => (
-  <StyledContainer rowHeaders>
-    <StyledTable rowHeaders>
-      <tbody>
-        {!!headers.length && (
-          <TableRow header>
-            {headers.map(header => <TableHeader {...mapProps(header)} />)}
-          </TableRow>
-        )}
-        {rows.map(row => (
-          <TableRow>
-            {row.map(
-              (cell, i) =>
-                rowHeaders && i === 0 ? (
-                  <TableHeader scope={TableHeader.ROW} {...mapProps(cell)} />
-                ) : (
-                  <TableCell {...mapProps(cell)} />
-                )
-            )}
-          </TableRow>
-        ))}
-      </tbody>
-    </StyledTable>
-  </StyledContainer>
+  <Container>
+    <ScrollContainer rowHeaders>
+      <StyledTable rowHeaders>
+        <thead>
+          {!!headers.length && (
+            <TableRow header>
+              {headers.map(
+                (header, i) =>
+                  rowHeaders && i === 0 ? (
+                    <Fragment>
+                      <TableHeader fixed {...mapProps(header)} />
+                      <TableCell role="presentation" aria-hidden="true" header>
+                        {getChildren(header)}
+                      </TableCell>
+                    </Fragment>
+                  ) : (
+                    <TableHeader {...mapProps(header)} />
+                  )
+              )}
+            </TableRow>
+          )}
+        </thead>
+        <tbody>
+          {rows.map(row => (
+            <TableRow>
+              {row.map(
+                (cell, i) =>
+                  rowHeaders && i === 0 ? (
+                    <Fragment>
+                      <TableHeader
+                        fixed
+                        scope={TableHeader.ROW}
+                        {...mapProps(cell)}
+                      />
+                      <TableCell role="presentation" aria-hidden="true">
+                        {getChildren(cell)}
+                      </TableCell>
+                    </Fragment>
+                  ) : (
+                    <TableCell {...mapProps(cell)} />
+                  )
+              )}
+            </TableRow>
+          ))}
+        </tbody>
+      </StyledTable>
+    </ScrollContainer>
+  </Container>
 );
 
 const ItemPropType = PropTypes.oneOfType([

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -69,18 +69,30 @@ class Table extends Component {
 
   onSortEnter = i => this.setState({ sortHover: i });
   onSortLeave = () => this.setState({ sortHover: null });
-
-  defaultSortBy = i => {
+  onSortBy = i => {
     const { rows, sortedRow, sortDirection } = this.state;
+    const { onSortBy } = this.props;
     const isActive = i === sortedRow;
     const nextDirection = getSortDirection(isActive, sortDirection);
-    const nextFn = nextDirection === ASCENDING ? descendingSort : ascendingSort;
 
+    const nextRows = onSortBy
+      ? onSortBy(i, nextDirection, rows)
+      : this.defaultSortBy(i, nextDirection, rows);
+
+    this.updateRows(i, nextDirection, nextRows);
+  };
+
+  updateRows = (i, nextDirection, rows) =>
     this.setState({
-      rows: [...rows].sort(nextFn(i)),
+      rows,
       sortedRow: i,
       sortDirection: nextDirection
     });
+
+  defaultSortBy = (i, nextDirection, rows) => {
+    const nextFn = nextDirection === ASCENDING ? descendingSort : ascendingSort;
+
+    return [...rows].sort(nextFn(i));
   };
 
   render() {
@@ -93,7 +105,7 @@ class Table extends Component {
           <StyledTable rowHeaders={rowHeaders}>
             <TableHead
               sortable
-              sortBy={this.defaultSortBy}
+              sortBy={this.onSortBy}
               sortDirection={sortDirection}
               sortedRow={sortedRow}
               onSortEnter={this.onSortEnter}
@@ -116,13 +128,15 @@ class Table extends Component {
 Table.propTypes = {
   headers: PropTypes.arrayOf(RowPropType),
   rows: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
-  rowHeaders: PropTypes.bool
+  rowHeaders: PropTypes.bool,
+  onSortBy: PropTypes.func
 };
 
 Table.defaultProps = {
   headers: [],
   rows: [],
-  rowHeaders: true
+  rowHeaders: true,
+  onSortBy: null
 };
 
 export default Table;

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -59,6 +59,9 @@ const containerStyles = ({ theme, rowHeaders }) =>
 const ScrollContainer = styled.div(containerStyles);
 const Container = styled.div(shadowSingle);
 
+/**
+ * Table interface component. It handles rendering rows/headers properly
+ */
 class Table extends Component {
   state = {
     rows: this.props.rows,
@@ -152,9 +155,25 @@ class Table extends Component {
 }
 
 Table.propTypes = {
+  /**
+   * An array of headers for the table. The Header can be a string or an object
+   * with options described on TableHeader component
+   */
   headers: PropTypes.arrayOf(RowPropType),
+  /**
+   * An array of rows with an array of cells for the table. The Cell can be a
+   * string or an object with options described on TableCell component
+   */
   rows: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
+  /**
+   * Enables/disables sticky columns on mobile
+   */
   rowHeaders: PropTypes.bool,
+  /**
+   * Custom onSortBy function for the onSort handler.
+   * The signature is (index, nextDirection, currentRows) and it should return
+   * an array of rows
+   */
   onSortBy: PropTypes.func
 };
 

--- a/src/components/Table/Table.spec.js
+++ b/src/components/Table/Table.spec.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import Table from '.';
+
+describe('Table', () => {
+  /**
+   * Style tests.
+   */
+  it('should render with default styles', () => {
+    const actual = create(<Table />);
+    expect(actual).toMatchSnapshot();
+  });
+
+  /**
+   * Accessibility tests.
+   */
+  it('should meet accessibility guidelines', async () => {
+    const wrapper = renderToHtml(<Table />);
+    const actual = await axe(wrapper);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/src/components/Table/Table.spec.js
+++ b/src/components/Table/Table.spec.js
@@ -8,30 +8,30 @@ const headers = [{ children: 'Foo', sortable: true }, 'Bar', 'Baz'];
 const items = [['1', '2', '3'], ['1', '2', '3'], ['1', '2', '3']];
 
 describe('Table', () => {
-  /**
-   * Style tests.
-   */
   beforeEach(jest.clearAllMocks);
 
-  it('should render with default styles', () => {
-    const actual = create(<Table headers={headers} rows={items} />);
-    expect(actual).toMatchSnapshot();
+  describe('Style tests', () => {
+    it('should render with default styles', () => {
+      const actual = create(<Table headers={headers} rows={items} />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with rowHeader styles', () => {
+      const actual = create(
+        <Table rowHeaders headers={headers} rows={items} />
+      );
+      expect(actual).toMatchSnapshot();
+    });
   });
 
-  it('should render with rowHeader styles', () => {
-    const actual = create(<Table rowHeaders headers={headers} rows={items} />);
-    expect(actual).toMatchSnapshot();
-  });
-
-  /**
-   * Accessibility tests.
-   */
-  it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(
-      <Table rowHeaders headers={headers} rows={items} />
-    );
-    const actual = await axe(wrapper);
-    expect(actual).toHaveNoViolations();
+  describe('Accessibility tests', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(
+        <Table rowHeaders headers={headers} rows={items} />
+      );
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
   });
 
   describe('onSortEnter()', () => {

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -17,19 +17,19 @@ const headers = [
 const rows = [
   [
     'Lorem ipsum dolor',
-    '12/04/2017',
+    { children: '12/01/2017', sortByValue: '0' },
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
   ],
   [
     'Lorem ipsum dolor sit amet',
-    '12/04/2017',
+    { children: '13/01/2017', sortByValue: '1' },
     'Virtual Terminal',
     { children: 'Enabled', align: TableCell.RIGHT }
   ],
   [
     'Lorem ipsum dolor sit amet, consectetur adipiscing',
-    '12/04/2017',
+    { children: '14/01/2017', sortByValue: '2' },
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
   ]

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import withTests from '../../util/withTests';
+import Table from './Table';
+import TableHeader from './components/TableHeader';
+import TableCell from './components/TableCell';
+
+const headers = [
+  'Username',
+  'Created at',
+  'Permissions',
+  { children: 'Status', align: TableHeader.RIGHT }
+];
+
+const rows = [
+  [
+    'foo@sumup.com',
+    '12/04/2017',
+    '-',
+    { children: 'Disabled', align: TableCell.RIGHT }
+  ],
+  [
+    'bar@sumup.com',
+    '12/04/2017',
+    'Virtual Terminal',
+    { children: 'Enabled', align: TableCell.RIGHT }
+  ],
+  [
+    'baz@sumup.com',
+    '12/04/2017',
+    '-',
+    { children: 'Disabled', align: TableCell.RIGHT }
+  ]
+];
+
+storiesOf('Table', module)
+  .addDecorator(withTests('Table'))
+  .add(
+    'Default Table',
+    withInfo()(() => (
+      <div style={{ width: '98vw' }}>
+        <Table headers={headers} rows={rows} />
+      </div>
+    ))
+  );

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -8,7 +8,7 @@ import TableHeader from './components/TableHeader';
 import TableCell from './components/TableCell';
 
 const headers = [
-  'Username',
+  { children: 'Name', fixed: true },
   'Created at',
   'Permissions',
   { children: 'Status', align: TableHeader.RIGHT }
@@ -16,19 +16,19 @@ const headers = [
 
 const rows = [
   [
-    'foo@sumup.com',
+    'Lorem ipsum dolor sit amet',
     '12/04/2017',
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
   ],
   [
-    'bar@sumup.com',
+    'Lorem ipsum dolor sit amet, consectetur',
     '12/04/2017',
     'Virtual Terminal',
     { children: 'Enabled', align: TableCell.RIGHT }
   ],
   [
-    'baz@sumup.com',
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
     '12/04/2017',
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
@@ -36,7 +36,6 @@ const rows = [
 ];
 
 storiesOf('Table', module)
-  .addDecorator(withTests('Table'))
   .add(
     'Default Table',
     withInfo()(() => (

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { boolean } from '@storybook/addon-knobs/react';
 
 import withTests from '../../util/withTests';
 import Table from './Table';
@@ -38,10 +39,14 @@ const rows = [
 storiesOf('Table', module)
   .addDecorator(withTests('Table'))
   .add(
-    'Default Table',
+    'Table',
     withInfo()(() => (
       <div style={{ width: '98vw' }}>
-        <Table headers={headers} rows={rows} />
+        <Table
+          headers={headers}
+          rows={rows}
+          rowHeaders={boolean('Mobile rows', false)}
+        />
       </div>
     ))
   );

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -8,7 +8,7 @@ import TableHeader from './components/TableHeader';
 import TableCell from './components/TableCell';
 
 const headers = [
-  'Name',
+  { children: 'Name', sortable: true },
   'Created at',
   'Permissions',
   { children: 'Status', align: TableHeader.RIGHT }

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -8,7 +8,7 @@ import TableHeader from './components/TableHeader';
 import TableCell from './components/TableCell';
 
 const headers = [
-  { children: 'Name', fixed: true },
+  'Name',
   'Created at',
   'Permissions',
   { children: 'Status', align: TableHeader.RIGHT }
@@ -16,19 +16,19 @@ const headers = [
 
 const rows = [
   [
-    'Lorem ipsum dolor sit amet',
+    'Lorem ipsum dolor',
     '12/04/2017',
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
   ],
   [
-    'Lorem ipsum dolor sit amet, consectetur',
+    'Lorem ipsum dolor sit amet',
     '12/04/2017',
     'Virtual Terminal',
     { children: 'Enabled', align: TableCell.RIGHT }
   ],
   [
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    'Lorem ipsum dolor sit amet, consectetur adipiscing',
     '12/04/2017',
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
@@ -36,6 +36,7 @@ const rows = [
 ];
 
 storiesOf('Table', module)
+  .addDecorator(withTests('Table'))
   .add(
     'Default Table',
     withInfo()(() => (

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -120,6 +120,7 @@ exports[`Table should render with default styles 1`] = `
 }
 
 .circuit-5 {
+  background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
   text-align: left;
@@ -176,6 +177,7 @@ exports[`Table should render with default styles 1`] = `
 }
 
 .circuit-15 {
+  background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
   text-align: left;
@@ -196,6 +198,7 @@ exports[`Table should render with default styles 1`] = `
 }
 
 .circuit-17 {
+  background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
   text-align: left;
@@ -480,6 +483,7 @@ exports[`Table should render with rowHeader styles 1`] = `
 }
 
 .circuit-5 {
+  background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
   text-align: left;
@@ -536,6 +540,7 @@ exports[`Table should render with rowHeader styles 1`] = `
 }
 
 .circuit-15 {
+  background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
   text-align: left;
@@ -556,6 +561,7 @@ exports[`Table should render with rowHeader styles 1`] = `
 }
 
 .circuit-17 {
+  background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
   text-align: left;

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -44,6 +44,7 @@ exports[`Table should render with default styles 1`] = `
 >
   <div
     className="circuit-2 circuit-3"
+    tabIndex={null}
   >
     <table
       className="circuit-0 circuit-1"

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -1,7 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table should render with default styles 1`] = `
-<element
-  className="circuit-0 circuit-1"
-/>
+.circuit-4 {
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
+.circuit-2 {
+  border-radius: 4px;
+}
+
+@media (max-width:767px) {
+  .circuit-2 {
+    margin-left: 145px;
+    overflow-x: auto;
+  }
+}
+
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-collapse: separate;
+  width: 100%;
+}
+
+@media (max-width:767px) {
+  .circuit-0 {
+    margin-left: -145px;
+    width: calc(100% + 145px);
+  }
+
+  .circuit-0:after {
+    content: '';
+    background-image: linear-gradient(90deg,rgba(0,0,0,.12),transparent);
+    height: 100%;
+    left: 145px;
+    position: absolute;
+    top: 0;
+    width: 6px;
+  }
+}
+
+<div
+  className="circuit-4 circuit-5"
+>
+  <div
+    className="circuit-2 circuit-3"
+  >
+    <table
+      className="circuit-0 circuit-1"
+    >
+      <thead />
+      <tbody />
+    </table>
+  </div>
+</div>
 `;

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -1,34 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table should render with default styles 1`] = `
-.circuit-4 {
+.circuit-47 {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-2 {
+.circuit-45 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-2 {
+  .circuit-45 {
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-0 {
+.circuit-43 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-0 {
+  .circuit-43 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-0:after {
+  .circuit-43:after {
     content: '';
     background-image: linear-gradient(90deg,rgba(0,0,0,.12),transparent);
     height: 100%;
@@ -39,18 +39,682 @@ exports[`Table should render with default styles 1`] = `
   }
 }
 
+.circuit-11 {
+  vertical-align: middle;
+}
+
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media (max-width:767px) {
+  .circuit-3 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-5 {
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+  padding: 8px 24px;
+}
+
+@media (max-width:767px) {
+  .circuit-5 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-7 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+}
+
+.circuit-13 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+}
+
+@media (max-width:767px) {
+  .circuit-13 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-15 {
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+}
+
+@media (max-width:767px) {
+  .circuit-15 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-17 {
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
 <div
-  className="circuit-4 circuit-5"
+  className="circuit-47 circuit-48"
 >
   <div
-    className="circuit-2 circuit-3"
+    className="circuit-45 circuit-46"
     tabIndex={null}
   >
     <table
-      className="circuit-0 circuit-1"
+      className="circuit-43 circuit-44"
     >
-      <thead />
-      <tbody />
+      <thead>
+        <tr
+          className="circuit-11 circuit-12"
+        >
+          <th
+            aria-sort="none"
+            className="circuit-3 circuit-4"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            scope="col"
+          >
+            <button
+              className="circuit-0 circuit-1 circuit-2"
+              type="button"
+            >
+              <div>
+                arrow.svg
+              </div>
+              <div>
+                arrow.svg
+              </div>
+            </button>
+            Foo
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-5 circuit-6"
+            role="presentation"
+          >
+            Foo
+          </td>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
+            onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
+          >
+            Bar
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
+            onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
+          >
+            Baz
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="circuit-11 circuit-12"
+        >
+          <th
+            aria-sort={null}
+            className="circuit-13 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-15 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+        >
+          <th
+            aria-sort={null}
+            className="circuit-13 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-15 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+        >
+          <th
+            aria-sort={null}
+            className="circuit-13 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-15 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Table should render with rowHeader styles 1`] = `
+.circuit-47 {
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
+.circuit-45 {
+  border-radius: 4px;
+}
+
+@media (max-width:767px) {
+  .circuit-45 {
+    margin-left: 145px;
+    overflow-x: auto;
+  }
+}
+
+.circuit-43 {
+  background-color: #FFFFFF;
+  border-collapse: separate;
+  width: 100%;
+}
+
+@media (max-width:767px) {
+  .circuit-43 {
+    margin-left: -145px;
+    width: calc(100% + 145px);
+  }
+
+  .circuit-43:after {
+    content: '';
+    background-image: linear-gradient(90deg,rgba(0,0,0,.12),transparent);
+    height: 100%;
+    left: 145px;
+    position: absolute;
+    top: 0;
+    width: 6px;
+  }
+}
+
+.circuit-11 {
+  vertical-align: middle;
+}
+
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media (max-width:767px) {
+  .circuit-3 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-5 {
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+  padding: 8px 24px;
+}
+
+@media (max-width:767px) {
+  .circuit-5 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-7 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+}
+
+.circuit-13 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+}
+
+@media (max-width:767px) {
+  .circuit-13 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-15 {
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+}
+
+@media (max-width:767px) {
+  .circuit-15 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-17 {
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+<div
+  className="circuit-47 circuit-48"
+>
+  <div
+    className="circuit-45 circuit-46"
+    tabIndex={null}
+  >
+    <table
+      className="circuit-43 circuit-44"
+    >
+      <thead>
+        <tr
+          className="circuit-11 circuit-12"
+        >
+          <th
+            aria-sort="none"
+            className="circuit-3 circuit-4"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            scope="col"
+          >
+            <button
+              className="circuit-0 circuit-1 circuit-2"
+              type="button"
+            >
+              <div>
+                arrow.svg
+              </div>
+              <div>
+                arrow.svg
+              </div>
+            </button>
+            Foo
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-5 circuit-6"
+            role="presentation"
+          >
+            Foo
+          </td>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
+            onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
+          >
+            Bar
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
+            onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
+          >
+            Baz
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="circuit-11 circuit-12"
+        >
+          <th
+            aria-sort={null}
+            className="circuit-13 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-15 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+        >
+          <th
+            aria-sort={null}
+            className="circuit-13 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-15 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+        >
+          <th
+            aria-sort={null}
+            className="circuit-13 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-15 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-17 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+      </tbody>
     </table>
   </div>
 </div>

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table should render with default styles 1`] = `
+<element
+  className="circuit-0 circuit-1"
+/>
+`;

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Table should render with default styles 1`] = `
+exports[`Table Style tests should render with default styles 1`] = `
 .circuit-47 {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
@@ -363,7 +363,7 @@ exports[`Table should render with default styles 1`] = `
 </div>
 `;
 
-exports[`Table should render with rowHeader styles 1`] = `
+exports[`Table Style tests should render with rowHeader styles 1`] = `
 .circuit-47 {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }

--- a/src/components/Table/components/SortArrow/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/SortArrow/__snapshots__/index.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SortArrow should render with ascending arrow styles 1`] = `
+exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
 .circuit-1 {
   padding: 0;
   margin: 0;
@@ -47,7 +47,7 @@ exports[`SortArrow should render with ascending arrow styles 1`] = `
 </button>
 `;
 
-exports[`SortArrow should render with both arrows styles 1`] = `
+exports[`SortArrow Style tests should render with both arrows styles 1`] = `
 .circuit-1 {
   padding: 0;
   margin: 0;
@@ -97,7 +97,7 @@ exports[`SortArrow should render with both arrows styles 1`] = `
 </button>
 `;
 
-exports[`SortArrow should render with descending arrow styles 1`] = `
+exports[`SortArrow Style tests should render with descending arrow styles 1`] = `
 .circuit-1 {
   padding: 0;
   margin: 0;

--- a/src/components/Table/components/SortArrow/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/SortArrow/__snapshots__/index.spec.js.snap
@@ -1,0 +1,145 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SortArrow should render with ascending arrow styles 1`] = `
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+<button
+  className="circuit-0 circuit-1 circuit-2"
+  type="button"
+>
+  <div>
+    arrow.svg
+  </div>
+</button>
+`;
+
+exports[`SortArrow should render with both arrows styles 1`] = `
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+<button
+  className="circuit-0 circuit-1 circuit-2"
+  type="button"
+>
+  <div>
+    arrow.svg
+  </div>
+  <div>
+    arrow.svg
+  </div>
+</button>
+`;
+
+exports[`SortArrow should render with descending arrow styles 1`] = `
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+<button
+  className="circuit-0 circuit-1 circuit-2"
+  type="button"
+>
+  <div>
+    arrow.svg
+  </div>
+</button>
+`;

--- a/src/components/Table/components/SortArrow/arrow.svg
+++ b/src/components/Table/components/SortArrow/arrow.svg
@@ -1,0 +1,3 @@
+<svg width="5" height="4" viewBox="0 0 5 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 4H0L2.5 0L5 4Z" fill="#2F80ED"/>
+</svg>

--- a/src/components/Table/components/SortArrow/index.js
+++ b/src/components/Table/components/SortArrow/index.js
@@ -26,6 +26,9 @@ const DownArrow = styled(ArrowIcon)`
   transform: rotate(180deg);
 `;
 
+/**
+ * [PRIVATE] Arrow component for TableHeader sorting
+ */
 const SortArrow = ({ direction }) => (
   <StyledWrapper>
     <Fragment>

--- a/src/components/Table/components/SortArrow/index.js
+++ b/src/components/Table/components/SortArrow/index.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+import ArrowIcon from './arrow.svg';
+
+import { ASCENDING, DESCENDING } from '../../constants';
+
+const baseStyles = ({ theme }) => css`
+  display: flex;
+  flex-direction: column;
+  left: ${theme.spacings.byte};
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  transition: opacity ${theme.transitions.default};
+`;
+
+const StyledWrapper = styled.span`
+  ${baseStyles};
+`;
+
+const DownArrow = styled(ArrowIcon)`
+  margin-top: 2px;
+  transform: rotate(180deg);
+`;
+
+const SortArrow = ({ direction }) => (
+  <StyledWrapper>
+    {direction !== DESCENDING && <ArrowIcon />}
+    {direction !== ASCENDING && <DownArrow />}
+  </StyledWrapper>
+);
+
+SortArrow.propTypes = {
+  direction: PropTypes.oneOf([ASCENDING, DESCENDING])
+};
+
+SortArrow.defaultProps = {
+  direction: null
+};
+
+export default SortArrow;

--- a/src/components/Table/components/SortArrow/index.js
+++ b/src/components/Table/components/SortArrow/index.js
@@ -1,14 +1,15 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 import ArrowIcon from './arrow.svg';
 
+import SvgButton from '../../../../components/SvgButton';
 import { ASCENDING, DESCENDING } from '../../constants';
 
 const baseStyles = ({ theme }) => css`
   display: flex;
   flex-direction: column;
-  left: ${theme.spacings.byte};
+  left: ${theme.spacings.kilo};
   opacity: 0;
   position: absolute;
   top: 50%;
@@ -16,7 +17,7 @@ const baseStyles = ({ theme }) => css`
   transition: opacity ${theme.transitions.default};
 `;
 
-const StyledWrapper = styled.span`
+const StyledWrapper = styled(SvgButton)`
   ${baseStyles};
 `;
 
@@ -27,8 +28,10 @@ const DownArrow = styled(ArrowIcon)`
 
 const SortArrow = ({ direction }) => (
   <StyledWrapper>
-    {direction !== DESCENDING && <ArrowIcon />}
-    {direction !== ASCENDING && <DownArrow />}
+    <Fragment>
+      {direction !== DESCENDING && <ArrowIcon />}
+      {direction !== ASCENDING && <DownArrow />}
+    </Fragment>
   </StyledWrapper>
 );
 

--- a/src/components/Table/components/SortArrow/index.spec.js
+++ b/src/components/Table/components/SortArrow/index.spec.js
@@ -4,30 +4,28 @@ import SortArrow from '.';
 import { ASCENDING, DESCENDING } from '../../constants';
 
 describe('SortArrow', () => {
-  /**
-   * Style tests.
-   */
-  it('should render with both arrows styles', () => {
-    const actual = create(<SortArrow />);
-    expect(actual).toMatchSnapshot();
+  describe('Style tests', () => {
+    it('should render with both arrows styles', () => {
+      const actual = create(<SortArrow />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with ascending arrow styles', () => {
+      const actual = create(<SortArrow direction={ASCENDING} />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with descending arrow styles', () => {
+      const actual = create(<SortArrow direction={DESCENDING} />);
+      expect(actual).toMatchSnapshot();
+    });
   });
 
-  it('should render with ascending arrow styles', () => {
-    const actual = create(<SortArrow direction={ASCENDING} />);
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with descending arrow styles', () => {
-    const actual = create(<SortArrow direction={DESCENDING} />);
-    expect(actual).toMatchSnapshot();
-  });
-
-  /**
-   * Accessibility tests.
-   */
-  it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<SortArrow />);
-    const actual = await axe(wrapper);
-    expect(actual).toHaveNoViolations();
+  describe('Accessibility tests', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<SortArrow />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
   });
 });

--- a/src/components/Table/components/SortArrow/index.spec.js
+++ b/src/components/Table/components/SortArrow/index.spec.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import SortArrow from '.';
+import { ASCENDING, DESCENDING } from '../../constants';
+
+describe('SortArrow', () => {
+  /**
+   * Style tests.
+   */
+  it('should render with both arrows styles', () => {
+    const actual = create(<SortArrow />);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should render with ascending arrow styles', () => {
+    const actual = create(<SortArrow direction={ASCENDING} />);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should render with descending arrow styles', () => {
+    const actual = create(<SortArrow direction={DESCENDING} />);
+    expect(actual).toMatchSnapshot();
+  });
+
+  /**
+   * Accessibility tests.
+   */
+  it('should meet accessibility guidelines', async () => {
+    const wrapper = renderToHtml(<SortArrow />);
+    const actual = await axe(wrapper);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/src/components/Table/components/TableBody/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableBody/__snapshots__/index.spec.js.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableBody Style tests should render with default styles 1`] = `
+.circuit-4 {
+  vertical-align: middle;
+}
+
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+<tbody>
+  <tr
+    className="circuit-4 circuit-5"
+  >
+    <td
+      className="circuit-0 circuit-1"
+    >
+      Foo
+    </td>
+    <td
+      className="circuit-0 circuit-1"
+    >
+      Bar
+    </td>
+  </tr>
+</tbody>
+`;
+
+exports[`TableBody Style tests should render with fixed Header styles 1`] = `
+.circuit-6 {
+  vertical-align: middle;
+}
+
+.circuit-4 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+}
+
+@media (max-width:767px) {
+  .circuit-0 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-2 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+}
+
+@media (max-width:767px) {
+  .circuit-2 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+<tbody>
+  <tr
+    className="circuit-6 circuit-7"
+  >
+    <th
+      aria-sort={null}
+      className="circuit-0 circuit-1"
+      scope="row"
+    >
+      Foo
+    </th>
+    <td
+      aria-hidden="true"
+      className="circuit-2 circuit-3"
+      role="presentation"
+    >
+      Foo
+    </td>
+    <td
+      className="circuit-4 circuit-3"
+    >
+      Bar
+    </td>
+  </tr>
+</tbody>
+`;

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -10,21 +10,23 @@ const TableBody = ({ rows, rowHeaders }) => (
   <tbody>
     {rows.map(row => (
       <TableRow>
-        {row.map((cell, i) => (
-          <Fragment>
-            <TableHeader
-              fixed={rowHeaders && i === 0}
-              scope={TableHeader.ROW}
-              {...mapProps(cell)}
-            />
-            {rowHeaders &&
-              i === 0 && (
+        {row.map(
+          (cell, i) =>
+            rowHeaders && i === 0 ? (
+              <Fragment>
+                <TableHeader
+                  fixed
+                  scope={TableHeader.ROW}
+                  {...mapProps(cell)}
+                />
                 <TableCell role="presentation" aria-hidden="true">
                   {getChildren(cell)}
                 </TableCell>
-              )}
-          </Fragment>
-        ))}
+              </Fragment>
+            ) : (
+              <TableCell {...mapProps(cell)} />
+            )
+        )}
       </TableRow>
     ))}
   </tbody>

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -5,19 +5,22 @@ import TableRow from '../TableRow';
 import TableHeader from '../TableHeader';
 import TableCell from '../TableCell';
 import { mapProps, getChildren, RowPropType } from '../../utils';
+import { TR_KEY_PREFIX, TD_KEY_PREFIX } from '../../constants';
 
 const TableBody = ({ rows, rowHeaders, sortHover }) => (
   <tbody>
-    {rows.map(row => (
-      <TableRow>
+    {rows.map((row, i) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <TableRow key={`${TR_KEY_PREFIX}-${i}`}>
         {row.map(
-          (cell, i) =>
-            rowHeaders && i === 0 ? (
-              <Fragment>
+          (cell, j) =>
+            rowHeaders && j === 0 ? (
+              // eslint-disable-next-line react/no-array-index-key
+              <Fragment key={`${TD_KEY_PREFIX}-${i}-${j}`}>
                 <TableHeader
                   fixed
                   scope={TableHeader.ROW}
-                  active={sortHover === i}
+                  isActive={sortHover === j}
                   {...mapProps(cell)}
                 />
                 <TableCell role="presentation" aria-hidden="true">
@@ -25,7 +28,12 @@ const TableBody = ({ rows, rowHeaders, sortHover }) => (
                 </TableCell>
               </Fragment>
             ) : (
-              <TableCell {...mapProps(cell)} active={sortHover === i} />
+              <TableCell
+                // eslint-disable-next-line react/no-array-index-key
+                key={`${TD_KEY_PREFIX}-${i}-${j}`}
+                isActive={sortHover === j}
+                {...mapProps(cell)}
+              />
             )
         )}
       </TableRow>

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -7,20 +7,24 @@ import TableCell from '../TableCell';
 import { mapProps, getChildren, RowPropType } from '../../utils';
 import { TR_KEY_PREFIX, TD_KEY_PREFIX } from '../../constants';
 
+const getRowKey = index => `${TR_KEY_PREFIX}-${index}`;
+const getCellKey = (rowIndex, cellIndex) =>
+  `${TD_KEY_PREFIX}-${rowIndex}-${cellIndex}`;
+
 const TableBody = ({ rows, rowHeaders, sortHover }) => (
   <tbody>
-    {rows.map((row, i) => (
+    {rows.map((row, rowIndex) => (
       // eslint-disable-next-line react/no-array-index-key
-      <TableRow key={`${TR_KEY_PREFIX}-${i}`}>
+      <TableRow key={getRowKey(rowIndex)}>
         {row.map(
-          (cell, j) =>
-            rowHeaders && j === 0 ? (
+          (cell, cellIndex) =>
+            rowHeaders && cellIndex === 0 ? (
               // eslint-disable-next-line react/no-array-index-key
-              <Fragment key={`${TD_KEY_PREFIX}-${i}-${j}`}>
+              <Fragment key={getCellKey(rowIndex, cellIndex)}>
                 <TableHeader
                   fixed
                   scope={TableHeader.ROW}
-                  isHovered={sortHover === j}
+                  isHovered={sortHover === cellIndex}
                   {...mapProps(cell)}
                 />
                 <TableCell role="presentation" aria-hidden="true">
@@ -30,8 +34,8 @@ const TableBody = ({ rows, rowHeaders, sortHover }) => (
             ) : (
               <TableCell
                 // eslint-disable-next-line react/no-array-index-key
-                key={`${TD_KEY_PREFIX}-${i}-${j}`}
-                isHovered={sortHover === j}
+                key={getCellKey(rowIndex, cellIndex)}
+                isHovered={sortHover === cellIndex}
                 {...mapProps(cell)}
               />
             )
@@ -41,15 +45,29 @@ const TableBody = ({ rows, rowHeaders, sortHover }) => (
   </tbody>
 );
 
+/**
+ * [PRIVATE] TableHead for the Table component. The Table handles rendering it
+ */
 TableBody.propTypes = {
+  /**
+   * An array of rows with cells for the table. The Cell can be a string
+   * or an object with options described on TableHeader component
+   */
   rows: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
+  /**
+   * Enables/disables sticky columns on mobile
+   */
   rowHeaders: PropTypes.bool,
+  /**
+   * [PRIVATE] The current hovered sort cell index
+   * Handled internally
+   */
   sortHover: PropTypes.number
 };
 
 TableBody.defaultProps = {
   rows: [],
-  rowHeaders: true,
+  rowHeaders: false,
   sortHover: null
 };
 

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -6,7 +6,7 @@ import TableHeader from '../TableHeader';
 import TableCell from '../TableCell';
 import { mapProps, getChildren, RowPropType } from '../../utils';
 
-const TableBody = ({ rows, rowHeaders }) => (
+const TableBody = ({ rows, rowHeaders, sortHover }) => (
   <tbody>
     {rows.map(row => (
       <TableRow>
@@ -17,6 +17,7 @@ const TableBody = ({ rows, rowHeaders }) => (
                 <TableHeader
                   fixed
                   scope={TableHeader.ROW}
+                  active={sortHover === i}
                   {...mapProps(cell)}
                 />
                 <TableCell role="presentation" aria-hidden="true">
@@ -24,7 +25,7 @@ const TableBody = ({ rows, rowHeaders }) => (
                 </TableCell>
               </Fragment>
             ) : (
-              <TableCell {...mapProps(cell)} />
+              <TableCell {...mapProps(cell)} active={sortHover === i} />
             )
         )}
       </TableRow>
@@ -34,12 +35,14 @@ const TableBody = ({ rows, rowHeaders }) => (
 
 TableBody.propTypes = {
   rows: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
-  rowHeaders: PropTypes.bool
+  rowHeaders: PropTypes.bool,
+  sortHover: PropTypes.number
 };
 
 TableBody.defaultProps = {
   rows: [],
-  rowHeaders: true
+  rowHeaders: true,
+  sortHover: null
 };
 
 export default TableBody;

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -1,0 +1,43 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+import TableRow from '../TableRow';
+import TableHeader from '../TableHeader';
+import TableCell from '../TableCell';
+import { mapProps, getChildren, RowPropType } from '../../utils';
+
+const TableBody = ({ rows, rowHeaders }) => (
+  <tbody>
+    {rows.map(row => (
+      <TableRow>
+        {row.map((cell, i) => (
+          <Fragment>
+            <TableHeader
+              fixed={rowHeaders && i === 0}
+              scope={TableHeader.ROW}
+              {...mapProps(cell)}
+            />
+            {rowHeaders &&
+              i === 0 && (
+                <TableCell role="presentation" aria-hidden="true">
+                  {getChildren(cell)}
+                </TableCell>
+              )}
+          </Fragment>
+        ))}
+      </TableRow>
+    ))}
+  </tbody>
+);
+
+TableBody.propTypes = {
+  rows: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
+  rowHeaders: PropTypes.bool
+};
+
+TableBody.defaultProps = {
+  rows: [],
+  rowHeaders: true
+};
+
+export default TableBody;

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -20,7 +20,7 @@ const TableBody = ({ rows, rowHeaders, sortHover }) => (
                 <TableHeader
                   fixed
                   scope={TableHeader.ROW}
-                  isActive={sortHover === j}
+                  isHovered={sortHover === j}
                   {...mapProps(cell)}
                 />
                 <TableCell role="presentation" aria-hidden="true">
@@ -31,7 +31,7 @@ const TableBody = ({ rows, rowHeaders, sortHover }) => (
               <TableCell
                 // eslint-disable-next-line react/no-array-index-key
                 key={`${TD_KEY_PREFIX}-${i}-${j}`}
-                isActive={sortHover === j}
+                isHovered={sortHover === j}
                 {...mapProps(cell)}
               />
             )

--- a/src/components/Table/components/TableBody/index.spec.js
+++ b/src/components/Table/components/TableBody/index.spec.js
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import TableBody from '.';
+
+const fixtureRows = [['Foo', 'Bar']];
+
+describe('TableBody', () => {
+  describe('Style tests', () => {
+    it('should render with default styles', () => {
+      const actual = create(<TableBody rows={fixtureRows} />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with fixed Header styles', () => {
+      const actual = create(<TableBody rowHeaders rows={fixtureRows} />);
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('rowHeaders', () => {
+    describe('no rowHeaders', () => {
+      it('should render a TableCell on the first cellIndex of each row', () => {
+        const wrapper = shallow(<TableBody rows={fixtureRows} />);
+
+        expect(
+          wrapper
+            .find('TableRow')
+            .at(0)
+            .find('TableCell')
+            .at(0).length
+        ).toBeTruthy();
+      });
+    });
+
+    it('should add fixed to first TableHeader', () => {
+      const wrapper = shallow(<TableBody rowHeaders rows={fixtureRows} />);
+
+      expect(
+        wrapper
+          .find('TableRow')
+          .at(0)
+          .find('TableHeader')
+          .at(0)
+          .props().fixed
+      ).toBeTruthy();
+    });
+
+    describe('presentational TableCell', () => {
+      it('should add it to the first header', () => {
+        const wrapper = shallow(<TableBody rowHeaders rows={fixtureRows} />);
+
+        expect(
+          wrapper
+            .find('TableRow')
+            .at(0)
+            .find('TableCell')
+            .at(0).length
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe('sortHover', () => {
+    describe('Cell index not relative to sortHover', () => {
+      it('should not add isHovered to it', () => {
+        const sortHover = 1;
+        const wrapper = shallow(
+          <TableBody sortHover={sortHover} rows={fixtureRows} />
+        );
+
+        expect(
+          wrapper
+            .find('TableRow')
+            .at(0)
+            .find('TableCell')
+            .at(0)
+            .props().isHovered
+        ).toBeFalsy();
+      });
+    });
+    describe('relative Cell index to sortHover', () => {
+      it('should add isHovered to it', () => {
+        const sortHover = 0;
+        const wrapper = shallow(
+          <TableBody sortHover={sortHover} rows={fixtureRows} />
+        );
+
+        expect(
+          wrapper
+            .find('TableRow')
+            .at(0)
+            .find('TableCell')
+            .at(0)
+            .props().isHovered
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Accessibility tests', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<TableBody rowHeader rows={fixtureRows} />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Table/components/TableCell/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableCell/__snapshots__/index.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableCell should render with default styles 1`] = `
+exports[`TableCell Style tests should render with default styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
@@ -19,7 +19,7 @@ exports[`TableCell should render with default styles 1`] = `
 </td>
 `;
 
-exports[`TableCell should render with header styles 1`] = `
+exports[`TableCell Style tests should render with header styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
@@ -38,7 +38,7 @@ exports[`TableCell should render with header styles 1`] = `
 </td>
 `;
 
-exports[`TableCell should render with isHovered styles 1`] = `
+exports[`TableCell Style tests should render with isHovered styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;

--- a/src/components/Table/components/TableCell/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableCell/__snapshots__/index.spec.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableCell should render with default styles 1`] = `
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+<td
+  className="circuit-0 circuit-1"
+>
+  Foo
+</td>
+`;
+
+exports[`TableCell should render with header styles 1`] = `
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+<td
+  className="circuit-0 circuit-1"
+>
+  Foo
+</td>
+`;
+
+exports[`TableCell should render with isHovered styles 1`] = `
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  background-color: #FAFBFC;
+}
+
+<td
+  className="circuit-0 circuit-1"
+>
+  Foo
+</td>
+`;

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -31,8 +31,8 @@ const presentationStyles = ({ theme, role, header }) =>
     `};
   `;
 
-const activeStyles = ({ theme, active }) =>
-  active &&
+const activeStyles = ({ theme, isActive }) =>
+  isActive &&
   css`
     label: table-cell--hover;
     background-color: ${theme.colors.n100};
@@ -51,13 +51,13 @@ TableCell.CENTER = directions.CENTER;
 TableCell.propTypes = {
   align: PropTypes.oneOf([TableCell.LEFT, TableCell.RIGHT, TableCell.CENTER]),
   header: PropTypes.bool,
-  active: PropTypes.bool
+  isActive: PropTypes.bool
 };
 
 TableCell.defaultProps = {
   align: TableCell.LEFT,
   header: false,
-  active: false
+  isActive: false
 };
 
 export default TableCell;

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -7,6 +7,7 @@ const PRESENTATION = 'presentation';
 
 const baseStyles = ({ theme, align }) => css`
   label: table-cell;
+  background-color: ${theme.colors.white};
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
   padding: ${theme.spacings.giga};
   text-align: ${align};
@@ -38,6 +39,10 @@ const hoverStyles = ({ theme, isHovered }) =>
     background-color: ${theme.colors.n100};
   `;
 
+/**
+ * TableCell component for the Table. You shouldn't import this component
+ * directly, the Table handles it
+ */
 const TableCell = styled.td`
   ${baseStyles};
   ${presentationStyles};
@@ -49,8 +54,20 @@ TableCell.RIGHT = directions.RIGHT;
 TableCell.CENTER = directions.CENTER;
 
 TableCell.propTypes = {
+  /**
+   * Aligns the content of the Cell with text-align
+   */
   align: PropTypes.oneOf([TableCell.LEFT, TableCell.RIGHT, TableCell.CENTER]),
+  /**
+   * [PRIVATE] Add heading styles to placeholder Cell.
+   * Handled internally
+   */
   header: PropTypes.bool,
+  /**
+   * [PRIVATE] Adds active style to the Cell if it is currently hovered by
+   * sort.
+   * Handled internally
+   */
   isHovered: PropTypes.bool
 };
 

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -31,8 +31,8 @@ const presentationStyles = ({ theme, role, header }) =>
     `};
   `;
 
-const activeStyles = ({ theme, isActive }) =>
-  isActive &&
+const hoverStyles = ({ theme, isHovered }) =>
+  isHovered &&
   css`
     label: table-cell--hover;
     background-color: ${theme.colors.n100};
@@ -41,7 +41,7 @@ const activeStyles = ({ theme, isActive }) =>
 const TableCell = styled.td`
   ${baseStyles};
   ${presentationStyles};
-  ${activeStyles};
+  ${hoverStyles};
 `;
 
 TableCell.LEFT = directions.LEFT;
@@ -51,13 +51,13 @@ TableCell.CENTER = directions.CENTER;
 TableCell.propTypes = {
   align: PropTypes.oneOf([TableCell.LEFT, TableCell.RIGHT, TableCell.CENTER]),
   header: PropTypes.bool,
-  isActive: PropTypes.bool
+  isHovered: PropTypes.bool
 };
 
 TableCell.defaultProps = {
   align: TableCell.LEFT,
   header: false,
-  isActive: false
+  isHovered: false
 };
 
 export default TableCell;

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+
+import { directions } from '../../../../styles/constants';
+
+const baseStyles = ({ theme, align }) => css`
+  label: table-cell;
+  text-align: ${align};
+  border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
+  padding: ${theme.spacings.mega};
+  white-space: nowrap;
+`;
+
+const TableCell = styled.td(baseStyles);
+
+TableCell.LEFT = directions.LEFT;
+TableCell.RIGHT = directions.RIGHT;
+TableCell.CENTER = directions.CENTER;
+
+TableCell.propTypes = {
+  align: PropTypes.oneOf([TableCell.LEFT, TableCell.RIGHT, TableCell.CENTER])
+};
+
+TableCell.defaultProps = {
+  align: TableCell.LEFT
+};
+
+export default TableCell;

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -8,7 +8,7 @@ const PRESENTATION = 'presentation';
 const baseStyles = ({ theme, align }) => css`
   label: table-cell;
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
-  padding: ${theme.spacings.mega};
+  padding: ${theme.spacings.giga};
   text-align: ${align};
   transition: background-color ${theme.transitions.default};
   vertical-align: middle;
@@ -21,7 +21,7 @@ const presentationStyles = ({ theme, role, header }) =>
     label: table-cell--presentation;
     display: none;
 
-    ${header && `padding: ${theme.spacings.byte} ${theme.spacings.mega}`};
+    ${header && `padding: ${theme.spacings.byte} ${theme.spacings.giga}`};
 
     ${theme.mq.untilMega`
       display: table-cell;

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -10,6 +10,7 @@ const baseStyles = ({ theme, align }) => css`
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
   padding: ${theme.spacings.mega};
   text-align: ${align};
+  transition: background-color ${theme.transitions.default};
   vertical-align: middle;
   white-space: nowrap;
 `;
@@ -30,9 +31,17 @@ const presentationStyles = ({ theme, role, header }) =>
     `};
   `;
 
+const activeStyles = ({ theme, active }) =>
+  active &&
+  css`
+    label: table-cell--hover;
+    background-color: ${theme.colors.n100};
+  `;
+
 const TableCell = styled.td`
   ${baseStyles};
   ${presentationStyles};
+  ${activeStyles};
 `;
 
 TableCell.LEFT = directions.LEFT;
@@ -41,12 +50,14 @@ TableCell.CENTER = directions.CENTER;
 
 TableCell.propTypes = {
   align: PropTypes.oneOf([TableCell.LEFT, TableCell.RIGHT, TableCell.CENTER]),
-  header: PropTypes.bool
+  header: PropTypes.bool,
+  active: PropTypes.bool
 };
 
 TableCell.defaultProps = {
   align: TableCell.LEFT,
-  header: false
+  header: false,
+  active: false
 };
 
 export default TableCell;

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -3,26 +3,50 @@ import styled, { css } from 'react-emotion';
 
 import { directions } from '../../../../styles/constants';
 
+const PRESENTATION = 'presentation';
+
 const baseStyles = ({ theme, align }) => css`
   label: table-cell;
-  text-align: ${align};
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
   padding: ${theme.spacings.mega};
+  text-align: ${align};
+  vertical-align: middle;
   white-space: nowrap;
 `;
 
-const TableCell = styled.td(baseStyles);
+const presentationStyles = ({ theme, role, header }) =>
+  role === PRESENTATION &&
+  css`
+    label: table-cell--presentation;
+    display: none;
+
+    ${header && `padding: ${theme.spacings.byte} ${theme.spacings.mega}`};
+
+    ${theme.mq.untilMega`
+      display: table-cell;
+      min-width: 145px;
+      white-space: unset;
+      width: 145px;
+    `};
+  `;
+
+const TableCell = styled.td`
+  ${baseStyles};
+  ${presentationStyles};
+`;
 
 TableCell.LEFT = directions.LEFT;
 TableCell.RIGHT = directions.RIGHT;
 TableCell.CENTER = directions.CENTER;
 
 TableCell.propTypes = {
-  align: PropTypes.oneOf([TableCell.LEFT, TableCell.RIGHT, TableCell.CENTER])
+  align: PropTypes.oneOf([TableCell.LEFT, TableCell.RIGHT, TableCell.CENTER]),
+  header: PropTypes.bool
 };
 
 TableCell.defaultProps = {
-  align: TableCell.LEFT
+  align: TableCell.LEFT,
+  header: false
 };
 
 export default TableCell;

--- a/src/components/Table/components/TableCell/index.spec.js
+++ b/src/components/Table/components/TableCell/index.spec.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import TableCell from '.';
+
+const children = 'Foo';
+
+describe('TableCell', () => {
+  /**
+   * Style tests.
+   */
+  it('should render with default styles', () => {
+    const actual = create(<TableCell>{children}</TableCell>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should render with isHovered styles', () => {
+    const actual = create(<TableCell isHovered>{children}</TableCell>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should render with header styles', () => {
+    const actual = create(<TableCell header>{children}</TableCell>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  /**
+   * Accessibility tests.
+   */
+  it('should meet accessibility guidelines', async () => {
+    const wrapper = renderToHtml(<TableCell sortable>{children}</TableCell>);
+    const actual = await axe(wrapper);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/src/components/Table/components/TableCell/index.spec.js
+++ b/src/components/Table/components/TableCell/index.spec.js
@@ -5,30 +5,28 @@ import TableCell from '.';
 const children = 'Foo';
 
 describe('TableCell', () => {
-  /**
-   * Style tests.
-   */
-  it('should render with default styles', () => {
-    const actual = create(<TableCell>{children}</TableCell>);
-    expect(actual).toMatchSnapshot();
+  describe('Style tests', () => {
+    it('should render with default styles', () => {
+      const actual = create(<TableCell>{children}</TableCell>);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with isHovered styles', () => {
+      const actual = create(<TableCell isHovered>{children}</TableCell>);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with header styles', () => {
+      const actual = create(<TableCell header>{children}</TableCell>);
+      expect(actual).toMatchSnapshot();
+    });
   });
 
-  it('should render with isHovered styles', () => {
-    const actual = create(<TableCell isHovered>{children}</TableCell>);
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with header styles', () => {
-    const actual = create(<TableCell header>{children}</TableCell>);
-    expect(actual).toMatchSnapshot();
-  });
-
-  /**
-   * Accessibility tests.
-   */
-  it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<TableCell sortable>{children}</TableCell>);
-    const actual = await axe(wrapper);
-    expect(actual).toHaveNoViolations();
+  describe('Accessibility tests', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<TableCell sortable>{children}</TableCell>);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
   });
 });

--- a/src/components/Table/components/TableCell/index.story.js
+++ b/src/components/Table/components/TableCell/index.story.js
@@ -4,25 +4,25 @@ import { withInfo } from '@storybook/addon-info';
 import { boolean, text, select } from '@storybook/addon-knobs/react';
 
 import withTests from '../../../../util/withTests';
-import TableHeader from '.';
+import TableCell from '.';
 
 const options = {
-  [TableHeader.LEFT]: TableHeader.LEFT,
-  [TableHeader.RIGHT]: TableHeader.RIGHT,
-  [TableHeader.CENTER]: TableHeader.CENTER
+  [TableCell.LEFT]: TableCell.LEFT,
+  [TableCell.RIGHT]: TableCell.RIGHT,
+  [TableCell.CENTER]: TableCell.CENTER
 };
 
-storiesOf('TableHeader', module)
-  .addDecorator(withTests('TableHeader'))
+storiesOf('TableCell', module)
+  // .addDecorator(withTests('TableCell'))
   .add(
-    'Table Header',
+    'Table Cell',
     withInfo()(() => (
-      <TableHeader
+      <TableCell
         style={{ width: '300px', alignSelf: 'center' }}
         align={select('Align', options)}
-        sortable={boolean('Sortable', false)}
+        isHovered={boolean('Hover styles', false)}
       >
         {text('Content', 'Header')}
-      </TableHeader>
+      </TableCell>
     ))
   );

--- a/src/components/Table/components/TableCell/index.story.js
+++ b/src/components/Table/components/TableCell/index.story.js
@@ -13,7 +13,7 @@ const options = {
 };
 
 storiesOf('TableCell', module)
-  // .addDecorator(withTests('TableCell'))
+  .addDecorator(withTests('TableCell'))
   .add(
     'Table Cell',
     withInfo()(() => (

--- a/src/components/Table/components/TableHead/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableHead/__snapshots__/index.spec.js.snap
@@ -1,0 +1,271 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableHead Style tests should render with default styles 1`] = `
+.circuit-9 {
+  vertical-align: middle;
+}
+
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-5 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+}
+
+<thead>
+  <tr
+    className="circuit-9 circuit-10"
+  >
+    <th
+      aria-sort="none"
+      className="circuit-3 circuit-4"
+      onClick={[Function]}
+      onMouseEnter={null}
+      onMouseLeave={null}
+      scope="col"
+    >
+      <button
+        className="circuit-0 circuit-1 circuit-2"
+        type="button"
+      >
+        <div>
+          arrow.svg
+        </div>
+        <div>
+          arrow.svg
+        </div>
+      </button>
+      Foo
+    </th>
+    <th
+      aria-sort={null}
+      className="circuit-5 circuit-4"
+      onClick={null}
+      onMouseEnter={null}
+      onMouseLeave={null}
+      scope="col"
+    >
+      Bar
+    </th>
+    <th
+      aria-sort={null}
+      className="circuit-5 circuit-4"
+      onClick={null}
+      onMouseEnter={null}
+      onMouseLeave={null}
+      scope="col"
+    >
+      Baz
+    </th>
+  </tr>
+</thead>
+`;
+
+exports[`TableHead Style tests should render with rowHeader styles 1`] = `
+.circuit-9 {
+  vertical-align: middle;
+}
+
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-5 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+}
+
+<thead>
+  <tr
+    className="circuit-9 circuit-10"
+  >
+    <th
+      aria-sort="none"
+      className="circuit-3 circuit-4"
+      onClick={[Function]}
+      onMouseEnter={null}
+      onMouseLeave={null}
+      scope="col"
+    >
+      <button
+        className="circuit-0 circuit-1 circuit-2"
+        type="button"
+      >
+        <div>
+          arrow.svg
+        </div>
+        <div>
+          arrow.svg
+        </div>
+      </button>
+      Foo
+    </th>
+    <th
+      aria-sort={null}
+      className="circuit-5 circuit-4"
+      onClick={null}
+      onMouseEnter={null}
+      onMouseLeave={null}
+      scope="col"
+    >
+      Bar
+    </th>
+    <th
+      aria-sort={null}
+      className="circuit-5 circuit-4"
+      onClick={null}
+      onMouseEnter={null}
+      onMouseLeave={null}
+      scope="col"
+    >
+      Baz
+    </th>
+  </tr>
+</thead>
+`;

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -6,7 +6,7 @@ import TableRow from '../TableRow';
 import TableHeader from '../TableHeader';
 import TableCell from '../TableCell';
 import { mapProps, getChildren, RowPropType } from '../../utils';
-import { ASCENDING, DESCENDING } from '../../constants';
+import { ASCENDING, DESCENDING, TH_KEY_PREFIX } from '../../constants';
 
 const TableHead = ({
   headers,
@@ -23,7 +23,8 @@ const TableHead = ({
         {headers.map((header, i) => {
           const props = mapProps(header);
           return (
-            <Fragment>
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={`${TH_KEY_PREFIX}-${i}`}>
               <TableHeader
                 {...props}
                 fixed={rowHeaders && i === 0}
@@ -52,7 +53,7 @@ const TableHead = ({
 );
 
 TableHead.propTypes = {
-  headers: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
+  headers: PropTypes.arrayOf(RowPropType),
   rowHeaders: PropTypes.bool,
   sortBy: PropTypes.func,
   sortDirection: PropTypes.oneOf([ASCENDING, DESCENDING]),

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -7,7 +7,14 @@ import TableHeader from '../TableHeader';
 import TableCell from '../TableCell';
 import { mapProps, getChildren, RowPropType } from '../../utils';
 
-const TableHead = ({ headers, rowHeaders, sortBy }) => (
+const TableHead = ({
+  headers,
+  rowHeaders,
+  sortable,
+  sortBy,
+  onSortEnter,
+  onSortLeave
+}) => (
   <thead>
     {!!headers.length && (
       <TableRow header>
@@ -15,9 +22,11 @@ const TableHead = ({ headers, rowHeaders, sortBy }) => (
           <Fragment>
             <TableHeader
               {...mapProps(header)}
-              sortable
+              sortable={sortable}
               fixed={rowHeaders && i === 0}
-              onClick={() => sortBy(i)}
+              onClick={sortable && (() => sortBy(i))}
+              onMouseEnter={onSortEnter && (() => onSortEnter(i))}
+              onMouseLeave={onSortLeave && (() => onSortLeave(i))}
             />
             {rowHeaders &&
               i === 0 && (
@@ -35,13 +44,19 @@ const TableHead = ({ headers, rowHeaders, sortBy }) => (
 TableHead.propTypes = {
   headers: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
   rowHeaders: PropTypes.bool,
-  sortBy: PropTypes.func
+  sortable: PropTypes.bool,
+  sortBy: PropTypes.func,
+  onSortEnter: PropTypes.func,
+  onSortLeave: PropTypes.func
 };
 
 TableHead.defaultProps = {
   headers: [],
   rowHeaders: true,
-  sortBy: noop
+  sortable: false,
+  sortBy: noop,
+  onSortEnter: null,
+  onSortLeave: null
 };
 
 export default TableHead;

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -6,12 +6,15 @@ import TableRow from '../TableRow';
 import TableHeader from '../TableHeader';
 import TableCell from '../TableCell';
 import { mapProps, getChildren, RowPropType } from '../../utils';
+import { ASCENDING, DESCENDING } from '../../constants';
 
 const TableHead = ({
   headers,
   rowHeaders,
   sortable,
   sortBy,
+  sortDirection,
+  sortedRow,
   onSortEnter,
   onSortLeave
 }) => (
@@ -27,6 +30,8 @@ const TableHead = ({
               onClick={sortable && (() => sortBy(i))}
               onMouseEnter={onSortEnter && (() => onSortEnter(i))}
               onMouseLeave={onSortLeave && (() => onSortLeave(i))}
+              sortDirection={sortedRow === i ? sortDirection : null}
+              isSorted={sortedRow === i}
             />
             {rowHeaders &&
               i === 0 && (
@@ -46,6 +51,8 @@ TableHead.propTypes = {
   rowHeaders: PropTypes.bool,
   sortable: PropTypes.bool,
   sortBy: PropTypes.func,
+  sortDirection: PropTypes.oneOf([ASCENDING, DESCENDING]),
+  sortedRow: PropTypes.number,
   onSortEnter: PropTypes.func,
   onSortLeave: PropTypes.func
 };
@@ -55,6 +62,8 @@ TableHead.defaultProps = {
   rowHeaders: true,
   sortable: false,
   sortBy: noop,
+  sortDirection: null,
+  sortedRow: null,
   onSortEnter: null,
   onSortLeave: null
 };

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -1,0 +1,46 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { noop } from 'lodash/fp';
+
+import TableRow from '../TableRow';
+import TableHeader from '../TableHeader';
+import TableCell from '../TableCell';
+import { mapProps, getChildren, RowPropType } from '../../utils';
+
+const TableHead = ({ headers, rowHeaders, sortBy }) => (
+  <thead>
+    {!!headers.length && (
+      <TableRow header>
+        {headers.map((header, i) => (
+          <Fragment>
+            <TableHeader
+              {...mapProps(header)}
+              fixed={rowHeaders && i === 0}
+              onClick={() => sortBy(i)}
+            />
+            {rowHeaders &&
+              i === 0 && (
+                <TableCell role="presentation" aria-hidden="true" header>
+                  {getChildren(header)}
+                </TableCell>
+              )}
+          </Fragment>
+        ))}
+      </TableRow>
+    )}
+  </thead>
+);
+
+TableHead.propTypes = {
+  headers: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
+  rowHeaders: PropTypes.bool,
+  sortBy: PropTypes.func
+};
+
+TableHead.defaultProps = {
+  headers: [],
+  rowHeaders: true,
+  sortBy: noop
+};
+
+export default TableHead;

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -15,6 +15,7 @@ const TableHead = ({ headers, rowHeaders, sortBy }) => (
           <Fragment>
             <TableHeader
               {...mapProps(header)}
+              sortable
               fixed={rowHeaders && i === 0}
               onClick={() => sortBy(i)}
             />

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -11,7 +11,6 @@ import { ASCENDING, DESCENDING } from '../../constants';
 const TableHead = ({
   headers,
   rowHeaders,
-  sortable,
   sortBy,
   sortDirection,
   sortedRow,
@@ -21,26 +20,32 @@ const TableHead = ({
   <thead>
     {!!headers.length && (
       <TableRow header>
-        {headers.map((header, i) => (
-          <Fragment>
-            <TableHeader
-              {...mapProps(header)}
-              sortable={sortable}
-              fixed={rowHeaders && i === 0}
-              onClick={sortable && (() => sortBy(i))}
-              onMouseEnter={onSortEnter && (() => onSortEnter(i))}
-              onMouseLeave={onSortLeave && (() => onSortLeave(i))}
-              sortDirection={sortedRow === i ? sortDirection : null}
-              isSorted={sortedRow === i}
-            />
-            {rowHeaders &&
-              i === 0 && (
-                <TableCell role="presentation" aria-hidden="true" header>
-                  {getChildren(header)}
-                </TableCell>
-              )}
-          </Fragment>
-        ))}
+        {headers.map((header, i) => {
+          const props = mapProps(header);
+          return (
+            <Fragment>
+              <TableHeader
+                {...props}
+                fixed={rowHeaders && i === 0}
+                onClick={props.sortable ? () => sortBy(i) : null}
+                onMouseEnter={
+                  props.sortable ? onSortEnter && (() => onSortEnter(i)) : null
+                }
+                onMouseLeave={
+                  props.sortable ? onSortLeave && (() => onSortLeave(i)) : null
+                }
+                sortDirection={sortedRow === i ? sortDirection : null}
+                isSorted={sortedRow === i}
+              />
+              {rowHeaders &&
+                i === 0 && (
+                  <TableCell role="presentation" aria-hidden="true" header>
+                    {getChildren(header)}
+                  </TableCell>
+                )}
+            </Fragment>
+          );
+        })}
       </TableRow>
     )}
   </thead>
@@ -49,9 +54,9 @@ const TableHead = ({
 TableHead.propTypes = {
   headers: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
   rowHeaders: PropTypes.bool,
-  sortable: PropTypes.bool,
   sortBy: PropTypes.func,
   sortDirection: PropTypes.oneOf([ASCENDING, DESCENDING]),
+  sortable: PropTypes.bool,
   sortedRow: PropTypes.number,
   onSortEnter: PropTypes.func,
   onSortLeave: PropTypes.func
@@ -60,9 +65,9 @@ TableHead.propTypes = {
 TableHead.defaultProps = {
   headers: [],
   rowHeaders: true,
-  sortable: false,
   sortBy: noop,
   sortDirection: null,
+  sortable: null,
   sortedRow: null,
   onSortEnter: null,
   onSortLeave: null

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -11,7 +11,7 @@ import { ASCENDING, DESCENDING, TH_KEY_PREFIX } from '../../constants';
 const TableHead = ({
   headers,
   rowHeaders,
-  sortBy,
+  onSortBy,
   sortDirection,
   sortedRow,
   onSortEnter,
@@ -28,7 +28,8 @@ const TableHead = ({
               <TableHeader
                 {...props}
                 fixed={rowHeaders && i === 0}
-                onClick={props.sortable ? () => sortBy(i) : null}
+                // eslint-disable-next-line react/prop-types
+                onClick={props.sortable ? () => onSortBy(i) : null}
                 onMouseEnter={
                   props.sortable ? onSortEnter && (() => onSortEnter(i)) : null
                 }
@@ -52,23 +53,46 @@ const TableHead = ({
   </thead>
 );
 
+/**
+ * [PRIVATE] TableHead for the Table component. The Table handlers rendering it
+ */
 TableHead.propTypes = {
+  /**
+   * An array of headers for the table. The Header can be a string or an object
+   * with options described on TableHeader component
+   */
   headers: PropTypes.arrayOf(RowPropType),
+  /**
+   * Enables/disables sticky columns on mobile
+   */
   rowHeaders: PropTypes.bool,
-  sortBy: PropTypes.func,
+  /**
+   * [PRIVATE] sortBy handler
+   */
+  onSortBy: PropTypes.func,
+  /**
+   * [PRIVATE] The current sortDirection
+   */
   sortDirection: PropTypes.oneOf([ASCENDING, DESCENDING]),
-  sortable: PropTypes.bool,
+  /**
+   * [PRIVATE] The current sorted row index
+   */
   sortedRow: PropTypes.number,
+  /**
+   * [PRIVATE] sortEnter handler
+   */
   onSortEnter: PropTypes.func,
+  /**
+   * [PRIVATE] sortLeave handler
+   */
   onSortLeave: PropTypes.func
 };
 
 TableHead.defaultProps = {
   headers: [],
-  rowHeaders: true,
-  sortBy: noop,
+  rowHeaders: false,
+  onSortBy: noop,
   sortDirection: null,
-  sortable: null,
   sortedRow: null,
   onSortEnter: null,
   onSortLeave: null

--- a/src/components/Table/components/TableHead/index.spec.js
+++ b/src/components/Table/components/TableHead/index.spec.js
@@ -1,0 +1,229 @@
+import React from 'react';
+
+import TableHead from '.';
+import { ASCENDING } from '../../constants';
+
+const fixtureHeaders = [{ children: 'Foo', sortable: true }, 'Bar', 'Baz'];
+
+describe('TableHead', () => {
+  describe('Style tests', () => {
+    it('should render with default styles', () => {
+      const actual = create(<TableHead headers={fixtureHeaders} />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with rowHeader styles', () => {
+      const actual = create(<TableHead rowHeader headers={fixtureHeaders} />);
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('rowHeaders', () => {
+    it('should add fixed to first TableHeader', () => {
+      const wrapper = shallow(
+        <TableHead rowHeaders headers={fixtureHeaders} />
+      );
+
+      expect(
+        wrapper
+          .find('TableHeader')
+          .at(0)
+          .props().fixed
+      ).toBeTruthy();
+    });
+
+    describe('presentational TableCell', () => {
+      it('should add it to the first header', () => {
+        const wrapper = shallow(
+          <TableHead rowHeaders headers={fixtureHeaders} />
+        );
+
+        expect(wrapper.find('TableCell').at(0).length).toBeTruthy();
+      });
+    });
+  });
+
+  describe('TableHeader onClick', () => {
+    describe('non sortable', () => {
+      it('should not dispatch the onSortBy handler', () => {
+        const headers = ['Foo'];
+        const mock = jest.fn();
+        const wrapper = shallow(
+          <TableHead onSortBy={mock} headers={headers} />
+        );
+
+        wrapper
+          .find('TableHeader')
+          .at(0)
+          .simulate('click');
+
+        expect(mock).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should dispatch the onSortBy handler', () => {
+      const headers = [{ children: 'Foo', sortable: true }];
+      const mock = jest.fn();
+      const wrapper = shallow(<TableHead onSortBy={mock} headers={headers} />);
+
+      wrapper
+        .find('TableHeader')
+        .at(0)
+        .simulate('click');
+
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+
+  describe('TableHeader onSortEnter', () => {
+    describe('non sortable', () => {
+      it('should not dispatch the onSortEnter handler', () => {
+        const headers = ['Foo'];
+        const mock = jest.fn();
+        const wrapper = shallow(
+          <TableHead onSortEnter={mock} headers={headers} />
+        );
+
+        wrapper
+          .find('TableHeader')
+          .at(0)
+          .simulate('mouseEnter');
+
+        expect(mock).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should dispatch the onSortEnter handler', () => {
+      const headers = [{ children: 'Foo', sortable: true }];
+      const mock = jest.fn();
+      const wrapper = shallow(
+        <TableHead onSortEnter={mock} headers={headers} />
+      );
+
+      wrapper
+        .find('TableHeader')
+        .at(0)
+        .simulate('mouseEnter');
+
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+
+  describe('TableHeader onSortLeave', () => {
+    describe('non sortable', () => {
+      it('should not dispatch the onSortLeave handler', () => {
+        const headers = ['Foo'];
+        const mock = jest.fn();
+        const wrapper = shallow(
+          <TableHead onSortLeave={mock} headers={headers} />
+        );
+
+        wrapper
+          .find('TableHeader')
+          .at(0)
+          .simulate('mouseLeave');
+
+        expect(mock).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should dispatch the onSortLeave handler', () => {
+      const headers = [{ children: 'Foo', sortable: true }];
+      const mock = jest.fn();
+      const wrapper = shallow(
+        <TableHead onSortLeave={mock} headers={headers} />
+      );
+
+      wrapper
+        .find('TableHeader')
+        .at(0)
+        .simulate('mouseLeave');
+
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+
+  describe('sortDirection', () => {
+    describe('sortedRow is the same as current and has sortDirection', () => {
+      it('should add sortDirection prop to TableHeader', () => {
+        const headers = ['Foo', 'Bar'];
+        const sortedRow = 1;
+        const sortDirection = ASCENDING;
+        const props = {
+          headers,
+          sortedRow,
+          sortDirection
+        };
+        const wrapper = shallow(<TableHead {...props} />);
+        const expected = ASCENDING;
+        const actual = wrapper
+          .find('TableHeader')
+          .at(1)
+          .props().sortDirection;
+
+        expect(actual).toBe(expected);
+      });
+    });
+
+    describe('no sortDirection', () => {
+      it('should not add sortDirection prop to TableHeader', () => {
+        const headers = ['Foo', 'Bar'];
+        const sortedRow = 1;
+        const wrapper = shallow(
+          <TableHead sortedRow={sortedRow} headers={headers} />
+        );
+
+        expect(
+          wrapper
+            .find('TableHeader')
+            .at(1)
+            .props().sortDirection
+        ).toBeFalsy();
+      });
+    });
+  });
+
+  describe('isSorted', () => {
+    describe('sortedRow is the same as current Header', () => {
+      it('should add isSorted prop to TableHeader', () => {
+        const headers = ['Foo', 'Bar'];
+        const sortedRow = 1;
+        const wrapper = shallow(
+          <TableHead sortedRow={sortedRow} headers={headers} />
+        );
+
+        expect(
+          wrapper
+            .find('TableHeader')
+            .at(1)
+            .props().isSorted
+        ).toBeTruthy();
+      });
+    });
+
+    it('should not add isSorted prop to TableHeader', () => {
+      const headers = ['Foo', 'Bar'];
+      const sortedRow = 1;
+      const wrapper = shallow(
+        <TableHead sortedRow={sortedRow} headers={headers} />
+      );
+
+      expect(
+        wrapper
+          .find('TableHeader')
+          .at(0)
+          .props().isSorted
+      ).toBeFalsy();
+    });
+  });
+
+  describe('Accessibility tests', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(
+        <TableHead rowHeader headers={fixtureHeaders} />
+      );
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
@@ -1,0 +1,335 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableHeader should render with active styles 1`] = `
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  background-color: #FAFBFC;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+}
+
+<th
+  aria-sort={null}
+  className="circuit-0 circuit-1"
+  scope="col"
+>
+  Foo
+</th>
+`;
+
+exports[`TableHeader should render with default styles 1`] = `
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+}
+
+<th
+  aria-sort={null}
+  className="circuit-0 circuit-1"
+  scope="col"
+>
+  Foo
+</th>
+`;
+
+exports[`TableHeader should render with row styles 1`] = `
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+}
+
+<th
+  aria-sort={null}
+  className="circuit-0 circuit-1"
+  scope="row"
+>
+  Foo
+</th>
+`;
+
+exports[`TableHeader should render with sortable styles 1`] = `
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+<th
+  aria-sort="none"
+  className="circuit-3 circuit-4"
+  scope="col"
+>
+  <button
+    className="circuit-0 circuit-1 circuit-2"
+    type="button"
+  >
+    <div>
+      arrow.svg
+    </div>
+    <div>
+      arrow.svg
+    </div>
+  </button>
+  Foo
+</th>
+`;
+
+exports[`TableHeader sortable + sorted should render with sortable + sorted ascending styles 1`] = `
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+.circuit-3 > button {
+  opacity: 1;
+}
+
+<th
+  aria-sort="ascending"
+  className="circuit-3 circuit-4"
+  scope="col"
+>
+  <button
+    className="circuit-0 circuit-1 circuit-2"
+    type="button"
+  >
+    <div>
+      arrow.svg
+    </div>
+  </button>
+  Foo
+</th>
+`;
+
+exports[`TableHeader sortable + sorted should render with sortable + sorted descending styles 1`] = `
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+.circuit-3 > button {
+  opacity: 1;
+}
+
+<th
+  aria-sort="descending"
+  className="circuit-3 circuit-4"
+  scope="col"
+>
+  <button
+    className="circuit-0 circuit-1 circuit-2"
+    type="button"
+  >
+    <div>
+      arrow.svg
+    </div>
+  </button>
+  Foo
+</th>
+`;

--- a/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableHeader should render with default styles 1`] = `
+exports[`TableHeader Style tests should render with default styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
@@ -25,7 +25,7 @@ exports[`TableHeader should render with default styles 1`] = `
 </th>
 `;
 
-exports[`TableHeader should render with hovered styles 1`] = `
+exports[`TableHeader Style tests should render with hovered styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
@@ -51,7 +51,7 @@ exports[`TableHeader should render with hovered styles 1`] = `
 </th>
 `;
 
-exports[`TableHeader should render with row styles 1`] = `
+exports[`TableHeader Style tests should render with row styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
@@ -71,7 +71,7 @@ exports[`TableHeader should render with row styles 1`] = `
 </th>
 `;
 
-exports[`TableHeader should render with sortable styles 1`] = `
+exports[`TableHeader Style tests should render with sortable styles 1`] = `
 .circuit-3 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
@@ -158,7 +158,7 @@ exports[`TableHeader should render with sortable styles 1`] = `
 </th>
 `;
 
-exports[`TableHeader sortable + sorted should render with sortable + sorted ascending styles 1`] = `
+exports[`TableHeader Style tests sortable + sorted should render with sortable + sorted ascending styles 1`] = `
 .circuit-1 {
   padding: 0;
   margin: 0;
@@ -246,7 +246,7 @@ exports[`TableHeader sortable + sorted should render with sortable + sorted asce
 </th>
 `;
 
-exports[`TableHeader sortable + sorted should render with sortable + sorted descending styles 1`] = `
+exports[`TableHeader Style tests sortable + sorted should render with sortable + sorted descending styles 1`] = `
 .circuit-1 {
   padding: 0;
   margin: 0;

--- a/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableHeader should render with active styles 1`] = `
+exports[`TableHeader should render with default styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
@@ -9,7 +9,6 @@ exports[`TableHeader should render with active styles 1`] = `
   -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
   transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
   white-space: nowrap;
-  background-color: #FAFBFC;
   color: #5C656F;
   font-size: 13px;
   font-weight: 700;
@@ -26,7 +25,7 @@ exports[`TableHeader should render with active styles 1`] = `
 </th>
 `;
 
-exports[`TableHeader should render with default styles 1`] = `
+exports[`TableHeader should render with hovered styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
@@ -35,6 +34,7 @@ exports[`TableHeader should render with default styles 1`] = `
   -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
   transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
   white-space: nowrap;
+  background-color: #FAFBFC;
   color: #5C656F;
   font-size: 13px;
   font-weight: 700;

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -10,11 +10,14 @@ import { ASCENDING, DESCENDING } from '../../constants';
 const COL = 'col';
 const ROW = 'row';
 
+const getAriaSort = (sortable, sortDirection) =>
+  sortable ? sortDirection || 'none' : null;
+
 const baseStyles = ({ theme, align }) => css`
   label: table-header;
   background-color: ${theme.colors.white};
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
-  padding: ${theme.spacings.mega};
+  padding: ${theme.spacings.giga};
   text-align: ${align};
   transition: background-color ${theme.transitions.default},
     color ${theme.transitions.default};
@@ -28,7 +31,7 @@ const colStyles = ({ theme, scope }) =>
     color: ${theme.colors.n700};
     font-size: ${theme.typography.text.kilo.fontSize};
     font-weight: ${theme.fontWeight.bold};
-    padding: ${theme.spacings.byte} ${theme.spacings.mega};
+    padding: ${theme.spacings.byte} ${theme.spacings.giga};
     vertical-align: middle;
   `;
 
@@ -51,12 +54,13 @@ const sortableStyles = ({ theme, sortable }) =>
     label: table-header--sortable;
     cursor: pointer;
     position: relative;
+    user-select: none;
 
     &:hover {
       background-color: ${theme.colors.n100};
       color: ${theme.colors.b500};
 
-      & > span {
+      & > button {
         opacity: 1;
       }
     }
@@ -66,7 +70,7 @@ const sortableActiveStyles = ({ sortable, isSorted }) =>
   sortable &&
   isSorted &&
   css`
-    & > span {
+    & > button {
       opacity: 1;
     }
   `;
@@ -88,7 +92,11 @@ const StyledHeader = styled.th`
 `;
 
 const TableHeader = ({ sortable, children, sortDirection, ...rest }) => (
-  <StyledHeader sortable {...rest}>
+  <StyledHeader
+    sortable={sortable}
+    aria-sort={getAriaSort(sortable, sortDirection)}
+    {...rest}
+  >
     {sortable && <SortArrow direction={sortDirection} />}
     {children}
   </StyledHeader>

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -1,0 +1,67 @@
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+
+import { directions } from '../../../../styles/constants';
+
+const COL = 'col';
+const ROW = 'row';
+
+const colStyles = ({ theme, scope }) =>
+  scope === COL &&
+  css`
+    label: table-header--col;
+    color: ${theme.colors.n700};
+    font-size: ${theme.typography.text.kilo.fontSize};
+    font-weight: ${theme.fontWeight.bold};
+    padding: ${theme.spacings.byte} ${theme.spacings.mega};
+  `;
+
+const rowStyles = ({ theme, scope }) =>
+  scope === ROW &&
+  css`
+    label: table-header--row;
+    ${theme.mq.untilMega`
+      background-color: ${theme.colors.white};
+      left: 0;
+      min-width: 145px;
+      position: absolute;
+      top: auto;
+      width: 145px;
+    `};
+  `;
+
+const baseStyles = ({ theme, align }) => css`
+  label: table-header;
+  border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
+  padding: ${theme.spacings.mega};
+  text-align: ${align};
+  white-space: nowrap;
+`;
+
+const TableHeader = styled.th`
+  ${baseStyles};
+  ${rowStyles};
+  ${colStyles};
+`;
+
+TableHeader.LEFT = directions.LEFT;
+TableHeader.RIGHT = directions.RIGHT;
+TableHeader.CENTER = directions.CENTER;
+TableHeader.COL = COL;
+TableHeader.ROW = ROW;
+
+TableHeader.propTypes = {
+  align: PropTypes.oneOf([
+    TableHeader.LEFT,
+    TableHeader.RIGHT,
+    TableHeader.CENTER
+  ]),
+  scope: PropTypes.string
+};
+
+TableHeader.defaultProps = {
+  align: TableHeader.LEFT,
+  scope: TableHeader.COL
+};
+
+export default TableHeader;

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -21,6 +21,13 @@ const baseStyles = ({ theme, align }) => css`
   white-space: nowrap;
 `;
 
+const hoveredStyles = ({ theme, isHovered }) =>
+  isHovered &&
+  css`
+    label: table-cell--hover;
+    background-color: ${theme.colors.n100};
+  `;
+
 const colStyles = ({ theme, scope }) =>
   scope === COL &&
   css`
@@ -72,22 +79,19 @@ const sortableActiveStyles = ({ sortable, isSorted }) =>
     }
   `;
 
-const activeStyles = ({ theme, isActive }) =>
-  isActive &&
-  css`
-    label: table-cell--hover;
-    background-color: ${theme.colors.n100};
-  `;
-
 const StyledHeader = styled.th`
   ${baseStyles};
-  ${activeStyles};
+  ${hoveredStyles};
   ${rowStyles};
   ${colStyles};
   ${sortableStyles};
   ${sortableActiveStyles};
 `;
 
+/**
+ * TableHeader component for the Table. You shouldn't import this component
+ * directly, the Table handles it
+ */
 const TableHeader = ({ sortable, children, sortDirection, ...rest }) => (
   <StyledHeader
     sortable={sortable}
@@ -106,17 +110,40 @@ TableHeader.COL = COL;
 TableHeader.ROW = ROW;
 
 TableHeader.propTypes = {
+  /**
+   * Aligns the content of the Header with text-align
+   */
   align: PropTypes.oneOf([
     TableHeader.LEFT,
     TableHeader.RIGHT,
     TableHeader.CENTER
   ]),
-  scope: PropTypes.string,
+  /**
+   * [PRIVATE] Adds ROL or COL styles based on the provided Scope.
+   * Handled internally
+   */
+  scope: PropTypes.oneOf([TableHeader.COL, TableHeader.ROW]),
+  /**
+   * [PRIVATE] Adds sticky style to the Header based on rowHeader definition.
+   * Handled internally
+   */
   fixed: PropTypes.bool,
+  /**
+   * Defines whether or not the Header is sortable
+   */
   sortable: PropTypes.bool,
-  isActive: PropTypes.bool,
+  /**
+   * [PRIVATE] Adds active style to the Header if it is currently hovered by
+   * sort.
+   * Handled internally
+   */
+  isHovered: PropTypes.bool,
   children: childrenPropType,
   sortDirection: PropTypes.oneOf([ASCENDING, DESCENDING]),
+  /**
+   * [PRIVATE] Adds sorted style to the Header if it is currently sorted
+   * Handled internally
+   */
   isSorted: PropTypes.bool
 };
 
@@ -125,7 +152,7 @@ TableHeader.defaultProps = {
   scope: TableHeader.COL,
   fixed: false,
   sortable: false,
-  isActive: false,
+  isHovered: false,
   children: null,
   sortDirection: null,
   isSorted: false

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -2,17 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
+import SortArrow from '../SortArrow';
 import { directions } from '../../../../styles/constants';
+import { childrenPropType } from '../../../../util/shared-prop-types';
+import { ASCENDING, DESCENDING } from '../../constants';
 
 const COL = 'col';
 const ROW = 'row';
 
 const baseStyles = ({ theme, align }) => css`
   label: table-header;
+  background-color: ${theme.colors.white};
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
   padding: ${theme.spacings.mega};
   text-align: ${align};
-  transition: background-color ${theme.transitions.default};
+  transition: background-color ${theme.transitions.default},
+    color ${theme.transitions.default};
   white-space: nowrap;
 `;
 
@@ -32,7 +37,6 @@ const rowStyles = ({ theme, fixed }) =>
   css`
     label: table-header--row;
     ${theme.mq.untilMega`
-      background-color: ${theme.colors.white};
       left: 0;
       top: auto;
       position: absolute;
@@ -46,9 +50,24 @@ const sortableStyles = ({ theme, sortable }) =>
   css`
     label: table-header--sortable;
     cursor: pointer;
+    position: relative;
 
     &:hover {
       background-color: ${theme.colors.n100};
+      color: ${theme.colors.b500};
+
+      & > span {
+        opacity: 1;
+      }
+    }
+  `;
+
+const sortableActiveStyles = ({ sortable, isSorted }) =>
+  sortable &&
+  isSorted &&
+  css`
+    & > span {
+      opacity: 1;
     }
   `;
 
@@ -61,13 +80,19 @@ const activeStyles = ({ theme, active }) =>
 
 const StyledHeader = styled.th`
   ${baseStyles};
+  ${activeStyles};
   ${rowStyles};
   ${colStyles};
   ${sortableStyles};
-  ${activeStyles};
+  ${sortableActiveStyles};
 `;
 
-const TableHeader = props => <StyledHeader {...props} />;
+const TableHeader = ({ sortable, children, sortDirection, ...rest }) => (
+  <StyledHeader sortable {...rest}>
+    {sortable && <SortArrow direction={sortDirection} />}
+    {children}
+  </StyledHeader>
+);
 
 TableHeader.LEFT = directions.LEFT;
 TableHeader.RIGHT = directions.RIGHT;
@@ -84,7 +109,10 @@ TableHeader.propTypes = {
   scope: PropTypes.string,
   fixed: PropTypes.bool,
   sortable: PropTypes.bool,
-  active: PropTypes.bool
+  active: PropTypes.bool,
+  children: childrenPropType,
+  sortDirection: PropTypes.oneOf([ASCENDING, DESCENDING]),
+  isSorted: PropTypes.bool
 };
 
 TableHeader.defaultProps = {
@@ -92,7 +120,10 @@ TableHeader.defaultProps = {
   scope: TableHeader.COL,
   fixed: false,
   sortable: false,
-  active: false
+  active: false,
+  children: null,
+  sortDirection: null,
+  isSorted: false
 };
 
 export default TableHeader;

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
@@ -6,17 +7,14 @@ import { directions } from '../../../../styles/constants';
 const COL = 'col';
 const ROW = 'row';
 
-const sortableStyles = ({ theme, sortable }) =>
-  sortable &&
-  css`
-    label: table-header--sortable;
-    cursor: pointer;
-    transition: background-color ${theme.transitions.default};
-
-    &:hover {
-      background-color: ${theme.colors.n100};
-    }
-  `;
+const baseStyles = ({ theme, align }) => css`
+  label: table-header;
+  border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
+  padding: ${theme.spacings.mega};
+  text-align: ${align};
+  transition: background-color ${theme.transitions.default};
+  white-space: nowrap;
+`;
 
 const colStyles = ({ theme, scope }) =>
   scope === COL &&
@@ -43,20 +41,33 @@ const rowStyles = ({ theme, fixed }) =>
     `};
   `;
 
-const baseStyles = ({ theme, align }) => css`
-  label: table-header;
-  border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
-  padding: ${theme.spacings.mega};
-  text-align: ${align};
-  white-space: nowrap;
-`;
+const sortableStyles = ({ theme, sortable }) =>
+  sortable &&
+  css`
+    label: table-header--sortable;
+    cursor: pointer;
 
-const TableHeader = styled.th`
+    &:hover {
+      background-color: ${theme.colors.n100};
+    }
+  `;
+
+const activeStyles = ({ theme, active }) =>
+  active &&
+  css`
+    label: table-cell--hover;
+    background-color: ${theme.colors.n100};
+  `;
+
+const StyledHeader = styled.th`
   ${baseStyles};
   ${rowStyles};
   ${colStyles};
   ${sortableStyles};
+  ${activeStyles};
 `;
+
+const TableHeader = props => <StyledHeader {...props} />;
 
 TableHeader.LEFT = directions.LEFT;
 TableHeader.RIGHT = directions.RIGHT;
@@ -72,14 +83,16 @@ TableHeader.propTypes = {
   ]),
   scope: PropTypes.string,
   fixed: PropTypes.bool,
-  sortable: PropTypes.bool
+  sortable: PropTypes.bool,
+  active: PropTypes.bool
 };
 
 TableHeader.defaultProps = {
   align: TableHeader.LEFT,
   scope: TableHeader.COL,
   fixed: false,
-  sortable: false
+  sortable: false,
+  active: false
 };
 
 export default TableHeader;

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -6,6 +6,18 @@ import { directions } from '../../../../styles/constants';
 const COL = 'col';
 const ROW = 'row';
 
+const sortableStyles = ({ theme, sortable }) =>
+  sortable &&
+  css`
+    label: table-header--sortable;
+    cursor: pointer;
+    transition: background-color ${theme.transitions.default};
+
+    &:hover {
+      background-color: ${theme.colors.n100};
+    }
+  `;
+
 const colStyles = ({ theme, scope }) =>
   scope === COL &&
   css`
@@ -43,6 +55,7 @@ const TableHeader = styled.th`
   ${baseStyles};
   ${rowStyles};
   ${colStyles};
+  ${sortableStyles};
 `;
 
 TableHeader.LEFT = directions.LEFT;
@@ -58,13 +71,15 @@ TableHeader.propTypes = {
     TableHeader.CENTER
   ]),
   scope: PropTypes.string,
-  fixed: PropTypes.bool
+  fixed: PropTypes.bool,
+  sortable: PropTypes.bool
 };
 
 TableHeader.defaultProps = {
   align: TableHeader.LEFT,
   scope: TableHeader.COL,
-  fixed: false
+  fixed: false,
+  sortable: false
 };
 
 export default TableHeader;

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -5,10 +5,7 @@ import styled, { css } from 'react-emotion';
 import SortArrow from '../SortArrow';
 import { directions } from '../../../../styles/constants';
 import { childrenPropType } from '../../../../util/shared-prop-types';
-import { ASCENDING, DESCENDING } from '../../constants';
-
-const COL = 'col';
-const ROW = 'row';
+import { ASCENDING, DESCENDING, COL, ROW } from '../../constants';
 
 const getAriaSort = (sortable, sortDirection) =>
   sortable ? sortDirection || 'none' : null;
@@ -75,8 +72,8 @@ const sortableActiveStyles = ({ sortable, isSorted }) =>
     }
   `;
 
-const activeStyles = ({ theme, active }) =>
-  active &&
+const activeStyles = ({ theme, isActive }) =>
+  isActive &&
   css`
     label: table-cell--hover;
     background-color: ${theme.colors.n100};
@@ -117,7 +114,7 @@ TableHeader.propTypes = {
   scope: PropTypes.string,
   fixed: PropTypes.bool,
   sortable: PropTypes.bool,
-  active: PropTypes.bool,
+  isActive: PropTypes.bool,
   children: childrenPropType,
   sortDirection: PropTypes.oneOf([ASCENDING, DESCENDING]),
   isSorted: PropTypes.bool
@@ -128,7 +125,7 @@ TableHeader.defaultProps = {
   scope: TableHeader.COL,
   fixed: false,
   sortable: false,
-  active: false,
+  isActive: false,
   children: null,
   sortDirection: null,
   isSorted: false

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -14,19 +14,20 @@ const colStyles = ({ theme, scope }) =>
     font-size: ${theme.typography.text.kilo.fontSize};
     font-weight: ${theme.fontWeight.bold};
     padding: ${theme.spacings.byte} ${theme.spacings.mega};
+    vertical-align: middle;
   `;
 
-const rowStyles = ({ theme, scope }) =>
-  scope === ROW &&
+const rowStyles = ({ theme, fixed }) =>
+  fixed &&
   css`
     label: table-header--row;
     ${theme.mq.untilMega`
       background-color: ${theme.colors.white};
       left: 0;
-      min-width: 145px;
-      position: absolute;
       top: auto;
+      position: absolute;
       width: 145px;
+      white-space: unset;
     `};
   `;
 
@@ -56,12 +57,14 @@ TableHeader.propTypes = {
     TableHeader.RIGHT,
     TableHeader.CENTER
   ]),
-  scope: PropTypes.string
+  scope: PropTypes.string,
+  fixed: PropTypes.bool
 };
 
 TableHeader.defaultProps = {
   align: TableHeader.LEFT,
-  scope: TableHeader.COL
+  scope: TableHeader.COL,
+  fixed: false
 };
 
 export default TableHeader;

--- a/src/components/Table/components/TableHeader/index.spec.js
+++ b/src/components/Table/components/TableHeader/index.spec.js
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import TableHeader from '.';
+import { ASCENDING, DESCENDING } from '../../constants';
+
+const children = 'Foo';
+
+describe('TableHeader', () => {
+  /**
+   * Style tests.
+   */
+  beforeEach(jest.clearAllMocks);
+
+  it('should render with default styles', () => {
+    const actual = create(<TableHeader>{children}</TableHeader>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should render with row styles', () => {
+    const actual = create(
+      <TableHeader scope={TableHeader.ROW}>{children}</TableHeader>
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should render with sortable styles', () => {
+    const actual = create(<TableHeader sortable>{children}</TableHeader>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should render with active styles', () => {
+    const actual = create(<TableHeader isActive>{children}</TableHeader>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  describe('sortable + sorted', () => {
+    it('should render with sortable + sorted ascending styles', () => {
+      const actual = create(
+        <TableHeader sortable isSorted sortDirection={ASCENDING}>
+          {children}
+        </TableHeader>
+      );
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with sortable + sorted descending styles', () => {
+      const actual = create(
+        <TableHeader sortable isSorted sortDirection={DESCENDING}>
+          {children}
+        </TableHeader>
+      );
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  /**
+   * Accessibility tests.
+   */
+  it('should meet accessibility guidelines', async () => {
+    const wrapper = renderToHtml(
+      <TableHeader sortable>{children}</TableHeader>
+    );
+    const actual = await axe(wrapper);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/src/components/Table/components/TableHeader/index.spec.js
+++ b/src/components/Table/components/TableHeader/index.spec.js
@@ -6,59 +6,57 @@ import { ASCENDING, DESCENDING } from '../../constants';
 const children = 'Foo';
 
 describe('TableHeader', () => {
-  /**
-   * Style tests.
-   */
-  it('should render with default styles', () => {
-    const actual = create(<TableHeader>{children}</TableHeader>);
-    expect(actual).toMatchSnapshot();
-  });
+  describe('Style tests', () => {
+    it('should render with default styles', () => {
+      const actual = create(<TableHeader>{children}</TableHeader>);
+      expect(actual).toMatchSnapshot();
+    });
 
-  it('should render with row styles', () => {
-    const actual = create(
-      <TableHeader scope={TableHeader.ROW}>{children}</TableHeader>
-    );
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with sortable styles', () => {
-    const actual = create(<TableHeader sortable>{children}</TableHeader>);
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with hovered styles', () => {
-    const actual = create(<TableHeader isHovered>{children}</TableHeader>);
-    expect(actual).toMatchSnapshot();
-  });
-
-  describe('sortable + sorted', () => {
-    it('should render with sortable + sorted ascending styles', () => {
+    it('should render with row styles', () => {
       const actual = create(
-        <TableHeader sortable isSorted sortDirection={ASCENDING}>
-          {children}
-        </TableHeader>
+        <TableHeader scope={TableHeader.ROW}>{children}</TableHeader>
       );
       expect(actual).toMatchSnapshot();
     });
 
-    it('should render with sortable + sorted descending styles', () => {
-      const actual = create(
-        <TableHeader sortable isSorted sortDirection={DESCENDING}>
-          {children}
-        </TableHeader>
-      );
+    it('should render with sortable styles', () => {
+      const actual = create(<TableHeader sortable>{children}</TableHeader>);
       expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with hovered styles', () => {
+      const actual = create(<TableHeader isHovered>{children}</TableHeader>);
+      expect(actual).toMatchSnapshot();
+    });
+
+    describe('sortable + sorted', () => {
+      it('should render with sortable + sorted ascending styles', () => {
+        const actual = create(
+          <TableHeader sortable isSorted sortDirection={ASCENDING}>
+            {children}
+          </TableHeader>
+        );
+        expect(actual).toMatchSnapshot();
+      });
+
+      it('should render with sortable + sorted descending styles', () => {
+        const actual = create(
+          <TableHeader sortable isSorted sortDirection={DESCENDING}>
+            {children}
+          </TableHeader>
+        );
+        expect(actual).toMatchSnapshot();
+      });
     });
   });
 
-  /**
-   * Accessibility tests.
-   */
-  it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(
-      <TableHeader sortable>{children}</TableHeader>
-    );
-    const actual = await axe(wrapper);
-    expect(actual).toHaveNoViolations();
+  describe('Accessibility tests', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(
+        <TableHeader sortable>{children}</TableHeader>
+      );
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
   });
 });

--- a/src/components/Table/components/TableHeader/index.spec.js
+++ b/src/components/Table/components/TableHeader/index.spec.js
@@ -28,8 +28,8 @@ describe('TableHeader', () => {
     expect(actual).toMatchSnapshot();
   });
 
-  it('should render with active styles', () => {
-    const actual = create(<TableHeader isActive>{children}</TableHeader>);
+  it('should render with hovered styles', () => {
+    const actual = create(<TableHeader isHovered>{children}</TableHeader>);
     expect(actual).toMatchSnapshot();
   });
 

--- a/src/components/Table/components/TableHeader/index.spec.js
+++ b/src/components/Table/components/TableHeader/index.spec.js
@@ -9,8 +9,6 @@ describe('TableHeader', () => {
   /**
    * Style tests.
    */
-  beforeEach(jest.clearAllMocks);
-
   it('should render with default styles', () => {
     const actual = create(<TableHeader>{children}</TableHeader>);
     expect(actual).toMatchSnapshot();

--- a/src/components/Table/components/TableHeader/index.story.js
+++ b/src/components/Table/components/TableHeader/index.story.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { boolean, text, select } from '@storybook/addon-knobs/react';
+
+import withTests from '../../../../util/withTests';
+import TableHeader from '.';
+
+const options = {
+  [TableHeader.LEFT]: TableHeader.LEFT,
+  [TableHeader.RIGHT]: TableHeader.RIGHT,
+  [TableHeader.CENTER]: TableHeader.CENTER
+};
+
+storiesOf('TableHeader', module)
+  .addDecorator(withTests('TableHeader'))
+  .add(
+    'Table',
+    withInfo()(() => (
+      <TableHeader
+        style={{ width: '300px', alignSelf: 'center' }}
+        align={select('Align', options)}
+        sortable={boolean('Sortable', false)}
+      >
+        {text('Content', 'Header')}
+      </TableHeader>
+    ))
+  );

--- a/src/components/Table/components/TableRow/index.js
+++ b/src/components/Table/components/TableRow/index.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 const baseStyles = () => css`
@@ -14,13 +13,5 @@ const baseStyles = () => css`
 `;
 
 const TableRow = styled.tr(baseStyles);
-
-TableRow.propTypes = {
-  header: PropTypes.bool
-};
-
-TableRow.defaultProps = {
-  header: false
-};
 
 export default TableRow;

--- a/src/components/Table/components/TableRow/index.js
+++ b/src/components/Table/components/TableRow/index.js
@@ -1,21 +1,11 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
-const rowStyles = ({ theme, header }) =>
-  !header &&
-  css`
-    label: table-row--header;
-    &:hover {
-      background-color: ${theme.colors.n100};
-    }
-  `;
-
-const baseStyles = ({ theme }) => css`
+const baseStyles = () => css`
   label: table-row;
-  position: relative;
-  transition: background-color ${theme.transitions.default};
+  vertical-align: middle;
 
-  &:last-child {
+  tbody & &:last-child {
     th,
     td {
       border-bottom: none;
@@ -23,10 +13,7 @@ const baseStyles = ({ theme }) => css`
   }
 `;
 
-const TableRow = styled.tr`
-  ${baseStyles};
-  ${rowStyles};
-`;
+const TableRow = styled.tr(baseStyles);
 
 TableRow.propTypes = {
   header: PropTypes.bool

--- a/src/components/Table/components/TableRow/index.js
+++ b/src/components/Table/components/TableRow/index.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+
+const rowStyles = ({ theme, header }) =>
+  !header &&
+  css`
+    label: table-row--header;
+    &:hover {
+      background-color: ${theme.colors.n100};
+    }
+  `;
+
+const baseStyles = ({ theme }) => css`
+  label: table-row;
+  position: relative;
+  transition: background-color ${theme.transitions.default};
+
+  &:last-child {
+    th,
+    td {
+      border-bottom: none;
+    }
+  }
+`;
+
+const TableRow = styled.tr`
+  ${baseStyles};
+  ${rowStyles};
+`;
+
+TableRow.propTypes = {
+  header: PropTypes.bool
+};
+
+TableRow.defaultProps = {
+  header: false
+};
+
+export default TableRow;

--- a/src/components/Table/constants.js
+++ b/src/components/Table/constants.js
@@ -1,0 +1,2 @@
+export const ASCENDING = 'ascending';
+export const DESCENDING = 'descending';

--- a/src/components/Table/constants.js
+++ b/src/components/Table/constants.js
@@ -1,2 +1,7 @@
 export const ASCENDING = 'ascending';
 export const DESCENDING = 'descending';
+export const COL = 'col';
+export const ROW = 'row';
+export const TR_KEY_PREFIX = 'table-row';
+export const TD_KEY_PREFIX = 'table-cell';
+export const TH_KEY_PREFIX = 'table-header';

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -1,0 +1,3 @@
+import Table from './Table';
+
+export default Table;

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -8,6 +8,8 @@ export const mapProps = props =>
 
 export const getChildren = props => mapProps(props).children;
 
+export const getSortByValue = props => props.sortByValue || getChildren(props);
+
 export const getSortDirection = (isActive, currentSort) => {
   if (!currentSort || !isActive) {
     return ASCENDING;
@@ -17,10 +19,10 @@ export const getSortDirection = (isActive, currentSort) => {
 };
 
 export const ascendingSort = curry(
-  (i, a, b) => getChildren(a[i]) > getChildren(b[i])
+  (i, a, b) => getSortByValue(a[i]) > getSortByValue(b[i])
 );
 export const descendingSort = curry(
-  (i, a, b) => getChildren(a[i]) < getChildren(b[i])
+  (i, a, b) => getSortByValue(a[i]) < getSortByValue(b[i])
 );
 
 export const RowPropType = PropTypes.oneOfType([

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import { curry, isString } from 'lodash/fp';
+import { ASCENDING, DESCENDING } from './constants';
+import { childrenPropType } from '../../util/shared-prop-types';
+
+export const mapProps = props =>
+  isString(props) ? { children: props } : props;
+
+export const getChildren = props => mapProps(props).children;
+
+export const getSortDirection = (isActive, currentSort) => {
+  if (!currentSort || !isActive) {
+    return ASCENDING;
+  }
+
+  return currentSort === ASCENDING ? DESCENDING : ASCENDING;
+};
+
+export const ascendingSort = curry(
+  (i, a, b) => getChildren(a[i]) > getChildren(b[i])
+);
+export const descendingSort = curry(
+  (i, a, b) => getChildren(a[i]) < getChildren(b[i])
+);
+
+export const RowPropType = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.shape({
+    children: childrenPropType,
+    align: PropTypes.string
+  })
+]);

--- a/src/components/Table/utils.spec.js
+++ b/src/components/Table/utils.spec.js
@@ -1,0 +1,145 @@
+import * as utils from './utils';
+import { ASCENDING, DESCENDING } from './constants';
+
+describe('Table utils', () => {
+  describe('mapProps()', () => {
+    describe('isString', () => {
+      it('should map the string to children key', () => {
+        const props = 'Foo';
+        const expected = { children: props };
+        const actual = utils.mapProps(props);
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    it('should forward the props object', () => {
+      const props = { children: 'Foo' };
+      const expected = props;
+      const actual = utils.mapProps(props);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('getChildren()', () => {
+    describe('isString', () => {
+      it('should return it', () => {
+        const props = 'Foo';
+        const expected = props;
+        const actual = utils.getChildren(props);
+
+        expect(actual).toBe(expected);
+      });
+    });
+
+    it('should return the children prop', () => {
+      const props = { children: 'Foo' };
+      const expected = 'Foo';
+      const actual = utils.getChildren(props);
+
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('getSortByValue()', () => {
+    describe('no sortByValue', () => {
+      it('should return the children', () => {
+        const props = 'Foo';
+        const expected = props;
+        const actual = utils.getSortByValue(props);
+
+        expect(actual).toBe(expected);
+      });
+    });
+
+    it('should return the sortByValue', () => {
+      const props = { sortByValue: 'Foo' };
+      const expected = props.sortByValue;
+      const actual = utils.getSortByValue(props);
+
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('getSortDirection()', () => {
+    describe('sort not active', () => {
+      it('should return ASCENDING', () => {
+        const expected = ASCENDING;
+        const isActive = false;
+        const actual = utils.getSortDirection(isActive);
+
+        expect(actual).toBe(expected);
+      });
+    });
+
+    describe('no currentSort', () => {
+      it('should return ASCENDING', () => {
+        const expected = ASCENDING;
+        const isActive = true;
+        const actual = utils.getSortDirection(isActive);
+
+        expect(actual).toBe(expected);
+      });
+    });
+
+    describe('ASCENDING', () => {
+      it('should return DESCENDING', () => {
+        const currentSort = ASCENDING;
+        const isActive = true;
+        const expected = DESCENDING;
+        const actual = utils.getSortDirection(isActive, currentSort);
+
+        expect(actual).toBe(expected);
+      });
+    });
+
+    describe('DESCENDING', () => {
+      it('should return ASCENDING', () => {
+        const currentSort = DESCENDING;
+        const isActive = true;
+        const expected = ASCENDING;
+        const actual = utils.getSortDirection(isActive, currentSort);
+
+        expect(actual).toBe(expected);
+      });
+    });
+
+    describe('unknown direction', () => {
+      it('should return ASCENDING', () => {
+        const currentSort = 'Foo';
+        const isActive = true;
+        const expected = ASCENDING;
+        const actual = utils.getSortDirection(isActive, currentSort);
+
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('ascendingSort', () => {
+    it('should sort the array by sortByValue/children on ascending order', () => {
+      const index = 0;
+      const a = ['Foo'];
+      const b = ['Bar'];
+      const arr = [a, b];
+      const expected = [b, a];
+      const actual = [...arr].sort(utils.ascendingSort(index));
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('descendingSort', () => {
+    it('should sort the array by sortByValue/children on descending order', () => {
+      const index = 0;
+      const a = ['Bar'];
+      const b = ['Foo'];
+      const arr = [a, b];
+      const expected = [b, a];
+      const actual = [...arr].sort(utils.descendingSort(index));
+
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/src/themes/default.js
+++ b/src/themes/default.js
@@ -211,6 +211,7 @@ const breakpoints = {
   kilo: 480,
   kiloToMega: '(min-width: 480px) and (max-width: 767px)',
   mega: 768,
+  untilMega: '(max-width: 767px)',
   megaToGiga: '(min-width: 768px) and (max-width: 959px)',
   giga: 960,
   gigaToTera: '(min-width: 960px) and (max-width: 1279px)',


### PR DESCRIPTION
Related to: https://sumupteam.atlassian.net/browse/TOOL-56

TODO: 

- [x] Fix table keys in general (tr, td, th) [Our linter does not allow us to use index as part of the key]
- [x] Add specs
- [x] Add stories/docs
- [x] Discuss the provided API
- [ ] Test on IE (For some reason browserstack isn't opening storybook locally, maybe some fancy js)

Nice GIF: 

![image](https://media.giphy.com/media/37R8VnBliNcLUdUGZR/giphy.gif)

The API:

The `Table` component accepts the following props:

```
{
  headers: [],
  rows: [],
  rowHeaders: true,
  onSortBy: null
}
```

`headers` populates the table headers, while `rows` populates the rows, something like:

```
[
  'Name',
  'Created at',
  'Permissions',
  'Status'
];
```

`rowHeaders` enables the mobile sticky rows:
![image](https://user-images.githubusercontent.com/2780941/40063846-821538ee-585e-11e8-8c60-c20e876683d1.png)

`onSortBy` overrides the defaultSortBy, the signature is `(index, nextDirection, currentRows) => nextRows`, and it should return an array of rows

The `headers/rows` item can be passed also as an object, in order for more complex use cases.

`header`:
```
{
  align: PropTypes.oneOf([
    TableHeader.LEFT,
    TableHeader.RIGHT,
    TableHeader.CENTER
  ]), // text-align
  sortable: PropTypes.bool, // enable/disables sort on specific header
  children: childrenPropType // content to be rendered, can be anything
};
```

and `cell` (item from row):
```
{
  align: PropTypes.oneOf([TableCell.LEFT, TableCell.RIGHT, TableCell.CENTER]),
  children: childrenPropType,
  sortByValue: any // content to be used on sortBy function instead of children.  This is useful when you pass down components or only presentational values, but need something else to use by the sort. (Such as showing dates but wanting to sortBy the timestamp)
}
```

