### PR TITLE
Enable italic Text

### DIFF
--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -38,7 +38,7 @@ const HeadingElement = styled(HtmlElement)`
  * different HTML tags.
  */
 const Heading = props => (
-  <HeadingElement {...props} blacklist={{ noMargin: true }} />
+  <HeadingElement {...props} blacklist={{ size: true, noMargin: true }} />
 );
 
 Heading.KILO = KILO;

--- a/src/components/Heading/__snapshots__/Heading.spec.js.snap
+++ b/src/components/Heading/__snapshots__/Heading.spec.js.snap
@@ -10,7 +10,6 @@ exports[`Heading should render as h1 element, when passed "h1" for the element p
 
 <h1
   className="circuit-0 circuit-1"
-  size="peta"
 >
   H1 heading
 </h1>
@@ -26,7 +25,6 @@ exports[`Heading should render as h2 element, when passed "h2" for the element p
 
 <h2
   className="circuit-0 circuit-1"
-  size="peta"
 >
   H2 heading
 </h2>
@@ -42,7 +40,6 @@ exports[`Heading should render as h3 element, when passed "h3" for the element p
 
 <h3
   className="circuit-0 circuit-1"
-  size="peta"
 >
   H3 heading
 </h3>
@@ -58,7 +55,6 @@ exports[`Heading should render as h4 element, when passed "h4" for the element p
 
 <h4
   className="circuit-0 circuit-1"
-  size="peta"
 >
   H4 heading
 </h4>
@@ -74,7 +70,6 @@ exports[`Heading should render as h5 element, when passed "h5" for the element p
 
 <h5
   className="circuit-0 circuit-1"
-  size="peta"
 >
   H5 heading
 </h5>
@@ -90,7 +85,6 @@ exports[`Heading should render as h6 element, when passed "h6" for the element p
 
 <h6
   className="circuit-0 circuit-1"
-  size="peta"
 >
   H6 heading
 </h6>
@@ -107,7 +101,6 @@ exports[`Heading should render with no margin styles when passed the noMargin pr
 
 <h2
   className="circuit-0 circuit-1"
-  size="peta"
 />
 `;
 
@@ -121,7 +114,6 @@ exports[`Heading should render with size exa, when passed "exa" for the size pro
 
 <h2
   className="circuit-0 circuit-1"
-  size="exa"
 >
   exa heading
 </h2>
@@ -137,7 +129,6 @@ exports[`Heading should render with size giga, when passed "giga" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  size="giga"
 >
   giga heading
 </h2>
@@ -153,7 +144,6 @@ exports[`Heading should render with size kilo, when passed "kilo" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  size="kilo"
 >
   kilo heading
 </h2>
@@ -169,7 +159,6 @@ exports[`Heading should render with size mega, when passed "mega" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  size="mega"
 >
   mega heading
 </h2>
@@ -185,7 +174,6 @@ exports[`Heading should render with size peta, when passed "peta" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  size="peta"
 >
   peta heading
 </h2>
@@ -201,7 +189,6 @@ exports[`Heading should render with size tera, when passed "tera" for the size p
 
 <h2
   className="circuit-0 circuit-1"
-  size="tera"
 >
   tera heading
 </h2>
@@ -217,7 +204,6 @@ exports[`Heading should render with size zetta, when passed "zetta" for the size
 
 <h2
   className="circuit-0 circuit-1"
-  size="zetta"
 >
   zetta heading
 </h2>

--- a/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -31,8 +31,6 @@ exports[`Markdown should override HTML tags with React components 1`] = `
   </h2>
   <p
     className="circuit-0 circuit-1"
-    italic={false}
-    size="mega"
   >
     Lorem markdownum vultusque eligit significent sinistro, et virgis, inter!
 Rapuere Apollineam equas coloni urbis conata, 
@@ -52,8 +50,6 @@ et magnis prorumpit flere? Dura quantum.
   </h3>
   <p
     className="circuit-0 circuit-1"
-    italic={false}
-    size="mega"
   >
     Mediis monstravit inmunis Troes non leonis 
     <strong
@@ -78,8 +74,6 @@ praecordiaque velut totosque norant alipedi candida electae est vestis, posse.
   >
     <p
       className="circuit-0 circuit-1"
-      italic={false}
-      size="mega"
     >
       Adstat Procnes et, in tempora Maenalon moles in nocte relicta, membra nec
 sudore nymphas robur! Adduxit sua equus Cadmeida 
@@ -118,8 +112,6 @@ terraeque gratus quaque, liquidumque quod: magnum mixta;
   </h3>
   <p
     className="circuit-0 circuit-1"
-    italic={false}
-    size="mega"
   >
     Mundus pugno, geniti sic muros Notum tu ad motis; nobis mihi tangi dextra?
 
@@ -153,8 +145,6 @@ teneo
   </h3>
   <p
     className="circuit-0 circuit-1"
-    italic={false}
-    size="mega"
   >
     Conceperat depositae si manibus utiliter resonare vitat ima mortis ecce. Huic
 leni agat pro! Fuit relinque.
@@ -187,8 +177,6 @@ leni agat pro! Fuit relinque.
   </h2>
   <p
     className="circuit-0 circuit-1"
-    italic={false}
-    size="mega"
   >
     <img
       alt="A random cute puppy"
@@ -199,8 +187,6 @@ leni agat pro! Fuit relinque.
   </p>
   <p
     className="circuit-0 circuit-1"
-    italic={false}
-    size="mega"
   >
     Parte quam aequore, nebulas demisere. Iurgia venit finxit nec manibus tamen
 cultus coniunx adituque.

--- a/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -31,6 +31,7 @@ exports[`Markdown should override HTML tags with React components 1`] = `
   </h2>
   <p
     className="circuit-0 circuit-1"
+    italic={false}
     size="mega"
   >
     Lorem markdownum vultusque eligit significent sinistro, et virgis, inter!
@@ -51,6 +52,7 @@ et magnis prorumpit flere? Dura quantum.
   </h3>
   <p
     className="circuit-0 circuit-1"
+    italic={false}
     size="mega"
   >
     Mediis monstravit inmunis Troes non leonis 
@@ -76,6 +78,7 @@ praecordiaque velut totosque norant alipedi candida electae est vestis, posse.
   >
     <p
       className="circuit-0 circuit-1"
+      italic={false}
       size="mega"
     >
       Adstat Procnes et, in tempora Maenalon moles in nocte relicta, membra nec
@@ -115,6 +118,7 @@ terraeque gratus quaque, liquidumque quod: magnum mixta;
   </h3>
   <p
     className="circuit-0 circuit-1"
+    italic={false}
     size="mega"
   >
     Mundus pugno, geniti sic muros Notum tu ad motis; nobis mihi tangi dextra?
@@ -149,6 +153,7 @@ teneo
   </h3>
   <p
     className="circuit-0 circuit-1"
+    italic={false}
     size="mega"
   >
     Conceperat depositae si manibus utiliter resonare vitat ima mortis ecce. Huic
@@ -182,6 +187,7 @@ leni agat pro! Fuit relinque.
   </h2>
   <p
     className="circuit-0 circuit-1"
+    italic={false}
     size="mega"
   >
     <img
@@ -193,6 +199,7 @@ leni agat pro! Fuit relinque.
   </p>
   <p
     className="circuit-0 circuit-1"
+    italic={false}
     size="mega"
   >
     Parte quam aequore, nebulas demisere. Iurgia venit finxit nec manibus tamen

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -27,6 +27,13 @@ const boldStyles = ({ theme, bold }) =>
     font-weight: ${theme.fontWeight.bold};
   `;
 
+const italicStyles = ({ italic }) =>
+  italic &&
+  css`
+    label: text--italic;
+    font-style: italic;
+  `;
+
 const marginStyles = ({ noMargin }) =>
   noMargin &&
   css`
@@ -36,7 +43,7 @@ const marginStyles = ({ noMargin }) =>
 
 const TextElement = styled(
   HtmlElement
-)`${baseStyles} ${sizeStyles} ${marginStyles} ${boldStyles}`;
+)`${baseStyles} ${sizeStyles} ${marginStyles} ${boldStyles} ${italicStyles}`;
 
 /**
  * The Text component is used for long-form text. Typically with
@@ -73,6 +80,10 @@ Text.propTypes = {
    */
   bold: PropTypes.bool,
   /**
+   * Bolds the text.
+   */
+  italic: PropTypes.bool,
+  /**
    * The HTML element to render.
    */
   element: PropTypes.string
@@ -84,6 +95,7 @@ Text.defaultProps = {
   className: '',
   noMargin: false,
   bold: false,
+  italic: false,
   children: null
 };
 

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -51,7 +51,10 @@ const TextElement = styled(
  * using different HTML tags.
  */
 const Text = props => (
-  <TextElement {...props} blacklist={{ bold: true, noMargin: true }} />
+  <TextElement
+    {...props}
+    blacklist={{ size: true, bold: true, italic: true, noMargin: true }}
+  />
 );
 
 Text.KILO = KILO;

--- a/src/components/Text/Text.spec.js
+++ b/src/components/Text/Text.spec.js
@@ -36,6 +36,11 @@ describe('Text', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render italic text when passed the italic prop', () => {
+    const actual = create(<Text italic />);
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Accessibility tests.
    */

--- a/src/components/Text/Text.story.js
+++ b/src/components/Text/Text.story.js
@@ -8,7 +8,7 @@ import withTests from '../../util/withTests';
 import Text from '.';
 
 const elements = ['p', 'article', 'div', 'span', 'strong', 'em'];
-const sizes = [Text.GIGA, Text.MEGA, Text.KILO];
+const sizes = [Text.KILO, Text.MEGA, Text.GIGA];
 
 // eslint-disable-next-line max-len
 const content = `An electronic circuit is composed of individual electronic components, such as resistors, transistors, capacitors, inductors and diodes, connected by conductive wires or traces through which electric current can flow.`;
@@ -20,8 +20,8 @@ storiesOf(`${GROUPS.TYPOGRAPHY}|Text`, module)
     withInfo()(() => (
       <div style={{ width: '66%', margin: '0 auto' }}>
         <Text
-          element={select('Element', elements, elements.Paragraph)}
-          size={select('Size', sizes, sizes.Kilo)}
+          element={select('Element', elements, elements[0])}
+          size={select('Size', sizes, sizes[0])}
           noMargin={boolean('No margin')}
           bold={boolean('Bold')}
           italic={boolean('Italic')}

--- a/src/components/Text/Text.story.js
+++ b/src/components/Text/Text.story.js
@@ -7,7 +7,7 @@ import { GROUPS } from '../../../.storybook/hierarchySeparators';
 import withTests from '../../util/withTests';
 import Text from '.';
 
-const elements = ['p', 'article', 'div'];
+const elements = ['p', 'article', 'div', 'span', 'strong', 'em'];
 const sizes = [Text.GIGA, Text.MEGA, Text.KILO];
 
 // eslint-disable-next-line max-len

--- a/src/components/Text/Text.story.js
+++ b/src/components/Text/Text.story.js
@@ -1,42 +1,33 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { select, boolean } from '@storybook/addon-knobs';
 import { GROUPS } from '../../../.storybook/hierarchySeparators';
 
 import withTests from '../../util/withTests';
 import Text from '.';
 
+const elements = ['p', 'article', 'div'];
+const sizes = [Text.GIGA, Text.MEGA, Text.KILO];
+
+// eslint-disable-next-line max-len
+const content = `An electronic circuit is composed of individual electronic components, such as resistors, transistors, capacitors, inductors and diodes, connected by conductive wires or traces through which electric current can flow.`;
+
 storiesOf(`${GROUPS.TYPOGRAPHY}|Text`, module)
   .addDecorator(withTests('Text'))
   .add(
-    'Giga Text with p',
+    'Default Text',
     withInfo()(() => (
-      <Text element="p" size={Text.GIGA}>
-        This is a giga Text with a p element
-      </Text>
-    ))
-  )
-  .add(
-    'Mega Text with article',
-    withInfo()(() => (
-      <Text element="article" size={Text.MEGA}>
-        This is an mega Text with an article element
-      </Text>
-    ))
-  )
-  .add(
-    'Kilo Text with div',
-    withInfo()(() => (
-      <Text element="div" size={Text.KILO}>
-        This is a kilo Text with a div element
-      </Text>
-    ))
-  )
-  .add(
-    'Bold Text',
-    withInfo()(() => (
-      <Text bold size={Text.KILO}>
-        This is bold text
-      </Text>
+      <div style={{ width: '66%', margin: '0 auto' }}>
+        <Text
+          element={select('Element', elements, elements.Paragraph)}
+          size={select('Size', sizes, sizes.Kilo)}
+          noMargin={boolean('No margin')}
+          bold={boolean('Bold')}
+          italic={boolean('Italic')}
+        >
+          {content}
+        </Text>
+      </div>
     ))
   );

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -10,8 +10,6 @@ exports[`Text should render as article element, when passed "article" for the el
 
 <article
   className="circuit-0 circuit-1"
-  italic={false}
-  size="mega"
 >
   ARTICLE heading
 </article>
@@ -27,8 +25,6 @@ exports[`Text should render as div element, when passed "div" for the element pr
 
 <div
   className="circuit-0 circuit-1"
-  italic={false}
-  size="mega"
 >
   DIV heading
 </div>
@@ -44,8 +40,6 @@ exports[`Text should render as p element, when passed "p" for the element prop 1
 
 <p
   className="circuit-0 circuit-1"
-  italic={false}
-  size="mega"
 >
   P heading
 </p>
@@ -62,8 +56,6 @@ exports[`Text should render bold text when passed the bold prop 1`] = `
 
 <p
   className="circuit-0 circuit-1"
-  italic={false}
-  size="mega"
 />
 `;
 
@@ -78,8 +70,6 @@ exports[`Text should render italic text when passed the italic prop 1`] = `
 
 <p
   className="circuit-0 circuit-1"
-  italic={true}
-  size="mega"
 />
 `;
 
@@ -94,8 +84,6 @@ exports[`Text should render with no margin styles when passed the noMargin prop 
 
 <p
   className="circuit-0 circuit-1"
-  italic={false}
-  size="mega"
 />
 `;
 
@@ -109,8 +97,6 @@ exports[`Text should render with size giga, when passed "giga" for the size prop
 
 <p
   className="circuit-0 circuit-1"
-  italic={false}
-  size="giga"
 >
   giga heading
 </p>
@@ -126,8 +112,6 @@ exports[`Text should render with size kilo, when passed "kilo" for the size prop
 
 <p
   className="circuit-0 circuit-1"
-  italic={false}
-  size="kilo"
 >
   kilo heading
 </p>
@@ -143,8 +127,6 @@ exports[`Text should render with size mega, when passed "mega" for the size prop
 
 <p
   className="circuit-0 circuit-1"
-  italic={false}
-  size="mega"
 >
   mega heading
 </p>

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -10,6 +10,7 @@ exports[`Text should render as article element, when passed "article" for the el
 
 <article
   className="circuit-0 circuit-1"
+  italic={false}
   size="mega"
 >
   ARTICLE heading
@@ -26,6 +27,7 @@ exports[`Text should render as div element, when passed "div" for the element pr
 
 <div
   className="circuit-0 circuit-1"
+  italic={false}
   size="mega"
 >
   DIV heading
@@ -42,6 +44,7 @@ exports[`Text should render as p element, when passed "p" for the element prop 1
 
 <p
   className="circuit-0 circuit-1"
+  italic={false}
   size="mega"
 >
   P heading
@@ -59,6 +62,23 @@ exports[`Text should render bold text when passed the bold prop 1`] = `
 
 <p
   className="circuit-0 circuit-1"
+  italic={false}
+  size="mega"
+/>
+`;
+
+exports[`Text should render italic text when passed the italic prop 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 15px;
+  line-height: 24px;
+  font-style: italic;
+}
+
+<p
+  className="circuit-0 circuit-1"
+  italic={true}
   size="mega"
 />
 `;
@@ -74,6 +94,7 @@ exports[`Text should render with no margin styles when passed the noMargin prop 
 
 <p
   className="circuit-0 circuit-1"
+  italic={false}
   size="mega"
 />
 `;
@@ -88,6 +109,7 @@ exports[`Text should render with size giga, when passed "giga" for the size prop
 
 <p
   className="circuit-0 circuit-1"
+  italic={false}
   size="giga"
 >
   giga heading
@@ -104,6 +126,7 @@ exports[`Text should render with size kilo, when passed "kilo" for the size prop
 
 <p
   className="circuit-0 circuit-1"
+  italic={false}
   size="kilo"
 >
   kilo heading
@@ -120,6 +143,7 @@ exports[`Text should render with size mega, when passed "mega" for the size prop
 
 <p
   className="circuit-0 circuit-1"
+  italic={false}
   size="mega"
 >
   mega heading


### PR DESCRIPTION
## Changes 

* Add boolean prop for italic styles to the Text component
* Update Text story with knobs
* Add missing blacklisted attributes to Heading and Text

_Ideally, we would use the proper italic version of Aktiv Grotesk, but for now, faux-italic should be fine._