### PR TITLE
Move Modal z-index to theme

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -102,7 +102,7 @@ const overlayClassName = {
     right: 0;
     top: 0;
     transition: opacity 200ms ease-in-out;
-    z-index: 1000;
+    z-index: ${theme.zIndex.modal};
 
     ${theme.mq.kilo`
       -webkit-overflow-scrolling: touch;

--- a/src/themes/default.js
+++ b/src/themes/default.js
@@ -230,5 +230,6 @@ export const zIndex = {
   default: 0,
   absolute: 1,
   select: 30,
-  tooltip: 31
+  tooltip: 31,
+  modal: 1000
 };


### PR DESCRIPTION
We need to be able to adjust the Modal's `z-index` on the website, so I propose to move it to the theme.