### PR TITLE
Refactor Popover as a controlled component

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -17,7 +17,7 @@ import {
 import { positionPropType, alignPropType } from '../../util/shared-prop-types';
 import { toPopperPlacement, popperModifiers } from './PopoverService';
 
-const ButtonWrapper = styled('div')`
+const ReferenceWrapper = styled('div')`
   label: popover__button-wrapper;
   display: inline-block;
 `;
@@ -121,12 +121,12 @@ class Popover extends Component {
       <Manager>
         <Reference>
           {({ ref }) => (
-            <ButtonWrapper
+            <ReferenceWrapper
               innerRef={this.receiveButtonRef}
               onClick={this.handleReferenceClick}
             >
               <div ref={ref}>{renderReference()}</div>
-            </ButtonWrapper>
+            </ReferenceWrapper>
           )}
         </Reference>
         {isOpen && (

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -38,6 +38,10 @@ class Popover extends Component {
 
   static propTypes = {
     /**
+     * isOpen controlled prop
+     */
+    isOpen: PropTypes.bool.isRequired,
+    /**
      * function rendering the popover
      */
     renderPopover: PropTypes.func.isRequired,
@@ -54,27 +58,22 @@ class Popover extends Component {
      */
     align: alignPropType,
     /**
-     * A callback that is called when the Popover closes
+     * A callback that is called when the Popover should close
      */
-    onClose: PropTypes.func
+    onButtonClose: PropTypes.func.isRequired,
+    /**
+     * A callback that is called on outside click
+     */
+    onOutsideClickClose: PropTypes.func.isRequired
   };
 
   static defaultProps = {
     position: Popover.BOTTOM,
-    align: Popover.START,
-    onClose: () => {}
+    align: Popover.START
   };
-
-  state = { isOpen: false };
 
   componentDidMount() {
     document.addEventListener('click', this.handleDocumentClick, true);
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.isOpen && !this.state.isOpen) {
-      this.props.onClose();
-    }
   }
 
   componentWillUnmount() {
@@ -86,7 +85,7 @@ class Popover extends Component {
     const isWithinButton = this.buttonRef && this.buttonRef.contains(target);
 
     if (!isWithinButton && !isWithinPopover) {
-      this.closePopover();
+      this.props.onOutsideClickClose();
     }
   };
 
@@ -101,14 +100,21 @@ class Popover extends Component {
     this.popoverRef = ref;
   };
 
-  handleReferenceClick = () =>
-    this.setState(({ isOpen }) => ({ isOpen: !isOpen }));
-
-  closePopover = () => this.setState({ isOpen: false });
+  handleReferenceClick = () => {
+    const { isOpen } = this.props;
+    if (isOpen) {
+      this.props.onButtonClose();
+    }
+  };
 
   render() {
-    const { renderPopover, renderReference, position, align } = this.props;
-    const { isOpen } = this.state;
+    const {
+      renderPopover,
+      renderReference,
+      position,
+      align,
+      isOpen
+    } = this.props;
 
     return (
       <Manager>
@@ -129,9 +135,7 @@ class Popover extends Component {
           {({ ref, style }) =>
             isOpen && (
               <PopoverWrapper style={style} innerRef={this.receivePopoverRef}>
-                <div ref={ref}>
-                  {renderPopover({ closePopover: this.closePopover })}
-                </div>
+                <div ref={ref}>{renderPopover()}</div>
               </PopoverWrapper>
             )
           }

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -40,7 +40,7 @@ class Popover extends Component {
     /**
      * isOpen controlled prop
      */
-    isOpen: PropTypes.bool.isRequired,
+    isOpen: PropTypes.bool,
     /**
      * function rendering the popover
      */
@@ -68,6 +68,7 @@ class Popover extends Component {
   };
 
   static defaultProps = {
+    isOpen: false,
     position: Popover.BOTTOM,
     align: Popover.START
   };
@@ -124,22 +125,22 @@ class Popover extends Component {
               innerRef={this.receiveButtonRef}
               onClick={this.handleReferenceClick}
             >
-              <div ref={ref}>{renderReference({ isOpen })}</div>
+              <div ref={ref}>{renderReference()}</div>
             </ButtonWrapper>
           )}
         </Reference>
-        <Popper
-          placement={toPopperPlacement(position, align)}
-          modifiers={popperModifiers}
-        >
-          {({ ref, style }) =>
-            isOpen && (
+        {isOpen && (
+          <Popper
+            placement={toPopperPlacement(position, align)}
+            modifiers={popperModifiers}
+          >
+            {({ ref, style }) => (
               <PopoverWrapper style={style} innerRef={this.receivePopoverRef}>
                 <div ref={ref}>{renderPopover()}</div>
               </PopoverWrapper>
-            )
-          }
-        </Popper>
+            )}
+          </Popper>
+        )}
       </Manager>
     );
   }

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -58,11 +58,11 @@ class Popover extends Component {
      */
     align: alignPropType,
     /**
-     * A callback that is called when the Popover should close
+     * A callback that is called when the popover should be closed when reference is clicked in an open state
      */
-    onButtonClose: PropTypes.func.isRequired,
+    onReferenceClickClose: PropTypes.func.isRequired,
     /**
-     * A callback that is called on outside click
+     * A callback that is called on click outside the popover wrapper or the reference
      */
     onOutsideClickClose: PropTypes.func.isRequired
   };
@@ -103,7 +103,7 @@ class Popover extends Component {
   handleReferenceClick = () => {
     const { isOpen } = this.props;
     if (isOpen) {
-      this.props.onButtonClose();
+      this.props.onReferenceClickClose();
     }
   };
 

--- a/src/components/Popover/Popover.spec.js
+++ b/src/components/Popover/Popover.spec.js
@@ -71,7 +71,7 @@ describe('Popover', () => {
         onReferenceClickClose={onReferenceClickClose}
       />
     );
-    actual.find('ButtonWrapper').simulate('click');
+    actual.find('ReferenceWrapper').simulate('click');
     expect(onReferenceClickClose).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/Popover/Popover.story.js
+++ b/src/components/Popover/Popover.story.js
@@ -18,6 +18,7 @@ class PopoverContainer extends Component {
 
   render() {
     const { closeOnButtonClick, ...restProps } = this.props;
+    const { isOpen } = this.state;
 
     return (
       <Popover
@@ -31,10 +32,10 @@ class PopoverContainer extends Component {
               width: '200px'
             }}
           >
-            Popover Content
+            Popover Content {typeof closeOnButtonClick}
           </div>
         )}
-        renderReference={({ isOpen }) => (
+        renderReference={() => (
           <Button
             primary={isOpen}
             size={Button.KILO}
@@ -43,7 +44,7 @@ class PopoverContainer extends Component {
             Button
           </Button>
         )}
-        onButtonClose={() =>
+        onReferenceClickClose={() =>
           closeOnButtonClick && this.setState({ isOpen: false })
         }
         onOutsideClickClose={() => this.setState({ isOpen: false })}

--- a/src/components/Popover/Popover.story.js
+++ b/src/components/Popover/Popover.story.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
-import { select } from '@storybook/addon-knobs/react';
-import { action } from '@storybook/addon-actions';
+import { select, boolean } from '@storybook/addon-knobs/react';
 
 import { GROUPS } from '../../../.storybook/hierarchySeparators';
 
@@ -13,32 +13,59 @@ import Button from '../Button';
 const positions = [Popover.TOP, Popover.BOTTOM, Popover.LEFT, Popover.RIGHT];
 const alignments = [Popover.START, Popover.END, Popover.CENTER];
 
+class PopoverContainer extends Component {
+  state = { isOpen: false };
+
+  render() {
+    const { closeOnButtonClick, ...restProps } = this.props;
+
+    return (
+      <Popover
+        {...this.state}
+        {...restProps}
+        renderPopover={() => (
+          <div
+            style={{
+              background: '#EEEEEE',
+              padding: '10px',
+              width: '200px'
+            }}
+          >
+            Popover Content
+          </div>
+        )}
+        renderReference={({ isOpen }) => (
+          <Button
+            primary={isOpen}
+            size={Button.KILO}
+            onClick={() => this.setState({ isOpen: true })}
+          >
+            Button
+          </Button>
+        )}
+        onButtonClose={() =>
+          closeOnButtonClick && this.setState({ isOpen: false })
+        }
+        onOutsideClickClose={() => this.setState({ isOpen: false })}
+      />
+    );
+  }
+}
+
+PopoverContainer.propTypes = {
+  closeOnButtonClick: PropTypes.bool.isRequired
+};
+
 storiesOf(`${GROUPS.COMPONENTS}|Popover`, module)
   .addDecorator(withTests('Popover'))
   .add(
     'Default Popover',
     withInfo()(() => (
       <div>
-        <Popover
-          onClose={action('onClose')}
+        <PopoverContainer
           position={select('position', positions, Popover.BOTTOM)}
           align={select('align', alignments, Popover.START)}
-          renderPopover={() => (
-            <div
-              style={{
-                background: '#EEEEEE',
-                padding: '10px',
-                width: '200px'
-              }}
-            >
-              Popover Content
-            </div>
-          )}
-          renderReference={({ isOpen }) => (
-            <Button primary={isOpen} size={Button.KILO}>
-              Button
-            </Button>
-          )}
+          closeOnButtonClick={boolean('closeOnButton', false)}
         />
       </div>
     ))

--- a/src/components/Popover/__snapshots__/Popover.spec.js.snap
+++ b/src/components/Popover/__snapshots__/Popover.spec.js.snap
@@ -1,196 +1,482 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Popover should render with default styles 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position bottom and alignment center 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position bottom and alignment end 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position bottom and alignment start 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position left and alignment center 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position left and alignment end 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position left and alignment start 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position right and alignment center 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position right and alignment end 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position right and alignment start 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position top and alignment center 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position top and alignment end 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;
 
 exports[`Popover should render with position top and alignment start 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: inline-block;
 }
 
 <div
-  className="circuit-0 circuit-1"
-  onClick={[Function]}
->
-  <div>
-    <span />
-  </div>
-</div>
+    className="circuit-0 circuit-1"
+    onClick={[Function]}
+  >
+    <div>
+      <span />
+    </div>
+  </div>,
+  .circuit-0 {
+  z-index: 20;
+}
+
+<div
+    className="circuit-0 circuit-1"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
+  >
+    <div>
+      <div />
+    </div>
+  </div>,
+]
 `;


### PR DESCRIPTION
Refactor `<Popover />` as controlled component. Now the users of the component should deal with displaying/hiding the popover with callbacks helping them. The generic case is still almost the same with giving more control for more specific cases. Also generally simplifies both the Popover and the components using it and actually makes tests easier to write.

**Changes**
* Receive `isOpen` props and `onReferenceClickClose` / `onOutsideClickClose` 
* Remove `closePopover` prop passed `renderPopover`
* Remove `isOpen` prop passed to `renderReference`