### PR TITLE
[Popover] Use capture for outsideClick

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -62,7 +62,7 @@ class Popover extends Component {
   state = { isOpen: false };
 
   componentDidMount() {
-    document.addEventListener('click', this.handleDocumentClick, false);
+    document.addEventListener('click', this.handleDocumentClick, true);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -72,7 +72,7 @@ class Popover extends Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.handleDocumentClick, false);
+    document.removeEventListener('click', this.handleDocumentClick, true);
   }
 
   handleDocumentClick = ({ target }) => {


### PR DESCRIPTION
When having dynamic components inside the popover, it is possible for the clicked element to be removed from the DOM before the event gets processed by the Popover's handler.

Using capture allows the Popover to process the event before the DOM underneath can disappear. I am still unsure about this, but seems to work better with `<AutoComplete />`