### PR TITLE
Fix button margin on larger screens

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -12,6 +12,10 @@ const marginStyles = ({ theme, noMargin }) =>
   css`
     li:not(:last-of-type) {
       margin-bottom: ${theme.spacings.mega};
+
+      ${theme.mq.kilo`
+        margin-bottom: 0;
+      `};
     }
   `;
 

--- a/src/components/ButtonGroup/ButtonGroup.story.js
+++ b/src/components/ButtonGroup/ButtonGroup.story.js
@@ -23,7 +23,7 @@ storiesOf(`${GROUPS.COMPONENTS}|Button/ButtonGroup`, module)
           noMargin={boolean('No Margin Bottom', false)}
         >
           <Button secondary>Cancel</Button>
-          <Button>Confirm</Button>
+          <Button primary>Confirm</Button>
         </ButtonGroup>
       </div>
     ))

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
@@ -11,6 +11,12 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
   margin-bottom: 16px;
 }
 
+@media (min-width:480px) {
+  .circuit-0 li:not(:last-of-type) {
+    margin-bottom: 0;
+  }
+}
+
 .circuit-0 > * {
   width: 100%;
 }
@@ -87,6 +93,12 @@ exports[`ButtonGroup should render with default styles 1`] = `
 
 .circuit-0 li:not(:last-of-type) {
   margin-bottom: 16px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 li:not(:last-of-type) {
+    margin-bottom: 0;
+  }
 }
 
 .circuit-0 > * {


### PR DESCRIPTION
This was causing an extra space between buttons and the container of the ButtonGroup. For example, when rendered inside a Card, the Buttons would have extra margins towards the Card's bottom edge.

##### Changes
- Remove bottom margins on screens > 480px.
- Update story to use primary button