### PR TITLE
[BUG] Forward additional props to the Button

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { pick } from 'lodash/fp';
+import { omit } from 'lodash/fp';
 
 import { sizes } from '../../styles/constants';
 
@@ -8,8 +8,7 @@ import RegularButton from './components/RegularButton';
 import {
   BUTTON_PROP_TYPES,
   BUTTON_DEFAULT_PROPS,
-  PLAIN_BUTTON_PROPS,
-  BUTTON_PROPS
+  REGULAR_BUTTON_ONLY_PROPS
 } from './constants';
 
 const { KILO, MEGA, GIGA } = sizes;
@@ -20,9 +19,9 @@ const { KILO, MEGA, GIGA } = sizes;
  */
 const Button = ({ plain, ...props }) =>
   plain ? (
-    <PlainButton {...pick(PLAIN_BUTTON_PROPS, props)} />
+    <PlainButton {...omit(REGULAR_BUTTON_ONLY_PROPS, props)} />
   ) : (
-    <RegularButton {...pick(BUTTON_PROPS, props)} />
+    <RegularButton {...props} />
   );
 
 Button.propTypes = BUTTON_PROP_TYPES;

--- a/src/components/Button/constants.js
+++ b/src/components/Button/constants.js
@@ -60,28 +60,11 @@ export const BUTTON_DEFAULT_PROPS = {
   target: null
 };
 
-const SHARED_PROPS = [
-  'children',
-  'className',
-  'data-selector',
-  'disabled',
-  'href',
-  'onClick',
-  'primary',
-  'size',
-  'type'
-];
-
-export const BUTTON_PROPS = [
-  ...SHARED_PROPS,
+export const REGULAR_BUTTON_ONLY_PROPS = [
   'blacklist',
   'deepRef',
   'element',
   'flat',
   'secondary',
-  'size',
-  'stretch',
-  'target'
+  'stretch'
 ];
-
-export const PLAIN_BUTTON_PROPS = [...SHARED_PROPS, 'size', 'target'];

--- a/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
+++ b/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
@@ -270,60 +270,6 @@ exports[`LoadingButton Style tests should have default styles 1`] = `
 `;
 
 exports[`LoadingButton Style tests should have isLoading styles 1`] = `
-.circuit-9 {
-  background-color: #FAFBFC;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
-  display: block;
-  color: #5C656F;
-  cursor: pointer;
-  font-weight: 700;
-  width: auto;
-  height: auto;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 15px;
-  line-height: 24px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-9:active {
-  background-color: #D8DDE1;
-  border-color: #9DA7B1;
-  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
-}
-
-.circuit-9:focus {
-  border-color: #9DA7B1;
-  border-width: 2px;
-  outline: 0;
-  padding: calc(8px - 1px) calc(24px - 1px);
-}
-
-.circuit-9:hover {
-  background-color: #D8DDE1;
-}
-
-.circuit-9:hover,
-.circuit-9:active {
-  border-color: #9DA7B1;
-  border-width: 1px;
-  padding: calc(8px - 0px) calc(24px - 0px);
-}
-
-.circuit-9[disabled],
-.circuit-9:disabled {
-  opacity: 0.4;
-  pointer-events: none;
-  -webkit-user-selectable: none;
-  -moz-user-selectable: none;
-  -ms-user-selectable: none;
-  user-selectable: none;
-}
-
 .circuit-7 {
   position: relative;
 }
@@ -362,6 +308,62 @@ exports[`LoadingButton Style tests should have isLoading styles 1`] = `
   -webkit-transition: opacity 200ms ease-in-out,-webkit-transform 200ms ease-in-out;
   -webkit-transition: opacity 200ms ease-in-out,transform 200ms ease-in-out;
   transition: opacity 200ms ease-in-out,transform 200ms ease-in-out;
+}
+
+.circuit-9 {
+  background-color: #FAFBFC;
+  border-color: #D8DDE1;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 1px rgba(255,255,255,0.06);
+  display: block;
+  color: #5C656F;
+  cursor: pointer;
+  font-weight: 700;
+  width: auto;
+  height: auto;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 15px;
+  line-height: 24px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+  overflow-y: hidden;
+  pointer-events: none;
+}
+
+.circuit-9:active {
+  background-color: #D8DDE1;
+  border-color: #9DA7B1;
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
+}
+
+.circuit-9:focus {
+  border-color: #9DA7B1;
+  border-width: 2px;
+  outline: 0;
+  padding: calc(8px - 1px) calc(24px - 1px);
+}
+
+.circuit-9:hover {
+  background-color: #D8DDE1;
+}
+
+.circuit-9:hover,
+.circuit-9:active {
+  border-color: #9DA7B1;
+  border-width: 1px;
+  padding: calc(8px - 0px) calc(24px - 0px);
+}
+
+.circuit-9[disabled],
+.circuit-9:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+  -webkit-user-selectable: none;
+  -moz-user-selectable: none;
+  -ms-user-selectable: none;
+  user-selectable: none;
 }
 
 <button


### PR DESCRIPTION
## Changes

- Blacklist regular button props. Previously, the props were whitelisted, which prevented additional props from being passed.
- Incidentally, this also fixes a previously unknown bug in the LoadingButton component, which would remain clickable in its loading state because the `isLoading` prop wasn't passed down to the RegularButton.