### PR TITLE
[Popover] Move style props to outer component

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -112,8 +112,8 @@ class Popover extends Component {
         >
           {({ ref, style }) =>
             isOpen && (
-              <div ref={this.receivePopoverRef}>
-                <div {...{ ref, style }}>
+              <div style={style} ref={this.receivePopoverRef}>
+                <div ref={ref}>
                   {renderPopover({ closePopover: this.closePopover })}
                 </div>
               </div>

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,7 @@ export { default as Card, CardHeader, CardFooter } from './components/Card';
 export { default as Image } from './components/Image';
 export { default as LoadingBar } from './components/LoadingBar';
 export { default as Tag } from './components/Tag';
+export { default as Popover } from './components/Popover';
 export { default as Tooltip } from './components/Tooltip';
 export {
   default as Modal,


### PR DESCRIPTION
Fixes popover positioning by moving the absolute styles to the outer component. 

* Also, actually exporting the component.