### PR TITLE
Add [type=button] default to Button

### DIFF
--- a/src/components/Button/components/PlainButton/PlainButton.js
+++ b/src/components/Button/components/PlainButton/PlainButton.js
@@ -44,7 +44,7 @@ const PlainButton = ({ href, ...rest }) =>
   href ? (
     <PlainButtonWrapper noMargin {...{ ...rest, href }} />
   ) : (
-    <ButtonLinkWrapper noMargin {...rest} />
+    <ButtonLinkWrapper type="button" noMargin {...rest} />
   );
 
 export default PlainButton;

--- a/src/components/Button/components/PlainButton/PlainButton.spec.js
+++ b/src/components/Button/components/PlainButton/PlainButton.spec.js
@@ -7,32 +7,52 @@ describe('PlainButton', () => {
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<Button>Link</Button>);
+    const actual = create(<Button plain>Link</Button>);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with href', () => {
-    const actual = create(<Button href="example">Button</Button>);
+    const actual = create(
+      <Button plain href="example">
+        Button
+      </Button>
+    );
     expect(actual).toMatchSnapshot();
   });
 
   it('should have primary styles', () => {
-    const actual = create(<Button primary>Button</Button>);
+    const actual = create(
+      <Button plain primary>
+        Button
+      </Button>
+    );
     expect(actual).toMatchSnapshot();
   });
 
   it('should have kilo link styles', () => {
-    const actual = create(<Button size={Button.KILO}>Button</Button>);
+    const actual = create(
+      <Button plain size={Button.KILO}>
+        Button
+      </Button>
+    );
     expect(actual).toMatchSnapshot();
   });
 
   it('should have mega link styles', () => {
-    const actual = create(<Button size={Button.MEGA}>Button</Button>);
+    const actual = create(
+      <Button plain size={Button.MEGA}>
+        Button
+      </Button>
+    );
     expect(actual).toMatchSnapshot();
   });
 
   it('should have giga link styles', () => {
-    const actual = create(<Button size={Button.GIGA}>Button</Button>);
+    const actual = create(
+      <Button plain size={Button.GIGA}>
+        Button
+      </Button>
+    );
     expect(actual).toMatchSnapshot();
   });
 
@@ -41,15 +61,33 @@ describe('PlainButton', () => {
    */
   it('should meet accessibility guidelines when used as anchor', async () => {
     const wrapper = renderToHtml(
-      <Button href="http://accessibility.com">Link</Button>
+      <Button plain href="http://accessibility.com">
+        Link
+      </Button>
     );
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });
 
   it('should meet accessibility guidelines when used as button', async () => {
-    const wrapper = renderToHtml(<Button onClick={() => {}}>Link</Button>);
+    const wrapper = renderToHtml(
+      <Button plain onClick={() => {}}>
+        Link
+      </Button>
+    );
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
+  });
+
+  /**
+   * Logic tests.
+   */
+  it('should accept a type prop', () => {
+    const wrapper = shallow(
+      <Button plain type="submit">
+        Button
+      </Button>
+    );
+    expect(wrapper.prop('type')).toEqual('submit');
   });
 });

--- a/src/components/Button/components/PlainButton/__snapshots__/PlainButton.spec.js.snap
+++ b/src/components/Button/components/PlainButton/__snapshots__/PlainButton.spec.js.snap
@@ -2,57 +2,28 @@
 
 exports[`PlainButton should have giga link styles 1`] = `
 .circuit-0 {
-  background-color: #FAFBFC;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
-  display: block;
-  color: #5C656F;
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 18px;
+  line-height: 28px;
+  margin-bottom: 0;
+  box-shadow: none;
+  border: none;
+  background: none;
+  font-weight: normal;
+  padding: 0;
+  color: #9DA7B1;
   cursor: pointer;
-  font-weight: 700;
-  width: auto;
-  height: auto;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 15px;
-  line-height: 24px;
-  padding: calc(12px - 0px) calc(32px - 0px);
-}
-
-.circuit-0:active {
-  background-color: #D8DDE1;
-  border-color: #9DA7B1;
-  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
-}
-
-.circuit-0:focus {
-  border-color: #9DA7B1;
-  border-width: 2px;
-  outline: 0;
-  padding: calc(12px - 1px) calc(32px - 1px);
+  outline: none;
 }
 
 .circuit-0:hover {
-  background-color: #D8DDE1;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
-.circuit-0:hover,
 .circuit-0:active {
-  border-color: #9DA7B1;
-  border-width: 1px;
-  padding: calc(12px - 0px) calc(32px - 0px);
-}
-
-.circuit-0[disabled],
-.circuit-0:disabled {
-  opacity: 0.4;
-  pointer-events: none;
-  -webkit-user-selectable: none;
-  -moz-user-selectable: none;
-  -ms-user-selectable: none;
-  user-selectable: none;
+  color: #212933;
 }
 
 <button
@@ -60,6 +31,7 @@ exports[`PlainButton should have giga link styles 1`] = `
   disabled={false}
   size="giga"
   target={null}
+  type="button"
 >
   Button
 </button>
@@ -67,57 +39,28 @@ exports[`PlainButton should have giga link styles 1`] = `
 
 exports[`PlainButton should have kilo link styles 1`] = `
 .circuit-0 {
-  background-color: #FAFBFC;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
-  display: block;
-  color: #5C656F;
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 13px;
+  line-height: 20px;
+  margin-bottom: 0;
+  box-shadow: none;
+  border: none;
+  background: none;
+  font-weight: normal;
+  padding: 0;
+  color: #9DA7B1;
   cursor: pointer;
-  font-weight: 700;
-  width: auto;
-  height: auto;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 15px;
-  line-height: 24px;
-  padding: calc(4px - 0px) calc(16px - 0px);
-}
-
-.circuit-0:active {
-  background-color: #D8DDE1;
-  border-color: #9DA7B1;
-  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
-}
-
-.circuit-0:focus {
-  border-color: #9DA7B1;
-  border-width: 2px;
-  outline: 0;
-  padding: calc(4px - 1px) calc(16px - 1px);
+  outline: none;
 }
 
 .circuit-0:hover {
-  background-color: #D8DDE1;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
-.circuit-0:hover,
 .circuit-0:active {
-  border-color: #9DA7B1;
-  border-width: 1px;
-  padding: calc(4px - 0px) calc(16px - 0px);
-}
-
-.circuit-0[disabled],
-.circuit-0:disabled {
-  opacity: 0.4;
-  pointer-events: none;
-  -webkit-user-selectable: none;
-  -moz-user-selectable: none;
-  -ms-user-selectable: none;
-  user-selectable: none;
+  color: #212933;
 }
 
 <button
@@ -125,6 +68,7 @@ exports[`PlainButton should have kilo link styles 1`] = `
   disabled={false}
   size="kilo"
   target={null}
+  type="button"
 >
   Button
 </button>
@@ -132,57 +76,28 @@ exports[`PlainButton should have kilo link styles 1`] = `
 
 exports[`PlainButton should have mega link styles 1`] = `
 .circuit-0 {
-  background-color: #FAFBFC;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
-  display: block;
-  color: #5C656F;
-  cursor: pointer;
-  font-weight: 700;
-  width: auto;
-  height: auto;
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  font-weight: 400;
+  margin-bottom: 16px;
   font-size: 15px;
   line-height: 24px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-0:active {
-  background-color: #D8DDE1;
-  border-color: #9DA7B1;
-  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
-}
-
-.circuit-0:focus {
-  border-color: #9DA7B1;
-  border-width: 2px;
-  outline: 0;
-  padding: calc(8px - 1px) calc(24px - 1px);
+  margin-bottom: 0;
+  box-shadow: none;
+  border: none;
+  background: none;
+  font-weight: normal;
+  padding: 0;
+  color: #9DA7B1;
+  cursor: pointer;
+  outline: none;
 }
 
 .circuit-0:hover {
-  background-color: #D8DDE1;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
-.circuit-0:hover,
 .circuit-0:active {
-  border-color: #9DA7B1;
-  border-width: 1px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-0[disabled],
-.circuit-0:disabled {
-  opacity: 0.4;
-  pointer-events: none;
-  -webkit-user-selectable: none;
-  -moz-user-selectable: none;
-  -ms-user-selectable: none;
-  user-selectable: none;
+  color: #212933;
 }
 
 <button
@@ -190,6 +105,7 @@ exports[`PlainButton should have mega link styles 1`] = `
   disabled={false}
   size="mega"
   target={null}
+  type="button"
 >
   Button
 </button>
@@ -197,78 +113,33 @@ exports[`PlainButton should have mega link styles 1`] = `
 
 exports[`PlainButton should have primary styles 1`] = `
 .circuit-0 {
-  background-color: #FAFBFC;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
-  display: block;
-  color: #5C656F;
-  cursor: pointer;
-  font-weight: 700;
-  width: auto;
-  height: auto;
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  font-weight: 400;
+  margin-bottom: 16px;
   font-size: 15px;
   line-height: 24px;
-  background-color: #3388FF;
-  border-color: #2567D8;
-  color: #FFFFFF;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-0:active {
-  background-color: #D8DDE1;
-  border-color: #9DA7B1;
-  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
-}
-
-.circuit-0:focus {
-  border-color: #9DA7B1;
-  border-width: 2px;
-  outline: 0;
-  padding: calc(8px - 1px) calc(24px - 1px);
+  margin-bottom: 0;
+  box-shadow: none;
+  border: none;
+  background: none;
+  font-weight: normal;
+  padding: 0;
+  color: #9DA7B1;
+  cursor: pointer;
+  outline: none;
+  color: #3388FF;
 }
 
 .circuit-0:hover {
-  background-color: #D8DDE1;
-}
-
-.circuit-0:hover,
-.circuit-0:active {
-  border-color: #9DA7B1;
-  border-width: 1px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-0[disabled],
-.circuit-0:disabled {
-  opacity: 0.4;
-  pointer-events: none;
-  -webkit-user-selectable: none;
-  -moz-user-selectable: none;
-  -ms-user-selectable: none;
-  user-selectable: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .circuit-0:active {
-  background-color: #2567D8;
-  border-color: #1641AC;
+  color: #212933;
 }
 
-.circuit-0:focus {
-  border-color: #2567D8;
-}
-
-.circuit-0:hover {
-  background-color: #2567D8;
-}
-
-.circuit-0:hover,
 .circuit-0:active {
-  border-color: #1641AC;
+  color: #1641AC;
 }
 
 <button
@@ -276,6 +147,7 @@ exports[`PlainButton should have primary styles 1`] = `
   disabled={false}
   size="mega"
   target={null}
+  type="button"
 >
   Button
 </button>
@@ -283,57 +155,28 @@ exports[`PlainButton should have primary styles 1`] = `
 
 exports[`PlainButton should render with default styles 1`] = `
 .circuit-0 {
-  background-color: #FAFBFC;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
-  display: block;
-  color: #5C656F;
-  cursor: pointer;
-  font-weight: 700;
-  width: auto;
-  height: auto;
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  font-weight: 400;
+  margin-bottom: 16px;
   font-size: 15px;
   line-height: 24px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-0:active {
-  background-color: #D8DDE1;
-  border-color: #9DA7B1;
-  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
-}
-
-.circuit-0:focus {
-  border-color: #9DA7B1;
-  border-width: 2px;
-  outline: 0;
-  padding: calc(8px - 1px) calc(24px - 1px);
+  margin-bottom: 0;
+  box-shadow: none;
+  border: none;
+  background: none;
+  font-weight: normal;
+  padding: 0;
+  color: #9DA7B1;
+  cursor: pointer;
+  outline: none;
 }
 
 .circuit-0:hover {
-  background-color: #D8DDE1;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
-.circuit-0:hover,
 .circuit-0:active {
-  border-color: #9DA7B1;
-  border-width: 1px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-0[disabled],
-.circuit-0:disabled {
-  opacity: 0.4;
-  pointer-events: none;
-  -webkit-user-selectable: none;
-  -moz-user-selectable: none;
-  -ms-user-selectable: none;
-  user-selectable: none;
+  color: #212933;
 }
 
 <button
@@ -341,6 +184,7 @@ exports[`PlainButton should render with default styles 1`] = `
   disabled={false}
   size="mega"
   target={null}
+  type="button"
 >
   Link
 </button>
@@ -348,57 +192,28 @@ exports[`PlainButton should render with default styles 1`] = `
 
 exports[`PlainButton should render with href 1`] = `
 .circuit-0 {
-  background-color: #FAFBFC;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
-  display: inline-block;
-  color: #5C656F;
-  cursor: pointer;
-  font-weight: 700;
-  width: auto;
-  height: auto;
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  font-weight: 400;
+  margin-bottom: 16px;
   font-size: 15px;
   line-height: 24px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-0:active {
-  background-color: #D8DDE1;
-  border-color: #9DA7B1;
-  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
-}
-
-.circuit-0:focus {
-  border-color: #9DA7B1;
-  border-width: 2px;
-  outline: 0;
-  padding: calc(8px - 1px) calc(24px - 1px);
+  margin-bottom: 0;
+  box-shadow: none;
+  border: none;
+  background: none;
+  font-weight: normal;
+  padding: 0;
+  color: #9DA7B1;
+  cursor: pointer;
+  outline: none;
 }
 
 .circuit-0:hover {
-  background-color: #D8DDE1;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
-.circuit-0:hover,
 .circuit-0:active {
-  border-color: #9DA7B1;
-  border-width: 1px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-0[disabled],
-.circuit-0:disabled {
-  opacity: 0.4;
-  pointer-events: none;
-  -webkit-user-selectable: none;
-  -moz-user-selectable: none;
-  -ms-user-selectable: none;
-  user-selectable: none;
+  color: #212933;
 }
 
 <a

--- a/src/components/Button/components/RegularButton/RegularButton.js
+++ b/src/components/Button/components/RegularButton/RegularButton.js
@@ -234,7 +234,7 @@ const RegularButton = ({ href, ...props }) =>
   href ? (
     <LinkButtonElement {...{ ...props, href }} />
   ) : (
-    <ButtonElement {...props} />
+    <ButtonElement type="button" {...props} />
   );
 
 export default RegularButton;

--- a/src/components/Button/components/RegularButton/RegularButton.spec.js
+++ b/src/components/Button/components/RegularButton/RegularButton.spec.js
@@ -107,5 +107,10 @@ describe('RegularButton', () => {
       expect(wrapper.find('a')).toBePresent();
       expect(wrapper.find('a')).toHaveProp('target', '_blank');
     });
+
+    it('should accept a type prop', () => {
+      const wrapper = shallow(<Button type="submit">Button</Button>);
+      expect(wrapper.prop('type')).toEqual('submit');
+    });
   });
 });

--- a/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
+++ b/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
@@ -60,6 +60,7 @@ exports[`RegularButton should have button styles 1`] = `
   disabled={false}
   size="mega"
   target={null}
+  type="button"
 >
   Button
 </button>
@@ -125,6 +126,7 @@ exports[`RegularButton should have disabled button styles 1`] = `
   disabled={true}
   size="mega"
   target={null}
+  type="button"
 >
   Disabled button
 </button>
@@ -208,6 +210,7 @@ exports[`RegularButton should have flat button styles 1`] = `
   disabled={false}
   size="mega"
   target={null}
+  type="button"
 >
   Flat button
 </button>
@@ -291,6 +294,7 @@ exports[`RegularButton should have flat disabled button styles 1`] = `
   disabled={true}
   size="mega"
   target={null}
+  type="button"
 >
   Flat button
 </button>
@@ -356,6 +360,7 @@ exports[`RegularButton should have giga button styles 1`] = `
   disabled={false}
   size="giga"
   target={null}
+  type="button"
 >
   Button
 </button>
@@ -421,6 +426,7 @@ exports[`RegularButton should have kilo button styles 1`] = `
   disabled={false}
   size="kilo"
   target={null}
+  type="button"
 >
   Button
 </button>
@@ -486,6 +492,7 @@ exports[`RegularButton should have mega button styles 1`] = `
   disabled={false}
   size="mega"
   target={null}
+  type="button"
 >
   Button
 </button>
@@ -597,6 +604,7 @@ exports[`RegularButton should have secondary button styles 1`] = `
   disabled={false}
   size="mega"
   target={null}
+  type="button"
 >
   Secondary button
 </button>
@@ -708,6 +716,7 @@ exports[`RegularButton should have secondary disabled button styles 1`] = `
   disabled={true}
   size="mega"
   target={null}
+  type="button"
 >
   Secondary disabled button
 </button>
@@ -819,6 +828,7 @@ exports[`RegularButton should have secondary flat button styles 1`] = `
   disabled={false}
   size="mega"
   target={null}
+  type="button"
 >
   Secondary flat button
 </button>
@@ -886,6 +896,7 @@ exports[`RegularButton should have stretch button styles 1`] = `
   disabled={false}
   size="mega"
   target={null}
+  type="button"
 >
   Stretched button
 </button>

--- a/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
+++ b/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
@@ -101,6 +101,7 @@ exports[`Container Container Style tests should have default styles 1`] = `
   onClick={undefined}
   size="mega"
   target={null}
+  type="button"
 >
   <div
     className="circuit-7 circuit-8"

--- a/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
+++ b/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
@@ -106,6 +106,7 @@ exports[`LoadingButton Style tests should have active loading styles 1`] = `
   onClick={undefined}
   size="mega"
   target={null}
+  type="button"
 >
   <div
     className="circuit-7 circuit-8"
@@ -237,6 +238,7 @@ exports[`LoadingButton Style tests should have default styles 1`] = `
   onClick={undefined}
   size="mega"
   target={null}
+  type="button"
 >
   <div
     className="circuit-7 circuit-8"
@@ -368,6 +370,7 @@ exports[`LoadingButton Style tests should have isLoading styles 1`] = `
   onClick={null}
   size="mega"
   target={null}
+  type="button"
 >
   <div
     className="circuit-7 circuit-8"


### PR DESCRIPTION
Not having `type=button` for `<button>` can lead to easy to implement bugs in **ze d**.

**Changes**
* Adds `type=button` as default prop for Button when container is `<button>`
* Add logic test to ensure type can still be changed from the user.
* Changed `PlainButton` tests to test the plain variant as they were redundantly checking the RegularButton again.
