### PR TITLE
Use black text for success and warning

### DIFF
--- a/src/components/InlineNotification/InlineNotification.js
+++ b/src/components/InlineNotification/InlineNotification.js
@@ -23,13 +23,20 @@ const createLeftBorderStyles = colorName => ({ theme, size, type }) => {
     [WARNING]: theme.colors.warning
   };
 
+  const textColors = {
+    [DANGER]: theme.colors.danger,
+    [SUCCESS]: theme.colors.black,
+    [WARNING]: theme.colors.black
+  };
+
   return (
     colorName === type &&
     css`
       label: inline-notification--${type};
-      color: ${colors[type]};
+      color: ${textColors[type]};
       position: relative;
       margin-bottom: ${theme.spacings.mega};
+
       &:before {
         display: inline-block;
         border-top-right-radius: ${theme.borderRadius[size]};

--- a/src/components/InlineNotification/__snapshots__/InlineNotification.spec.js.snap
+++ b/src/components/InlineNotification/__snapshots__/InlineNotification.spec.js.snap
@@ -63,7 +63,7 @@ exports[`InlineNotification should render with giga spacing 1`] = `
 
 exports[`InlineNotification should render with success styles 1`] = `
 .circuit-0 {
-  color: #49B85B;
+  color: #0F131A;
   position: relative;
   margin-bottom: 16px;
 }
@@ -90,7 +90,7 @@ exports[`InlineNotification should render with success styles 1`] = `
 
 exports[`InlineNotification should render with warning styles 1`] = `
 .circuit-0 {
-  color: #D4A546;
+  color: #0F131A;
   position: relative;
   margin-bottom: 16px;
 }


### PR DESCRIPTION
After looking at success and warning `InlineNotification`s being used on the new Login page (i.e., IE warning & PRC info), @melmdesign and I decided to use black text for these two types. Text will remain red for errors.