### PR TITLE
Add giga size to List component

### DIFF
--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -4,10 +4,10 @@ import styled, { css } from 'react-emotion';
 
 import { childrenPropType } from '../../util/shared-prop-types';
 import HtmlElement from '../HtmlElement';
-import { textMega, textKilo } from '../../styles/style-helpers';
+import { textMega, textKilo, textGiga } from '../../styles/style-helpers';
 import { sizes } from '../../styles/constants';
 
-const { BIT, BYTE, KILO, MEGA } = sizes;
+const { BIT, BYTE, KILO, MEGA, GIGA } = sizes;
 
 const baseStyles = ({ theme }) => css`
   label: list;
@@ -18,37 +18,47 @@ const sizeStyles = ({ theme, size }) => {
   const settings = {
     [KILO]: {
       marginBottom: theme.spacings[KILO],
+      paddingLeft: theme.spacings[KILO],
       marginLeft: theme.spacings[BIT],
-      nestedLeft: theme.spacings[KILO],
       type: textKilo({ theme })
     },
     [MEGA]: {
       marginBottom: theme.spacings[BYTE],
-      marginLeft: theme.spacings[BIT],
-      nestedLeft: theme.spacings[KILO],
+      paddingLeft: theme.spacings[KILO],
+      marginLeft: theme.spacings[KILO],
       type: textMega({ theme })
+    },
+    [GIGA]: {
+      marginBottom: theme.spacings[KILO],
+      paddingLeft: theme.spacings[MEGA],
+      marginLeft: theme.spacings[KILO],
+      type: textGiga({ theme })
     }
   };
-  const { nestedLeft, marginBottom, marginLeft, type } = settings[size];
+  const { marginBottom, paddingLeft, marginLeft, type } = settings[size];
   return css`
     label: list--${size};
-    margin-left: ${marginLeft};
-    ${type} li {
+    padding-left: ${paddingLeft};
+    ${type};
+
+    li {
       margin-bottom: ${marginBottom};
       margin-left: ${marginLeft};
     }
+
     ul,
     ol {
-      margin-left: ${nestedLeft};
+      margin-left: ${marginLeft};
     }
   `;
 };
 
-const ListElement = props => (
+// eslint-disable-next-line react/prop-types
+const ListElement = ({ ordered, ...otherProps }) => (
   <HtmlElement
-    blacklist={{ size: true, ordered: true }}
-    element={({ ordered }) => (ordered ? 'ol' : 'ul')}
-    {...props}
+    blacklist={{ size: true }}
+    element={ordered ? 'ol' : 'ul'}
+    {...otherProps}
   />
 );
 
@@ -59,6 +69,7 @@ const List = styled(ListElement)(baseStyles, sizeStyles);
 
 List.KILO = KILO;
 List.MEGA = MEGA;
+List.GIGA = GIGA;
 
 List.propTypes = {
   /**
@@ -68,7 +79,7 @@ List.propTypes = {
   /**
    * A Circuit UI body text size.
    */
-  size: PropTypes.oneOf([List.KILO, List.MEGA]),
+  size: PropTypes.oneOf([List.KILO, List.MEGA, List.GIGA]),
   /**
    * Whether the list should be presented as an <ol>
    */

--- a/src/components/List/List.spec.js
+++ b/src/components/List/List.spec.js
@@ -33,6 +33,15 @@ describe('List', () => {
     expect(list).toMatchSnapshot();
   });
 
+  it('should render a giga unordered List', () => {
+    const list = create(
+      <List size={List.GIGA}>
+        <li>Hi there</li>
+      </List>
+    );
+    expect(list).toMatchSnapshot();
+  });
+
   it('should render nested unordered lists', () => {
     const list = create(
       <List>

--- a/src/components/List/List.story.js
+++ b/src/components/List/List.story.js
@@ -1,59 +1,26 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { boolean, select } from '@storybook/addon-knobs';
 import { GROUPS } from '../../../.storybook/hierarchySeparators';
 
 import withTests from '../../util/withTests';
 import List from './List';
 
+const sizes = [List.KILO, List.MEGA, List.GIGA];
+
 storiesOf(`${GROUPS.COMPONENTS}|List`, module)
   .addDecorator(withTests('List'))
   .add(
-    'List default',
+    'List',
     withInfo()(() => (
-      <List>
+      <List size={select('Size', sizes, sizes[0])} ordered={boolean('Ordered')}>
         <li>This is a list</li>
         <li>A very fine list</li>
-        <List>
-          <li>Sometimes a nested list</li>
-        </List>
-        <li>The kind of list you like</li>
-      </List>
-    ))
-  )
-  .add(
-    'List ordered',
-    withInfo()(() => (
-      <List ordered>
-        <li>This is a list</li>
-        <li>A very fine list</li>
-        <List>
-          <li>Sometimes a nested list</li>
-        </List>
-        <li>The kind of list you like</li>
-      </List>
-    ))
-  )
-  .add(
-    'List kilo',
-    withInfo()(() => (
-      <List size={List.KILO}>
-        <li>This is a list</li>
-        <li>A very fine list</li>
-        <List size={List.KILO}>
-          <li>Sometimes a nested list</li>
-        </List>
-        <li>The kind of list you like</li>
-      </List>
-    ))
-  )
-  .add(
-    'List mega',
-    withInfo()(() => (
-      <List size={List.MEGA}>
-        <li>This is a list</li>
-        <li>A very fine list</li>
-        <List size={List.MEGA}>
+        <List
+          size={select('Size', sizes, sizes[0])}
+          ordered={boolean('Ordered')}
+        >
           <li>Sometimes a nested list</li>
         </List>
         <li>The kind of list you like</li>

--- a/src/components/List/__snapshots__/List.spec.js.snap
+++ b/src/components/List/__snapshots__/List.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`List should render a default unordered List 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-left: 4px;
+  padding-left: 12px;
   font-size: 13px;
   line-height: 20px;
 }
@@ -11,6 +11,33 @@ exports[`List should render a default unordered List 1`] = `
 .circuit-0 li {
   margin-bottom: 12px;
   margin-left: 4px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 4px;
+}
+
+<ul
+  className="circuit-0 circuit-1"
+>
+  <li>
+    Hi there
+  </li>
+</ul>
+`;
+
+exports[`List should render a giga unordered List 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  padding-left: 16px;
+  font-size: 18px;
+  line-height: 28px;
+}
+
+.circuit-0 li {
+  margin-bottom: 12px;
+  margin-left: 12px;
 }
 
 .circuit-0 ul,
@@ -30,7 +57,7 @@ exports[`List should render a default unordered List 1`] = `
 exports[`List should render a kilo unordered List 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-left: 4px;
+  padding-left: 12px;
   font-size: 13px;
   line-height: 20px;
 }
@@ -42,7 +69,7 @@ exports[`List should render a kilo unordered List 1`] = `
 
 .circuit-0 ul,
 .circuit-0 ol {
-  margin-left: 12px;
+  margin-left: 4px;
 }
 
 <ul
@@ -57,14 +84,14 @@ exports[`List should render a kilo unordered List 1`] = `
 exports[`List should render a mega unordered List 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-left: 4px;
+  padding-left: 12px;
   font-size: 15px;
   line-height: 24px;
 }
 
 .circuit-0 li {
   margin-bottom: 8px;
-  margin-left: 4px;
+  margin-left: 12px;
 }
 
 .circuit-0 ul,
@@ -84,7 +111,7 @@ exports[`List should render a mega unordered List 1`] = `
 exports[`List should render an ordered list 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-left: 4px;
+  padding-left: 12px;
   font-size: 13px;
   line-height: 20px;
 }
@@ -96,7 +123,7 @@ exports[`List should render an ordered list 1`] = `
 
 .circuit-0 ul,
 .circuit-0 ol {
-  margin-left: 12px;
+  margin-left: 4px;
 }
 
 <ol
@@ -114,7 +141,7 @@ exports[`List should render an ordered list 1`] = `
 exports[`List should render nested unordered lists 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-left: 4px;
+  padding-left: 12px;
   font-size: 13px;
   line-height: 20px;
 }
@@ -126,7 +153,7 @@ exports[`List should render nested unordered lists 1`] = `
 
 .circuit-0 ul,
 .circuit-0 ol {
-  margin-left: 12px;
+  margin-left: 4px;
 }
 
 <ul


### PR DESCRIPTION
## Changes

* Add Giga size to List component to match Text component
* Fix spacing to match spec: https://github.com/sumup/circuit-ui/issues/37

<img width="273" alt="screenshot 2018-06-26 22 14 30" src="https://user-images.githubusercontent.com/11017722/41936865-e32e1fb4-798e-11e8-8f37-dc28f052a9b3.png">

👆 _Lists now have the correct spacing on the left side when preceded by a Text component. Previously, the bullet points would overflow to the left._

<img width="379" alt="screenshot 2018-06-26 22 14 36" src="https://user-images.githubusercontent.com/11017722/41936938-306de03e-798f-11e8-87fa-9a8f262a85ad.png">

👆 _New `GIGA` size to match the Text sizes._