### PR TITLE
Pass value prop down to select element

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -116,7 +116,7 @@ const Select = ({
   ...props
 }) => (
   <SelectContainer {...{ noMargin, inline, disabled }}>
-    <SelectElement {...{ ...props, disabled }}>
+    <SelectElement {...{ ...props, value, disabled }}>
       {!value && <option key="placeholder">{placeholder}</option>}
       {children ||
         (options &&

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -49,6 +49,7 @@ exports[`Select should render with default styles 1`] = `
   <select
     className="circuit-0 circuit-1"
     disabled={false}
+    value={null}
   >
     <option>
       Select an option
@@ -127,6 +128,7 @@ exports[`Select should render with disabled styles when passed the disabled prop
   <select
     className="circuit-0 circuit-1"
     disabled={true}
+    value={null}
   >
     <option>
       Select an option
@@ -204,6 +206,7 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
   <select
     className="circuit-0 circuit-1"
     disabled={false}
+    value={null}
   >
     <option>
       Select an option
@@ -280,6 +283,7 @@ exports[`Select should render with no margin styles when passed the noMargin pro
   <select
     className="circuit-0 circuit-1"
     disabled={false}
+    value={null}
   >
     <option>
       Select an option


### PR DESCRIPTION
##### Changes

- Make sure we pass down the value prop to the select element, so React can take care of the current selection for us.