### PR TITLE
Add default bottom spacing to List

### DIFF
--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -12,6 +12,7 @@ const { BIT, BYTE, KILO, MEGA, GIGA } = sizes;
 const baseStyles = ({ theme }) => css`
   label: list;
   font-weight: ${theme.fontWeight.regular};
+  margin-bottom: ${theme.spacings.mega};
 `;
 
 const sizeStyles = ({ theme, size }) => {
@@ -53,6 +54,13 @@ const sizeStyles = ({ theme, size }) => {
   `;
 };
 
+const marginStyles = ({ noMargin }) =>
+  noMargin &&
+  css`
+    label: text--no-margin;
+    margin-bottom: 0;
+  `;
+
 // eslint-disable-next-line react/prop-types
 const ListElement = ({ ordered, ...otherProps }) => (
   <HtmlElement
@@ -65,7 +73,11 @@ const ListElement = ({ ordered, ...otherProps }) => (
 /**
  * A list, which can be ordered or unordered
  */
-const List = styled(ListElement)(baseStyles, sizeStyles);
+const List = styled(ListElement)`
+  ${baseStyles};
+  ${sizeStyles};
+  ${marginStyles};
+`;
 
 List.KILO = KILO;
 List.MEGA = MEGA;
@@ -83,12 +95,17 @@ List.propTypes = {
   /**
    * Whether the list should be presented as an <ol>
    */
-  ordered: PropTypes.bool
+  ordered: PropTypes.bool,
+  /**
+   * Removes the default bottom margin from the text.
+   */
+  noMargin: PropTypes.bool
 };
 
 List.defaultProps = {
   size: List.KILO,
-  ordered: false
+  ordered: false,
+  noMargin: false
 };
 
 /**

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -64,7 +64,7 @@ const marginStyles = ({ noMargin }) =>
 // eslint-disable-next-line react/prop-types
 const ListElement = ({ ordered, ...otherProps }) => (
   <HtmlElement
-    blacklist={{ size: true }}
+    blacklist={{ size: true, noMargin: true }}
     element={ordered ? 'ol' : 'ul'}
     {...otherProps}
   />

--- a/src/components/List/List.spec.js
+++ b/src/components/List/List.spec.js
@@ -64,6 +64,15 @@ describe('List', () => {
     expect(list).toMatchSnapshot();
   });
 
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(
+      <List noMargin>
+        <li>Hi</li>
+      </List>
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Accessibility tests.
    */

--- a/src/components/List/__snapshots__/List.spec.js.snap
+++ b/src/components/List/__snapshots__/List.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`List should render a default unordered List 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 13px;
   line-height: 20px;
@@ -20,6 +21,7 @@ exports[`List should render a default unordered List 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
+  noMargin={false}
 >
   <li>
     Hi there
@@ -30,6 +32,7 @@ exports[`List should render a default unordered List 1`] = `
 exports[`List should render a giga unordered List 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   padding-left: 16px;
   font-size: 18px;
   line-height: 28px;
@@ -47,6 +50,7 @@ exports[`List should render a giga unordered List 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
+  noMargin={false}
 >
   <li>
     Hi there
@@ -57,6 +61,7 @@ exports[`List should render a giga unordered List 1`] = `
 exports[`List should render a kilo unordered List 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 13px;
   line-height: 20px;
@@ -74,6 +79,7 @@ exports[`List should render a kilo unordered List 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
+  noMargin={false}
 >
   <li>
     Hi there
@@ -84,6 +90,7 @@ exports[`List should render a kilo unordered List 1`] = `
 exports[`List should render a mega unordered List 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 15px;
   line-height: 24px;
@@ -101,6 +108,7 @@ exports[`List should render a mega unordered List 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
+  noMargin={false}
 >
   <li>
     Hi there
@@ -111,6 +119,7 @@ exports[`List should render a mega unordered List 1`] = `
 exports[`List should render an ordered list 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 13px;
   line-height: 20px;
@@ -128,6 +137,7 @@ exports[`List should render an ordered list 1`] = `
 
 <ol
   className="circuit-0 circuit-1"
+  noMargin={false}
 >
   <li>
     Hi
@@ -141,6 +151,7 @@ exports[`List should render an ordered list 1`] = `
 exports[`List should render nested unordered lists 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 13px;
   line-height: 20px;
@@ -158,16 +169,48 @@ exports[`List should render nested unordered lists 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
+  noMargin={false}
 >
   <li>
     Hi there
   </li>
   <ul
     className="circuit-0 circuit-1"
+    noMargin={false}
   >
     <li>
       Hi there
     </li>
   </ul>
+</ul>
+`;
+
+exports[`List should render with no margin styles when passed the noMargin prop 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-left: 12px;
+  font-size: 13px;
+  line-height: 20px;
+  margin-bottom: 0;
+}
+
+.circuit-0 li {
+  margin-bottom: 12px;
+  margin-left: 4px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 4px;
+}
+
+<ul
+  className="circuit-0 circuit-1"
+  noMargin={true}
+>
+  <li>
+    Hi
+  </li>
 </ul>
 `;

--- a/src/components/List/__snapshots__/List.spec.js.snap
+++ b/src/components/List/__snapshots__/List.spec.js.snap
@@ -21,7 +21,6 @@ exports[`List should render a default unordered List 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
-  noMargin={false}
 >
   <li>
     Hi there
@@ -50,7 +49,6 @@ exports[`List should render a giga unordered List 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
-  noMargin={false}
 >
   <li>
     Hi there
@@ -79,7 +77,6 @@ exports[`List should render a kilo unordered List 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
-  noMargin={false}
 >
   <li>
     Hi there
@@ -108,7 +105,6 @@ exports[`List should render a mega unordered List 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
-  noMargin={false}
 >
   <li>
     Hi there
@@ -137,7 +133,6 @@ exports[`List should render an ordered list 1`] = `
 
 <ol
   className="circuit-0 circuit-1"
-  noMargin={false}
 >
   <li>
     Hi
@@ -169,14 +164,12 @@ exports[`List should render nested unordered lists 1`] = `
 
 <ul
   className="circuit-0 circuit-1"
-  noMargin={false}
 >
   <li>
     Hi there
   </li>
   <ul
     className="circuit-0 circuit-1"
-    noMargin={false}
   >
     <li>
       Hi there
@@ -207,7 +200,6 @@ exports[`List should render with no margin styles when passed the noMargin prop 
 
 <ul
   className="circuit-0 circuit-1"
-  noMargin={true}
 >
   <li>
     Hi


### PR DESCRIPTION
Adds a default bottom margin to the List component, same as other text components. 

_I know there's been some discussion again whether Circuit UI components should have a default bottom margin — nevertheless, as long as they do, it should be consistent across all components._