### PR TITLE
Add accessibleOnly prop to Label

### DIFF
--- a/src/components/Label/Label.js
+++ b/src/components/Label/Label.js
@@ -1,7 +1,14 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
+import { hideVisually } from 'polished';
 
 import { textKilo } from '../../styles/style-helpers';
+
+const accessibleOnlyStyles = ({ accessibleOnly }) =>
+  accessibleOnly &&
+  css`
+    ${hideVisually()};
+  `;
 
 const baseStyles = ({ theme }) => css`
   label: form-label;
@@ -15,13 +22,19 @@ const baseStyles = ({ theme }) => css`
  */
 const Label = styled('label')`
   ${baseStyles};
+  ${accessibleOnlyStyles};
 `;
 
 Label.propTypes = {
   /**
    * The identifier of the corresponding form element.
    */
-  htmlFor: PropTypes.string.isRequired
+  htmlFor: PropTypes.string.isRequired,
+  accessibleOnly: PropTypes.bool
+};
+
+Label.defaultProps = {
+  accessibleOnly: false
 };
 
 /**

--- a/src/components/Label/Label.js
+++ b/src/components/Label/Label.js
@@ -4,8 +4,8 @@ import { hideVisually } from 'polished';
 
 import { textKilo } from '../../styles/style-helpers';
 
-const accessibleOnlyStyles = ({ accessibleOnly }) =>
-  accessibleOnly &&
+const visuallyHiddenStyles = ({ visuallyHidden }) =>
+  visuallyHidden &&
   css`
     ${hideVisually()};
   `;
@@ -22,7 +22,7 @@ const baseStyles = ({ theme }) => css`
  */
 const Label = styled('label')`
   ${baseStyles};
-  ${accessibleOnlyStyles};
+  ${visuallyHiddenStyles};
 `;
 
 Label.propTypes = {
@@ -30,11 +30,11 @@ Label.propTypes = {
    * The identifier of the corresponding form element.
    */
   htmlFor: PropTypes.string.isRequired,
-  accessibleOnly: PropTypes.bool
+  visuallyHidden: PropTypes.bool
 };
 
 Label.defaultProps = {
-  accessibleOnly: false
+  visuallyHidden: false
 };
 
 /**

--- a/src/components/Label/Label.spec.js
+++ b/src/components/Label/Label.spec.js
@@ -11,6 +11,15 @@ describe('Label', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should be visually hidden when used as accessible only label', () => {
+    const actual = create(
+      <Label accessibleOnly htmlFor="some-id">
+        Label
+      </Label>
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Accessibility tests.
    */

--- a/src/components/Label/Label.spec.js
+++ b/src/components/Label/Label.spec.js
@@ -13,7 +13,7 @@ describe('Label', () => {
 
   it('should be visually hidden when used as accessible only label', () => {
     const actual = create(
-      <Label accessibleOnly htmlFor="some-id">
+      <Label visuallyHidden htmlFor="some-id">
         Label
       </Label>
     );

--- a/src/components/Label/Label.story.js
+++ b/src/components/Label/Label.story.js
@@ -8,4 +8,10 @@ import Label from '.';
 
 storiesOf(`${GROUPS.FORMS}|Label`, module)
   .addDecorator(withTests('Label'))
-  .add('Default Label', withInfo()(() => <Label>An input label</Label>));
+  .add('Default Label', withInfo()(() => <Label>An input label</Label>))
+  .add(
+    'Label used for accessibility only',
+    withInfo()(() => (
+      <Label accessibleOnly>Only visible for screen readers</Label>
+    ))
+  );

--- a/src/components/Label/__snapshots__/Label.spec.js.snap
+++ b/src/components/Label/__snapshots__/Label.spec.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Label should be visually hidden when used as accessible only label 1`] = `
+.circuit-0 {
+  font-size: 13px;
+  line-height: 20px;
+  margin-bottom: 4px;
+  display: block;
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<label
+  className="circuit-0 circuit-1"
+  htmlFor="some-id"
+>
+  Label
+</label>
+`;
+
 exports[`Label should render with default styles 1`] = `
 .circuit-0 {
   font-size: 13px;


### PR DESCRIPTION
I needed this option for `LanguageSelect` and `CountrySelect` in the Dashboard. These don't have labels, as they are not part of a form.

What do you think, does this make sense?

**Note**: this is only for screen readers (i.e., you have a design without labels).