### PR TITLE
Make font sizes responsive

### DIFF
--- a/src/components/Blockquote/__snapshots__/Blockquote.spec.js.snap
+++ b/src/components/Blockquote/__snapshots__/Blockquote.spec.js.snap
@@ -26,13 +26,20 @@ exports[`Blockquote should render with giga styles 1`] = `
 .circuit-1 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 18px;
-  line-height: 28px;
+  font-size: 15px;
+  line-height: 24px;
   font-style: italic;
   padding-left: 12px;
   border-left: 2px solid #3388FF;
   padding-left: 16px;
   border-left: 3px solid #3388FF;
+}
+
+@media (min-width:480px) {
+  .circuit-1 {
+    font-size: 18px;
+    line-height: 28px;
+  }
 }
 
 <blockquote

--- a/src/components/Blockquote/__snapshots__/Blockquote.spec.js.snap
+++ b/src/components/Blockquote/__snapshots__/Blockquote.spec.js.snap
@@ -11,6 +11,13 @@ exports[`Blockquote should render with default styles 1`] = `
   border-left: 2px solid #3388FF;
 }
 
+@media (min-width:480px) {
+  .circuit-1 {
+    font-size: 13px;
+    line-height: 20px;
+  }
+}
+
 <blockquote
   className="circuit-0 circuit-1 circuit-2"
 >
@@ -62,6 +69,13 @@ exports[`Blockquote should render with mega styles 1`] = `
   font-style: italic;
   padding-left: 12px;
   border-left: 2px solid #3388FF;
+}
+
+@media (min-width:480px) {
+  .circuit-1 {
+    font-size: 15px;
+    line-height: 24px;
+  }
 }
 
 <blockquote

--- a/src/components/Button/components/PlainButton/__snapshots__/PlainButton.spec.js.snap
+++ b/src/components/Button/components/PlainButton/__snapshots__/PlainButton.spec.js.snap
@@ -60,6 +60,13 @@ exports[`PlainButton should have kilo link styles 1`] = `
   outline: none;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 13px;
+    line-height: 20px;
+  }
+}
+
 .circuit-0:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -94,6 +101,13 @@ exports[`PlainButton should have mega link styles 1`] = `
   color: #9DA7B1;
   cursor: pointer;
   outline: none;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
 }
 
 .circuit-0:hover {
@@ -131,6 +145,13 @@ exports[`PlainButton should have primary styles 1`] = `
   cursor: pointer;
   outline: none;
   color: #3388FF;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
 }
 
 .circuit-0:hover {
@@ -173,6 +194,13 @@ exports[`PlainButton should render with default styles 1`] = `
   outline: none;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
+}
+
 .circuit-0:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -207,6 +235,13 @@ exports[`PlainButton should render with href 1`] = `
   color: #9DA7B1;
   cursor: pointer;
   outline: none;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
 }
 
 .circuit-0:hover {

--- a/src/components/Button/components/PlainButton/__snapshots__/PlainButton.spec.js.snap
+++ b/src/components/Button/components/PlainButton/__snapshots__/PlainButton.spec.js.snap
@@ -4,8 +4,8 @@ exports[`PlainButton should have giga link styles 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 18px;
-  line-height: 28px;
+  font-size: 15px;
+  line-height: 24px;
   margin-bottom: 0;
   box-shadow: none;
   border: none;
@@ -15,6 +15,13 @@ exports[`PlainButton should have giga link styles 1`] = `
   color: #9DA7B1;
   cursor: pointer;
   outline: none;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 18px;
+    line-height: 28px;
+  }
 }
 
 .circuit-0:hover {

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -8,7 +8,7 @@ import { sizes } from '../../styles/constants';
 
 const { KILO, MEGA, GIGA, TERA, PETA, EXA, ZETTA } = sizes;
 
-const responsiveMap = {
+const mobileSizeMap = {
   [KILO]: KILO,
   [MEGA]: MEGA,
   [GIGA]: MEGA,
@@ -27,8 +27,8 @@ const baseStyles = ({ theme }) => css`
 const sizeStyles = ({ theme, size }) =>
   css`
     label: heading--${size};
-    font-size: ${theme.typography.headings[responsiveMap[size]].fontSize};
-    line-height: ${theme.typography.headings[responsiveMap[size]].lineHeight};
+    font-size: ${theme.typography.headings[mobileSizeMap[size]].fontSize};
+    line-height: ${theme.typography.headings[mobileSizeMap[size]].lineHeight};
 
     ${theme.mq.kilo`
       font-size: ${theme.typography.headings[size].fontSize};

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -8,17 +8,33 @@ import { sizes } from '../../styles/constants';
 
 const { KILO, MEGA, GIGA, TERA, PETA, EXA, ZETTA } = sizes;
 
+const responsiveMap = {
+  [KILO]: KILO,
+  [MEGA]: MEGA,
+  [GIGA]: MEGA,
+  [TERA]: GIGA,
+  [PETA]: TERA,
+  [EXA]: PETA,
+  [ZETTA]: PETA
+};
+
 const baseStyles = ({ theme }) => css`
   label: heading;
   font-weight: ${theme.fontWeight.bold};
   margin-bottom: ${theme.spacings.giga};
 `;
 
-const sizeStyles = ({ theme, size }) => css`
-  label: heading--${size};
-  font-size: ${theme.typography.headings[size].fontSize};
-  line-height: ${theme.typography.headings[size].lineHeight};
-`;
+const sizeStyles = ({ theme, size }) =>
+  css`
+    label: heading--${size};
+    font-size: ${theme.typography.headings[responsiveMap[size]].fontSize};
+    line-height: ${theme.typography.headings[responsiveMap[size]].lineHeight};
+
+    ${theme.mq.kilo`
+      font-size: ${theme.typography.headings[size].fontSize};
+      line-height: ${theme.typography.headings[size].lineHeight};
+    `};
+  `;
 
 const noMarginStyles = ({ noMargin }) =>
   noMargin &&

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -34,8 +34,7 @@ const HeadingElement = styled(HtmlElement)`
 `;
 
 /**
- * A heading flexible heading component capable of rendering using
- * different HTML tags.
+ * A flexible heading component capable of rendering using any HTML heading tag.
  */
 const Heading = props => (
   <HeadingElement {...props} blacklist={{ size: true, noMargin: true }} />

--- a/src/components/Heading/Heading.story.js
+++ b/src/components/Heading/Heading.story.js
@@ -1,66 +1,35 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { select, boolean, text } from '@storybook/addon-knobs/react';
+
 import { GROUPS } from '../../../.storybook/hierarchySeparators';
 
 import withTests from '../../util/withTests';
 import Heading from '.';
 
+const elements = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+const sizes = [
+  Heading.ZETTA,
+  Heading.EXA,
+  Heading.PETA,
+  Heading.TERA,
+  Heading.GIGA,
+  Heading.MEGA,
+  Heading.KILO
+];
+
 storiesOf(`${GROUPS.TYPOGRAPHY}|Heading`, module)
   .addDecorator(withTests('Heading'))
   .add(
-    'Zetta Heading with h1',
+    'Heading',
     withInfo()(() => (
-      <Heading element="h1" size={Heading.ZETTA}>
-        This is a zetta heading with an h1 element
-      </Heading>
-    ))
-  )
-  .add(
-    'Exa Heading with h2',
-    withInfo()(() => (
-      <Heading element="h2" size={Heading.EXA}>
-        This is an exa heading with an h2 element
-      </Heading>
-    ))
-  )
-  .add(
-    'Peta Heading with h3',
-    withInfo()(() => (
-      <Heading element="h3" size={Heading.PETA}>
-        This is a peta heading with an h3 element
-      </Heading>
-    ))
-  )
-  .add(
-    'Tera Heading with h4',
-    withInfo()(() => (
-      <Heading element="h4" size={Heading.TERA}>
-        This is a tera heading with an h4 element
-      </Heading>
-    ))
-  )
-  .add(
-    'Giga Heading with h5',
-    withInfo()(() => (
-      <Heading element="h5" size={Heading.GIGA}>
-        This is a giga heading with an h5 element
-      </Heading>
-    ))
-  )
-  .add(
-    'Mega Heading with h6',
-    withInfo()(() => (
-      <Heading element="h6" size={Heading.MEGA}>
-        This is a mega heading with an h6 element
-      </Heading>
-    ))
-  )
-  .add(
-    'Kilo Heading with h6',
-    withInfo()(() => (
-      <Heading element="h6" size={Heading.KILO}>
-        This is a kilo heading with an h6 element
+      <Heading
+        element={select('Element', elements, elements[0])}
+        size={select('Size', sizes, sizes[0])}
+        noMargin={boolean('No margin', false)}
+      >
+        {text('Text', 'This is a heading')}
       </Heading>
     ))
   );

--- a/src/components/Heading/__snapshots__/Heading.spec.js.snap
+++ b/src/components/Heading/__snapshots__/Heading.spec.js.snap
@@ -4,8 +4,15 @@ exports[`Heading should render as h1 element, when passed "h1" for the element p
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 32px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 28px;
+    line-height: 32px;
+  }
 }
 
 <h1
@@ -19,8 +26,15 @@ exports[`Heading should render as h2 element, when passed "h2" for the element p
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 32px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 28px;
+    line-height: 32px;
+  }
 }
 
 <h2
@@ -34,8 +48,15 @@ exports[`Heading should render as h3 element, when passed "h3" for the element p
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 32px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 28px;
+    line-height: 32px;
+  }
 }
 
 <h3
@@ -49,8 +70,15 @@ exports[`Heading should render as h4 element, when passed "h4" for the element p
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 32px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 28px;
+    line-height: 32px;
+  }
 }
 
 <h4
@@ -64,8 +92,15 @@ exports[`Heading should render as h5 element, when passed "h5" for the element p
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 32px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 28px;
+    line-height: 32px;
+  }
 }
 
 <h5
@@ -79,8 +114,15 @@ exports[`Heading should render as h6 element, when passed "h6" for the element p
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 32px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 28px;
+    line-height: 32px;
+  }
 }
 
 <h6
@@ -94,9 +136,16 @@ exports[`Heading should render with no margin styles when passed the noMargin pr
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 32px;
   margin-bottom: 0;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 28px;
+    line-height: 32px;
+  }
 }
 
 <h2
@@ -108,8 +157,15 @@ exports[`Heading should render with size exa, when passed "exa" for the size pro
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 36px;
-  line-height: 44px;
+  font-size: 28px;
+  line-height: 32px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 36px;
+    line-height: 44px;
+  }
 }
 
 <h2
@@ -123,8 +179,15 @@ exports[`Heading should render with size giga, when passed "giga" for the size p
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 22px;
+  font-size: 19px;
   line-height: 24px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 22px;
+    line-height: 24px;
+  }
 }
 
 <h2
@@ -142,6 +205,13 @@ exports[`Heading should render with size kilo, when passed "kilo" for the size p
   line-height: 24px;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 17px;
+    line-height: 24px;
+  }
+}
+
 <h2
   className="circuit-0 circuit-1"
 >
@@ -157,6 +227,13 @@ exports[`Heading should render with size mega, when passed "mega" for the size p
   line-height: 24px;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 19px;
+    line-height: 24px;
+  }
+}
+
 <h2
   className="circuit-0 circuit-1"
 >
@@ -168,8 +245,15 @@ exports[`Heading should render with size peta, when passed "peta" for the size p
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 32px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 28px;
+    line-height: 32px;
+  }
 }
 
 <h2
@@ -183,8 +267,15 @@ exports[`Heading should render with size tera, when passed "tera" for the size p
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 24px;
-  line-height: 32px;
+  font-size: 22px;
+  line-height: 24px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 24px;
+    line-height: 32px;
+  }
 }
 
 <h2
@@ -198,8 +289,15 @@ exports[`Heading should render with size zetta, when passed "zetta" for the size
 .circuit-0 {
   font-weight: 700;
   margin-bottom: 24px;
-  font-size: 42px;
-  line-height: 48px;
+  font-size: 28px;
+  line-height: 32px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 42px;
+    line-height: 48px;
+  }
 }
 
 <h2

--- a/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -8,6 +8,13 @@ exports[`Markdown should override HTML tags with React components 1`] = `
   line-height: 24px;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
+}
+
 .circuit-10 {
   display: block;
   height: auto;

--- a/src/components/SubHeading/SubHeading.js
+++ b/src/components/SubHeading/SubHeading.js
@@ -35,8 +35,8 @@ const SubHeadingElement = styled(HtmlElement)(
 );
 
 /**
- * A flexible component for subheadings. Capable of rendering using
- * different any of the heading HTML tags.
+ * A flexible subheading component capable of rendering using any HTML heading
+ * tag, except h1.
  */
 
 const SubHeading = props => (

--- a/src/components/SubHeading/SubHeading.story.js
+++ b/src/components/SubHeading/SubHeading.story.js
@@ -1,26 +1,27 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { select, boolean, text } from '@storybook/addon-knobs/react';
+
 import { GROUPS } from '../../../.storybook/hierarchySeparators';
 
 import withTests from '../../util/withTests';
 import SubHeading from '.';
 
+const elements = ['h2', 'h3', 'h4', 'h5', 'h6'];
+const sizes = [SubHeading.MEGA, SubHeading.KILO];
+
 storiesOf(`${GROUPS.TYPOGRAPHY}|SubHeading`, module)
   .addDecorator(withTests('SubHeading'))
   .add(
-    'Kilo SubHeading with h2',
+    'SubHeading',
     withInfo()(() => (
-      <SubHeading element="h2" size={SubHeading.KILO}>
-        This is an kilo SubHeading with an h2 element
-      </SubHeading>
-    ))
-  )
-  .add(
-    'Mega SubHeading with h3',
-    withInfo()(() => (
-      <SubHeading element="h3" size={SubHeading.MEGA}>
-        This is a mega SubHeading with an h3 element
+      <SubHeading
+        element={select('Element', elements, elements[0])}
+        size={select('Size', sizes, sizes[0])}
+        noMargin={boolean('No margin', false)}
+      >
+        {text('Text', 'This is a subheading')}
       </SubHeading>
     ))
   );

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -8,7 +8,7 @@ import { sizes } from '../../styles/constants';
 
 const { KILO, MEGA, GIGA } = sizes;
 
-const responsiveMap = {
+const mobileSizeMap = {
   [KILO]: KILO,
   [MEGA]: MEGA,
   [GIGA]: MEGA
@@ -23,8 +23,8 @@ const baseStyles = ({ theme }) => css`
 const sizeStyles = ({ theme, size }) =>
   css`
     label: text--${size};
-    font-size: ${theme.typography.text[responsiveMap[size]].fontSize};
-    line-height: ${theme.typography.text[responsiveMap[size]].lineHeight};
+    font-size: ${theme.typography.text[mobileSizeMap[size]].fontSize};
+    line-height: ${theme.typography.text[mobileSizeMap[size]].lineHeight};
 
     ${theme.mq.kilo`
       font-size: ${theme.typography.text[size].fontSize};

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -14,11 +14,34 @@ const baseStyles = ({ theme }) => css`
   margin-bottom: ${theme.spacings.mega};
 `;
 
-const sizeStyles = ({ theme, size }) => css`
-  label: text--${size};
-  font-size: ${theme.typography.text[size].fontSize};
-  line-height: ${theme.typography.text[size].lineHeight};
-`;
+const kiloStyles = ({ theme, size }) =>
+  size === KILO &&
+  css`
+    label: text--${KILO};
+    font-size: ${theme.typography.text[KILO].fontSize};
+    line-height: ${theme.typography.text[KILO].lineHeight};
+  `;
+
+const megaStyles = ({ theme, size }) =>
+  size === MEGA &&
+  css`
+    label: text--${MEGA};
+    font-size: ${theme.typography.text[MEGA].fontSize};
+    line-height: ${theme.typography.text[MEGA].lineHeight};
+  `;
+
+const gigaStyles = ({ theme, size }) =>
+  size === GIGA &&
+  css`
+    label: text--${GIGA};
+    font-size: ${theme.typography.text[MEGA].fontSize};
+    line-height: ${theme.typography.text[MEGA].lineHeight};
+
+    ${theme.mq.kilo`
+      font-size: ${theme.typography.text[GIGA].fontSize};
+      line-height: ${theme.typography.text[GIGA].lineHeight};
+    `};
+  `;
 
 const boldStyles = ({ theme, bold }) =>
   bold &&
@@ -43,7 +66,9 @@ const marginStyles = ({ noMargin }) =>
 
 const StyledText = styled(HtmlElement)`
   ${baseStyles};
-  ${sizeStyles};
+  ${kiloStyles};
+  ${megaStyles};
+  ${gigaStyles};
   ${marginStyles};
   ${boldStyles};
   ${italicStyles};

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -8,38 +8,27 @@ import { sizes } from '../../styles/constants';
 
 const { KILO, MEGA, GIGA } = sizes;
 
+const responsiveMap = {
+  [KILO]: KILO,
+  [MEGA]: MEGA,
+  [GIGA]: MEGA
+};
+
 const baseStyles = ({ theme }) => css`
   label: text;
   font-weight: ${theme.fontWeight.regular};
   margin-bottom: ${theme.spacings.mega};
 `;
 
-const kiloStyles = ({ theme, size }) =>
-  size === KILO &&
+const sizeStyles = ({ theme, size }) =>
   css`
-    label: text--${KILO};
-    font-size: ${theme.typography.text[KILO].fontSize};
-    line-height: ${theme.typography.text[KILO].lineHeight};
-  `;
-
-const megaStyles = ({ theme, size }) =>
-  size === MEGA &&
-  css`
-    label: text--${MEGA};
-    font-size: ${theme.typography.text[MEGA].fontSize};
-    line-height: ${theme.typography.text[MEGA].lineHeight};
-  `;
-
-const gigaStyles = ({ theme, size }) =>
-  size === GIGA &&
-  css`
-    label: text--${GIGA};
-    font-size: ${theme.typography.text[MEGA].fontSize};
-    line-height: ${theme.typography.text[MEGA].lineHeight};
+    label: text--${size};
+    font-size: ${theme.typography.text[responsiveMap[size]].fontSize};
+    line-height: ${theme.typography.text[responsiveMap[size]].lineHeight};
 
     ${theme.mq.kilo`
-      font-size: ${theme.typography.text[GIGA].fontSize};
-      line-height: ${theme.typography.text[GIGA].lineHeight};
+      font-size: ${theme.typography.text[size].fontSize};
+      line-height: ${theme.typography.text[size].lineHeight};
     `};
   `;
 
@@ -66,9 +55,7 @@ const marginStyles = ({ noMargin }) =>
 
 const StyledText = styled(HtmlElement)`
   ${baseStyles};
-  ${kiloStyles};
-  ${megaStyles};
-  ${gigaStyles};
+  ${sizeStyles};
   ${marginStyles};
   ${boldStyles};
   ${italicStyles};

--- a/src/components/Text/Text.story.js
+++ b/src/components/Text/Text.story.js
@@ -16,7 +16,7 @@ const content = `An electronic circuit is composed of individual electronic comp
 storiesOf(`${GROUPS.TYPOGRAPHY}|Text`, module)
   .addDecorator(withTests('Text'))
   .add(
-    'Default Text',
+    'Text',
     withInfo()(() => (
       <div style={{ width: '66%', margin: '0 auto' }}>
         <Text

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -8,6 +8,13 @@ exports[`Text should render as article element, when passed "article" for the el
   line-height: 24px;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
+}
+
 <article
   className="circuit-0 circuit-1"
 >
@@ -23,6 +30,13 @@ exports[`Text should render as div element, when passed "div" for the element pr
   line-height: 24px;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
+}
+
 <div
   className="circuit-0 circuit-1"
 >
@@ -36,6 +50,13 @@ exports[`Text should render as p element, when passed "p" for the element prop 1
   margin-bottom: 16px;
   font-size: 15px;
   line-height: 24px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
 }
 
 <p
@@ -54,6 +75,13 @@ exports[`Text should render bold text when passed the bold prop 1`] = `
   font-weight: 700;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
+}
+
 <p
   className="circuit-0 circuit-1"
 />
@@ -68,6 +96,13 @@ exports[`Text should render italic text when passed the italic prop 1`] = `
   font-style: italic;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
+}
+
 <p
   className="circuit-0 circuit-1"
 />
@@ -80,6 +115,13 @@ exports[`Text should render with no margin styles when passed the noMargin prop 
   font-size: 15px;
   line-height: 24px;
   margin-bottom: 0;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
 }
 
 <p
@@ -117,6 +159,13 @@ exports[`Text should render with size kilo, when passed "kilo" for the size prop
   line-height: 20px;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 13px;
+    line-height: 20px;
+  }
+}
+
 <p
   className="circuit-0 circuit-1"
 >
@@ -130,6 +179,13 @@ exports[`Text should render with size mega, when passed "mega" for the size prop
   margin-bottom: 16px;
   font-size: 15px;
   line-height: 24px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
 }
 
 <p

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -91,8 +91,15 @@ exports[`Text should render with size giga, when passed "giga" for the size prop
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 18px;
-  line-height: 28px;
+  font-size: 15px;
+  line-height: 24px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 18px;
+    line-height: 28px;
+  }
 }
 
 <p


### PR DESCRIPTION
## Changes

- Use knobs for Heading, SubHeading and Text components
- Add responsive font sizes for sizing Heading and Text components: on desktop viewports, the font-size matches the value of the size prop. On mobile (sub-kilo) viewports, the font size is scaled down by up to two size steps. Small sizes are not affected at all, large sizes scale down more. 