### PR TITLE
[Calendar] Re-rexport constants from `react-dates `

### DIFF
--- a/src/components/Calendar/constants.js
+++ b/src/components/Calendar/constants.js
@@ -1,0 +1,3 @@
+import * as constants from 'react-dates/constants';
+
+export default constants;

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -1,3 +1,4 @@
 export { default as RangePicker } from './RangePicker';
 export { default as RangePickerController } from './RangePickerController';
 export { default as SingleDayPicker } from './SingleDayPicker';
+export { default as CalendarConstants } from './constants';

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,8 @@ export { default as Text } from './components/Text';
 export {
   RangePicker,
   RangePickerController,
-  SingleDayPicker
+  SingleDayPicker,
+  CalendarConstants
 } from './components/Calendar';
 export { default as CalendarTag } from './components/CalendarTag';
 export { default as CalendarTagTwoStep } from './components/CalendarTagTwoStep';


### PR DESCRIPTION
Re-export constants instead of forcing users to import from `react-dates` or create a copy.