### PR TITLE
Limit width of cardscheme icons on IE

### DIFF
--- a/src/components/CardSchemes/__snapshots__/CardSchemes.spec.js.snap
+++ b/src/components/CardSchemes/__snapshots__/CardSchemes.spec.js.snap
@@ -16,6 +16,7 @@ exports[`CardSchemes should render with default styles 1`] = `
 .circuit-0 {
   height: 32px;
   width: auto;
+  max-width: 56px;
 }
 
 <ul

--- a/src/components/CardSchemes/components/PaymentMethodIcon/PaymentMethodIcon.js
+++ b/src/components/CardSchemes/components/PaymentMethodIcon/PaymentMethodIcon.js
@@ -12,6 +12,7 @@ const { BYTE, KILO, MEGA, GIGA } = sizes;
 const PaymentMethodIconWrapBaseStyles = ({ theme, size }) => css`
   height: ${theme.iconSizes[size]};
   width: auto;
+  max-width: ${theme.spacings.zetta};
 `;
 
 const PaymentMethodIconWrap = styled('div')(PaymentMethodIconWrapBaseStyles);
@@ -30,6 +31,7 @@ const PaymentMethodIcon = ({ iconId, size }) => {
     <PaymentMethodIconWrap size={size}>
       <IconSvg css="
           width: auto;
+          max-width: 100%;
           height: 100%;
           display: inline-block;
           line-height: 0;

--- a/src/components/CardSchemes/components/PaymentMethodIcon/__snapshots__/PaymentMethodIcon.spec.js.snap
+++ b/src/components/CardSchemes/components/PaymentMethodIcon/__snapshots__/PaymentMethodIcon.spec.js.snap
@@ -4,6 +4,7 @@ exports[`PaymentMethodIcon should render with default styles 1`] = `
 .circuit-0 {
   height: 16px;
   width: auto;
+  max-width: 56px;
 }
 
 <div


### PR DESCRIPTION
On IE11, the card scheme icons take up too much width.

_Old_

![screenshot 2018-07-24 13 12 23](https://user-images.githubusercontent.com/11017722/43134776-715f2782-8f43-11e8-84d4-6ea4d53ff833.png)

_New_

![screenshot 2018-07-24 13 13 10](https://user-images.githubusercontent.com/11017722/43134766-67a868c0-8f43-11e8-9204-e01c262cf2c9.png)
