### PR TITLE
Improve styling of Checkbox component

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -30,7 +30,7 @@ const labelBaseStyles = ({ theme }) => css`
     content: '';
     display: block;
     position: absolute;
-    top: 12px;
+    top: ${theme.spacings.kilo};
     left: 0;
     transform: translateY(-50%);
     transition: border 0.05s ease-in;
@@ -45,7 +45,7 @@ const labelBaseStyles = ({ theme }) => css`
     line-height: 0;
     opacity: 0;
     position: absolute;
-    top: 12px;
+    top: ${theme.spacings.kilo};
     transform: translateY(-50%) scale(0, 0);
     transition: transform 0.05s ease-in, opacity 0.05s ease-in;
   }

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -16,6 +16,7 @@ const checkmarkSvg = fill =>
 const labelBaseStyles = ({ theme }) => css`
   label: checkbox__label;
   color: ${theme.colors.n700};
+  display: inline-block;
   padding-left: ${theme.spacings.giga};
   position: relative;
 
@@ -29,7 +30,7 @@ const labelBaseStyles = ({ theme }) => css`
     content: '';
     display: block;
     position: absolute;
-    top: 50%;
+    top: 12px;
     left: 0;
     transform: translateY(-50%);
     transition: border 0.05s ease-in;
@@ -44,7 +45,7 @@ const labelBaseStyles = ({ theme }) => css`
     line-height: 0;
     opacity: 0;
     position: absolute;
-    top: 50%;
+    top: 12px;
     transform: translateY(-50%) scale(0, 0);
     transition: transform 0.05s ease-in, opacity 0.05s ease-in;
   }
@@ -125,10 +126,16 @@ const CheckboxWrapper = styled('div')`
 /**
  * Checkbox component for forms.
  */
-const Checkbox = ({ onChange, children, id: customId, ...props }) => {
+const Checkbox = ({
+  onChange,
+  children,
+  id: customId,
+  className,
+  ...props
+}) => {
   const id = customId || uniqueId('checkbox_');
   return (
-    <CheckboxWrapper>
+    <CheckboxWrapper className={className}>
       <CheckboxInput {...props} id={id} onClick={onChange} type="checkbox" />
       <CheckboxLabel {...props} htmlFor={id}>
         {children}
@@ -175,7 +182,11 @@ Checkbox.propTypes = {
    * Triggers disabled styles on the component. This is also forwarded as
    * attribute to the <input> element.
    */
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  /**
+   * Override styles for the Checkbox component.
+   */
+  className: PropTypes.string
 };
 
 Checkbox.defaultProps = {
@@ -184,7 +195,8 @@ Checkbox.defaultProps = {
   value: null,
   invalid: false,
   disabled: false,
-  children: null
+  children: null,
+  className: ''
 };
 
 /**

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -38,6 +38,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
 
 .circuit-2 {
   color: #5C656F;
+  display: inline-block;
   padding-left: 24px;
   position: relative;
 }
@@ -53,7 +54,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   content: '';
   display: block;
   position: absolute;
-  top: 50%;
+  top: 12px;
   left: 0;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
@@ -72,7 +73,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   line-height: 0;
   opacity: 0;
   position: absolute;
-  top: 50%;
+  top: 12px;
   -webkit-transform: translateY(-50%) scale(0,0);
   -ms-transform: translateY(-50%) scale(0,0);
   transform: translateY(-50%) scale(0,0);
@@ -143,6 +144,7 @@ exports[`Checkbox should render with default styles 1`] = `
 
 .circuit-2 {
   color: #5C656F;
+  display: inline-block;
   padding-left: 24px;
   position: relative;
 }
@@ -158,7 +160,7 @@ exports[`Checkbox should render with default styles 1`] = `
   content: '';
   display: block;
   position: absolute;
-  top: 50%;
+  top: 12px;
   left: 0;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
@@ -177,7 +179,7 @@ exports[`Checkbox should render with default styles 1`] = `
   line-height: 0;
   opacity: 0;
   position: absolute;
-  top: 50%;
+  top: 12px;
   -webkit-transform: translateY(-50%) scale(0,0);
   -ms-transform: translateY(-50%) scale(0,0);
   transform: translateY(-50%) scale(0,0);
@@ -248,6 +250,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 
 .circuit-2 {
   color: #5C656F;
+  display: inline-block;
   padding-left: 24px;
   position: relative;
   opacity: 0.5;
@@ -266,7 +269,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   content: '';
   display: block;
   position: absolute;
-  top: 50%;
+  top: 12px;
   left: 0;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
@@ -285,7 +288,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   line-height: 0;
   opacity: 0;
   position: absolute;
-  top: 50%;
+  top: 12px;
   -webkit-transform: translateY(-50%) scale(0,0);
   -ms-transform: translateY(-50%) scale(0,0);
   transform: translateY(-50%) scale(0,0);
@@ -371,6 +374,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 
 .circuit-2 {
   color: #5C656F;
+  display: inline-block;
   padding-left: 24px;
   position: relative;
 }
@@ -386,7 +390,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   content: '';
   display: block;
   position: absolute;
-  top: 50%;
+  top: 12px;
   left: 0;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
@@ -405,7 +409,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   line-height: 0;
   opacity: 0;
   position: absolute;
-  top: 50%;
+  top: 12px;
   -webkit-transform: translateY(-50%) scale(0,0);
   -ms-transform: translateY(-50%) scale(0,0);
   transform: translateY(-50%) scale(0,0);


### PR DESCRIPTION
## Changes

* Fix checkbox position when the label wraps over multiple lines
* Allow custom styling of the checkbox by passing the `className` prop to the wrapper

<img width="451" alt="screenshot 2018-06-26 21 35 09" src="https://user-images.githubusercontent.com/11017722/41936799-a5699ac8-798e-11e8-878b-0245d6af8213.png">
