### PR TITLE
Ensure (Regular)Button text is always centered

### DIFF
--- a/src/components/Button/components/RegularButton/RegularButton.js
+++ b/src/components/Button/components/RegularButton/RegularButton.js
@@ -55,6 +55,7 @@ const baseStyles = ({ theme, href, ...otherProps }) => css`
   font-weight: ${theme.fontWeight.bold};
   width: auto;
   height: auto;
+  text-align: center;
   text-decoration: none;
   ${textMega({ theme })};
 

--- a/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
+++ b/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
@@ -14,6 +14,7 @@ exports[`RegularButton should have button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -79,6 +80,7 @@ exports[`RegularButton should have disabled button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -144,6 +146,7 @@ exports[`RegularButton should have flat button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -227,6 +230,7 @@ exports[`RegularButton should have flat disabled button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -310,6 +314,7 @@ exports[`RegularButton should have giga button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -375,6 +380,7 @@ exports[`RegularButton should have kilo button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -440,6 +446,7 @@ exports[`RegularButton should have mega button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -505,6 +512,7 @@ exports[`RegularButton should have secondary button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -616,6 +624,7 @@ exports[`RegularButton should have secondary disabled button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -727,6 +736,7 @@ exports[`RegularButton should have secondary flat button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -838,6 +848,7 @@ exports[`RegularButton should have stretch button styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;

--- a/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
+++ b/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
@@ -14,6 +14,7 @@ exports[`Container Container Style tests should have default styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;

--- a/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
+++ b/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
@@ -14,6 +14,7 @@ exports[`LoadingButton Style tests should have active loading styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -150,6 +151,7 @@ exports[`LoadingButton Style tests should have default styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;
@@ -321,6 +323,7 @@ exports[`LoadingButton Style tests should have isLoading styles 1`] = `
   font-weight: 700;
   width: auto;
   height: auto;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 15px;


### PR DESCRIPTION
Once using #246 with some variants of the (Regular)Button, text wasn't centered once buttons were stretched to the width of the container.

This PR attempts to fix that.