### PR TITLE
Rollback react-text-mask to fixed version due to PureComponent bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "react-emotion": "^9.1.1",
     "react-modal": "^3.3.2",
     "react-popper": "^1.0.0-beta.6",
-    "react-text-mask": "^5.3.1",
+    "react-text-mask": "5.4.0",
     "react-with-styles": "^3.1.1",
     "recompose": "^0.26.0",
     "text-mask-addons": "^3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8162,9 +8162,9 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.2.0:
     prop-types "^15.6.0"
     react-is "^16.4.0"
 
-react-text-mask@^5.3.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/react-text-mask/-/react-text-mask-5.4.1.tgz#c3dd3e550e31d38b7c9da0178a2725960770e443"
+react-text-mask@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-text-mask/-/react-text-mask-5.4.0.tgz#4472eb2f0b9d8916017a2532c864707d51b98cf1"
   dependencies:
     prop-types "^15.5.6"
 


### PR DESCRIPTION
Due to: https://github.com/text-mask/text-mask/issues/813 Our masked input component won't update when new props are passed down (such as new mask patterns)

This should be temporarily until it's fixed on react-text-mask lib.