### PR TITLE
Improve ButtonGroup stacking on mobile

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -66,8 +66,8 @@ const ButtonGroupList = styled('ul')(
 /**
  * Groups its Button children into a list and adds margins between.
  */
-const ButtonGroup = ({ children, align, ...rest }) => (
-  <ButtonGroupList {...rest} align={align}>
+const ButtonGroup = ({ children, ...props }) => (
+  <ButtonGroupList {...props}>
     {Children.map(children, child => (child ? <li>{child}</li> : null))}
   </ButtonGroupList>
 );

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -7,17 +7,33 @@ import { directions } from '../../styles/constants';
 
 const ALIGMENT_TYPES = [directions.LEFT, directions.CENTER, directions.RIGHT];
 
+const getInlineStyles = theme => css`
+  display: flex;
+  flex-wrap: nowrap;
+
+  > li:not(:last-of-type) {
+    margin-bottom: 0;
+    margin-right: ${theme.spacings.mega};
+  }
+`;
+
 const baseStyles = ({ theme }) => css`
   label: button-group;
-  display: flex;
   list-style-type: none;
-  flex-wrap: nowrap;
   overflow: hidden;
   width: 100%;
 
-  > li:not(:last-of-type) {
-    margin-right: ${theme.spacings.mega};
+  > li {
+    &:not(:last-of-type) {
+      margin-bottom: ${theme.spacings.mega};
+    }
+
+    > * {
+      width: 100%;
+    }
   }
+
+  ${theme.mq.kilo(getInlineStyles(theme))};
 `;
 
 const alignmentStyles = ({ align }) => {
@@ -33,32 +49,18 @@ const alignmentStyles = ({ align }) => {
   `;
 };
 
-const stackedMobileStyles = ({ theme, stackedMobile }) =>
-  stackedMobile &&
+const inlineMobileStyles = ({ theme, inlineMobile }) =>
+  inlineMobile &&
   css`
-    label: button-group--stacked-mobile;
+    label: button-group--inline-mobile;
 
-    ${theme.mq.untilKilo`
-      display: block;
-
-      > li {
-        width: 100%;
-
-        &:not(:last-of-type) {
-          margin-bottom: ${theme.spacings.mega};
-        }
-
-        > * {
-          width: 100%;
-        }
-      }
-    `};
+    ${theme.mq.untilKilo(getInlineStyles(theme))};
   `;
 
 const ButtonGroupList = styled('ul')(
   baseStyles,
   alignmentStyles,
-  stackedMobileStyles
+  inlineMobileStyles
 );
 
 /**
@@ -84,14 +86,14 @@ ButtonGroup.propTypes = {
    */
   align: PropTypes.oneOf(ALIGMENT_TYPES),
   /**
-   * Whether to stack the buttons on mobile.
+   * Whether to display buttons inline on mobile.
    */
-  stackedMobile: PropTypes.bool
+  inlineMobile: PropTypes.bool
 };
 
 ButtonGroup.defaultProps = {
   align: ButtonGroup.RIGHT,
-  stackedMobile: true
+  inlineMobile: false
 };
 
 /**

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -68,7 +68,7 @@ const ButtonGroupList = styled('ul')(
  */
 const ButtonGroup = ({ children, align, ...rest }) => (
   <ButtonGroupList {...rest} align={align}>
-    {Children.map(children, child => <li>{child}</li>)}
+    {Children.map(children, child => (child ? <li>{child}</li> : null))}
   </ButtonGroupList>
 );
 

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -7,17 +7,18 @@ import { directions } from '../../styles/constants';
 
 const ALIGMENT_TYPES = [directions.LEFT, directions.CENTER, directions.RIGHT];
 
-const marginStyles = ({ theme, noMargin }) =>
-  !noMargin &&
-  css`
-    li:not(:last-of-type) {
-      margin-bottom: ${theme.spacings.mega};
+const baseStyles = ({ theme }) => css`
+  label: button-group;
+  display: flex;
+  list-style-type: none;
+  flex-wrap: nowrap;
+  overflow: hidden;
+  width: 100%;
 
-      ${theme.mq.kilo`
-        margin-bottom: 0;
-      `};
-    }
-  `;
+  > li:not(:last-of-type) {
+    margin-right: ${theme.spacings.mega};
+  }
+`;
 
 const alignmentStyles = ({ align }) => {
   const alignmentMap = {
@@ -32,39 +33,39 @@ const alignmentStyles = ({ align }) => {
   `;
 };
 
-const baseStyles = ({ theme }) => css`
-  label: button-group;
-  display: block;
-  list-style-type: none;
-  width: 100%;
+const stackedMobileStyles = ({ theme, stackedMobile }) =>
+  stackedMobile &&
+  css`
+    label: button-group--stacked-mobile;
 
-  > li {
-    width: 100%;
-    > button {
-      width: 100%;
-    }
-  }
+    ${theme.mq.untilKilo`
+      display: block;
 
-  ${theme.mq.kilo`
-    display: flex;
+      > li {
+        width: 100%;
 
-    > li {
-      width: auto;
-    }
+        &:not(:last-of-type) {
+          margin-bottom: ${theme.spacings.mega};
+        }
 
-    > li:not(:last-of-type) {
-      margin-right: ${theme.spacings.mega};
-    }
-  `};
-`;
+        > * {
+          width: 100%;
+        }
+      }
+    `};
+  `;
 
-const ButtonGroupList = styled('ul')(baseStyles, marginStyles, alignmentStyles);
+const ButtonGroupList = styled('ul')(
+  baseStyles,
+  alignmentStyles,
+  stackedMobileStyles
+);
 
 /**
  * Groups its Button children into a list and adds margins between.
  */
-const ButtonGroup = ({ children, align, noMargin, ...rest }) => (
-  <ButtonGroupList {...rest} align={align} noMargin={noMargin}>
+const ButtonGroup = ({ children, align, ...rest }) => (
+  <ButtonGroupList {...rest} align={align}>
     {Children.map(children, child => <li>{child}</li>)}
   </ButtonGroupList>
 );
@@ -79,18 +80,18 @@ ButtonGroup.propTypes = {
    */
   children: childrenPropType.isRequired,
   /**
-   * Removes the default bottom margin from the heading.
-   */
-  noMargin: PropTypes.bool,
-  /**
    * Direction to align the content. Either left/right
    */
-  align: PropTypes.oneOf(ALIGMENT_TYPES)
+  align: PropTypes.oneOf(ALIGMENT_TYPES),
+  /**
+   * Whether to stack the buttons on mobile.
+   */
+  stackedMobile: PropTypes.bool
 };
 
 ButtonGroup.defaultProps = {
   align: ButtonGroup.RIGHT,
-  noMargin: false
+  stackedMobile: true
 };
 
 /**

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -20,7 +20,6 @@ const getInlineStyles = theme => css`
 const baseStyles = ({ theme }) => css`
   label: button-group;
   list-style-type: none;
-  overflow: hidden;
   width: 100%;
 
   > li {

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -38,19 +38,22 @@ const baseStyles = ({ theme }) => css`
   list-style-type: none;
   width: 100%;
 
-  > * {
+  > li {
     width: 100%;
+    > button {
+      width: 100%;
+    }
   }
 
   ${theme.mq.kilo`
     display: flex;
 
-    li:not(:last-of-type) {
-      margin-right: ${theme.spacings.mega};
+    > li {
+      width: auto;
     }
 
-    > * {
-      width: auto;
+    > li:not(:last-of-type) {
+      margin-right: ${theme.spacings.mega};
     }
   `};
 `;

--- a/src/components/ButtonGroup/ButtonGroup.story.js
+++ b/src/components/ButtonGroup/ButtonGroup.story.js
@@ -13,17 +13,39 @@ storiesOf(`${GROUPS.COMPONENTS}|Button/ButtonGroup`, module)
   .add(
     'Default ButtonGroup',
     withInfo()(() => (
-      <div style={{ width: '500px', border: '1px dotted #000' }}>
+      <div
+        style={{ maxWidth: '500px', width: '100vw', border: '1px dotted #000' }}
+      >
         <ButtonGroup
           align={select(
             'Align',
             [ButtonGroup.LEFT, ButtonGroup.RIGHT],
             ButtonGroup.RIGHT
           )}
-          noMargin={boolean('No Margin Bottom', false)}
+          stackedMobile={boolean('Stacked on mobile', true)}
         >
           <Button secondary>Cancel</Button>
           <Button primary>Confirm</Button>
+        </ButtonGroup>
+      </div>
+    ))
+  )
+  .add(
+    'ButtonGroup with long button text',
+    withInfo()(() => (
+      <div
+        style={{ maxWidth: '500px', width: '100vw', border: '1px dotted #000' }}
+      >
+        <ButtonGroup
+          align={select(
+            'Align',
+            [ButtonGroup.LEFT, ButtonGroup.RIGHT],
+            ButtonGroup.RIGHT
+          )}
+          stackedMobile={boolean('Stacked on mobile', true)}
+        >
+          <Button secondary>This is some really long button text</Button>
+          <Button primary>This is also really long</Button>
         </ButtonGroup>
       </div>
     ))

--- a/src/components/ButtonGroup/ButtonGroup.story.js
+++ b/src/components/ButtonGroup/ButtonGroup.story.js
@@ -19,10 +19,10 @@ storiesOf(`${GROUPS.COMPONENTS}|Button/ButtonGroup`, module)
         <ButtonGroup
           align={select(
             'Align',
-            [ButtonGroup.LEFT, ButtonGroup.RIGHT],
+            [ButtonGroup.LEFT, ButtonGroup.CENTER, ButtonGroup.RIGHT],
             ButtonGroup.RIGHT
           )}
-          stackedMobile={boolean('Stacked on mobile', true)}
+          inlineMobile={boolean('Display inline on mobile', false)}
         >
           <Button secondary>Cancel</Button>
           <Button primary>Confirm</Button>

--- a/src/components/ButtonGroup/ButtonGroup.story.js
+++ b/src/components/ButtonGroup/ButtonGroup.story.js
@@ -29,24 +29,4 @@ storiesOf(`${GROUPS.COMPONENTS}|Button/ButtonGroup`, module)
         </ButtonGroup>
       </div>
     ))
-  )
-  .add(
-    'ButtonGroup with long button text',
-    withInfo()(() => (
-      <div
-        style={{ maxWidth: '500px', width: '100vw', border: '1px dotted #000' }}
-      >
-        <ButtonGroup
-          align={select(
-            'Align',
-            [ButtonGroup.LEFT, ButtonGroup.RIGHT],
-            ButtonGroup.RIGHT
-          )}
-          stackedMobile={boolean('Stacked on mobile', true)}
-        >
-          <Button secondary>This is some really long button text</Button>
-          <Button primary>This is also really long</Button>
-        </ButtonGroup>
-      </div>
-    ))
   );

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
@@ -2,14 +2,7 @@
 
 exports[`ButtonGroup Center aligment should render with center alignment styles 1`] = `
 .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   list-style-type: none;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
   overflow: hidden;
   width: 100%;
   -webkit-box-pack: center;
@@ -19,24 +12,27 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
 }
 
 .circuit-0 > li:not(:last-of-type) {
-  margin-right: 16px;
+  margin-bottom: 16px;
 }
 
-@media (max-width:479px) {
-  .circuit-0 {
-    display: block;
-  }
+.circuit-0 > li > * {
+  width: 100%;
+}
 
-  .circuit-0 > li {
-    width: 100%;
+@media (min-width:480px) {
+  .circuit-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
   }
 
   .circuit-0 > li:not(:last-of-type) {
-    margin-bottom: 16px;
-  }
-
-  .circuit-0 > li > * {
-    width: 100%;
+    margin-bottom: 0;
+    margin-right: 16px;
   }
 }
 
@@ -47,14 +43,7 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
 
 exports[`ButtonGroup Left aligment should render with left alignment styles 1`] = `
 .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   list-style-type: none;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
   overflow: hidden;
   width: 100%;
   -webkit-box-pack: start;
@@ -64,24 +53,27 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
 }
 
 .circuit-0 > li:not(:last-of-type) {
-  margin-right: 16px;
+  margin-bottom: 16px;
 }
 
-@media (max-width:479px) {
-  .circuit-0 {
-    display: block;
-  }
+.circuit-0 > li > * {
+  width: 100%;
+}
 
-  .circuit-0 > li {
-    width: 100%;
+@media (min-width:480px) {
+  .circuit-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
   }
 
   .circuit-0 > li:not(:last-of-type) {
-    margin-bottom: 16px;
-  }
-
-  .circuit-0 > li > * {
-    width: 100%;
+    margin-bottom: 0;
+    margin-right: 16px;
   }
 }
 
@@ -92,14 +84,7 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
 
 exports[`ButtonGroup No margin bottom should render without margin bottom styles 1`] = `
 .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   list-style-type: none;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
   overflow: hidden;
   width: 100%;
   -webkit-box-pack: end;
@@ -109,24 +94,27 @@ exports[`ButtonGroup No margin bottom should render without margin bottom styles
 }
 
 .circuit-0 > li:not(:last-of-type) {
-  margin-right: 16px;
+  margin-bottom: 16px;
 }
 
-@media (max-width:479px) {
-  .circuit-0 {
-    display: block;
-  }
+.circuit-0 > li > * {
+  width: 100%;
+}
 
-  .circuit-0 > li {
-    width: 100%;
+@media (min-width:480px) {
+  .circuit-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
   }
 
   .circuit-0 > li:not(:last-of-type) {
-    margin-bottom: 16px;
-  }
-
-  .circuit-0 > li > * {
-    width: 100%;
+    margin-bottom: 0;
+    margin-right: 16px;
   }
 }
 
@@ -137,14 +125,7 @@ exports[`ButtonGroup No margin bottom should render without margin bottom styles
 
 exports[`ButtonGroup should render with default styles 1`] = `
 .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   list-style-type: none;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
   overflow: hidden;
   width: 100%;
   -webkit-box-pack: end;
@@ -154,24 +135,27 @@ exports[`ButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-0 > li:not(:last-of-type) {
-  margin-right: 16px;
+  margin-bottom: 16px;
 }
 
-@media (max-width:479px) {
-  .circuit-0 {
-    display: block;
-  }
+.circuit-0 > li > * {
+  width: 100%;
+}
 
-  .circuit-0 > li {
-    width: 100%;
+@media (min-width:480px) {
+  .circuit-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
   }
 
   .circuit-0 > li:not(:last-of-type) {
-    margin-bottom: 16px;
-  }
-
-  .circuit-0 > li > * {
-    width: 100%;
+    margin-bottom: 0;
+    margin-right: 16px;
   }
 }
 

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
@@ -3,7 +3,6 @@
 exports[`ButtonGroup Center aligment should render with center alignment styles 1`] = `
 .circuit-0 {
   list-style-type: none;
-  overflow: hidden;
   width: 100%;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -44,7 +43,6 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
 exports[`ButtonGroup Left aligment should render with left alignment styles 1`] = `
 .circuit-0 {
   list-style-type: none;
-  overflow: hidden;
   width: 100%;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
@@ -85,7 +83,6 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
 exports[`ButtonGroup No margin bottom should render without margin bottom styles 1`] = `
 .circuit-0 {
   list-style-type: none;
-  overflow: hidden;
   width: 100%;
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;
@@ -126,7 +123,6 @@ exports[`ButtonGroup No margin bottom should render without margin bottom styles
 exports[`ButtonGroup should render with default styles 1`] = `
 .circuit-0 {
   list-style-type: none;
-  overflow: hidden;
   width: 100%;
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.js.snap
@@ -2,8 +2,15 @@
 
 exports[`ButtonGroup Center aligment should render with center alignment styles 1`] = `
 .circuit-0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style-type: none;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  overflow: hidden;
   width: 100%;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -11,34 +18,25 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   justify-content: center;
 }
 
-.circuit-0 > * {
-  width: 100%;
+.circuit-0 > li:not(:last-of-type) {
+  margin-right: 16px;
 }
 
-@media (min-width:480px) {
+@media (max-width:479px) {
   .circuit-0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
+    display: block;
   }
 
-  .circuit-0 li:not(:last-of-type) {
-    margin-right: 16px;
+  .circuit-0 > li {
+    width: 100%;
   }
 
-  .circuit-0 > * {
-    width: auto;
+  .circuit-0 > li:not(:last-of-type) {
+    margin-bottom: 16px;
   }
-}
 
-.circuit-0 li:not(:last-of-type) {
-  margin-bottom: 16px;
-}
-
-@media (min-width:480px) {
-  .circuit-0 li:not(:last-of-type) {
-    margin-bottom: 0;
+  .circuit-0 > li > * {
+    width: 100%;
   }
 }
 
@@ -49,8 +47,15 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
 
 exports[`ButtonGroup Left aligment should render with left alignment styles 1`] = `
 .circuit-0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style-type: none;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  overflow: hidden;
   width: 100%;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
@@ -58,34 +63,25 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
   justify-content: flex-start;
 }
 
-.circuit-0 > * {
-  width: 100%;
+.circuit-0 > li:not(:last-of-type) {
+  margin-right: 16px;
 }
 
-@media (min-width:480px) {
+@media (max-width:479px) {
   .circuit-0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
+    display: block;
   }
 
-  .circuit-0 li:not(:last-of-type) {
-    margin-right: 16px;
+  .circuit-0 > li {
+    width: 100%;
   }
 
-  .circuit-0 > * {
-    width: auto;
+  .circuit-0 > li:not(:last-of-type) {
+    margin-bottom: 16px;
   }
-}
 
-.circuit-0 li:not(:last-of-type) {
-  margin-bottom: 16px;
-}
-
-@media (min-width:480px) {
-  .circuit-0 li:not(:last-of-type) {
-    margin-bottom: 0;
+  .circuit-0 > li > * {
+    width: 100%;
   }
 }
 
@@ -96,8 +92,15 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
 
 exports[`ButtonGroup No margin bottom should render without margin bottom styles 1`] = `
 .circuit-0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style-type: none;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  overflow: hidden;
   width: 100%;
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;
@@ -105,24 +108,25 @@ exports[`ButtonGroup No margin bottom should render without margin bottom styles
   justify-content: flex-end;
 }
 
-.circuit-0 > * {
-  width: 100%;
+.circuit-0 > li:not(:last-of-type) {
+  margin-right: 16px;
 }
 
-@media (min-width:480px) {
+@media (max-width:479px) {
   .circuit-0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
+    display: block;
   }
 
-  .circuit-0 li:not(:last-of-type) {
-    margin-right: 16px;
+  .circuit-0 > li {
+    width: 100%;
   }
 
-  .circuit-0 > * {
-    width: auto;
+  .circuit-0 > li:not(:last-of-type) {
+    margin-bottom: 16px;
+  }
+
+  .circuit-0 > li > * {
+    width: 100%;
   }
 }
 
@@ -133,8 +137,15 @@ exports[`ButtonGroup No margin bottom should render without margin bottom styles
 
 exports[`ButtonGroup should render with default styles 1`] = `
 .circuit-0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   list-style-type: none;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  overflow: hidden;
   width: 100%;
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;
@@ -142,34 +153,25 @@ exports[`ButtonGroup should render with default styles 1`] = `
   justify-content: flex-end;
 }
 
-.circuit-0 > * {
-  width: 100%;
+.circuit-0 > li:not(:last-of-type) {
+  margin-right: 16px;
 }
 
-@media (min-width:480px) {
+@media (max-width:479px) {
   .circuit-0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
+    display: block;
   }
 
-  .circuit-0 li:not(:last-of-type) {
-    margin-right: 16px;
+  .circuit-0 > li {
+    width: 100%;
   }
 
-  .circuit-0 > * {
-    width: auto;
+  .circuit-0 > li:not(:last-of-type) {
+    margin-bottom: 16px;
   }
-}
 
-.circuit-0 li:not(:last-of-type) {
-  margin-bottom: 16px;
-}
-
-@media (min-width:480px) {
-  .circuit-0 li:not(:last-of-type) {
-    margin-bottom: 0;
+  .circuit-0 > li > * {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Changes:

- Removes the `noMargin` prop, as this was copied from the `Text` component and dealt with bottom margin. Buttons are usually at the bottom of a UI element and should not have bottom margin to begin with.
- Adds a `stackedOnMobile` prop, which defaults to `true`. This ensures buttons in a `ButtonGroup` are full-width and stacked on mobile devices. Setting the prop to `false` will keep the default behavior of inlining them inside a flexbox container.