### PR TITLE
Refactor <Checkbox /> prop/default passing

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -126,17 +126,11 @@ const CheckboxWrapper = styled('div')`
 /**
  * Checkbox component for forms.
  */
-const Checkbox = ({
-  onChange,
-  children,
-  id: customId,
-  className,
-  ...props
-}) => {
+const Checkbox = ({ children, id: customId, className, ...props }) => {
   const id = customId || uniqueId('checkbox_');
   return (
     <CheckboxWrapper className={className}>
-      <CheckboxInput {...props} id={id} onClick={onChange} type="checkbox" />
+      <CheckboxInput {...props} id={id} type="checkbox" />
       <CheckboxLabel {...props} htmlFor={id}>
         {children}
       </CheckboxLabel>
@@ -146,17 +140,9 @@ const Checkbox = ({
 
 Checkbox.propTypes = {
   /**
-   * Controles/Toggles the checked state.
-   */
-  onChange: PropTypes.func.isRequired,
-  /**
    * Value string for input.
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.bool,
-    PropTypes.array
-  ]),
+  value: PropTypes.string,
   /**
    * Child nodes to be rendered as the label.
    */
@@ -192,7 +178,7 @@ Checkbox.propTypes = {
 Checkbox.defaultProps = {
   id: null,
   checked: false,
-  value: null,
+  value: '',
   invalid: false,
   disabled: false,
   children: null,

--- a/src/components/Checkbox/Checkbox.spec.js
+++ b/src/components/Checkbox/Checkbox.spec.js
@@ -52,9 +52,9 @@ describe('Checkbox', () => {
   });
 
   it('should call onChange when toggled', () => {
-    const wrapper = shallow(<Checkbox {...{ onChange }} />);
+    const wrapper = shallow(<Checkbox {...{ name, onChange }} />);
     const label = wrapper.find('CheckboxInput');
-    label.simulate('click');
+    label.simulate('change');
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -91,9 +91,9 @@ exports[`Checkbox should render with checked styles when passed the checked prop
     disabled={false}
     id="checkbox_2"
     name="name"
-    onClick={[MockFunction]}
+    onChange={[MockFunction]}
     type="checkbox"
-    value={null}
+    value=""
   />
   <label
     checked={true}
@@ -101,7 +101,8 @@ exports[`Checkbox should render with checked styles when passed the checked prop
     disabled={false}
     htmlFor="checkbox_2"
     name="name"
-    value={null}
+    onChange={[MockFunction]}
+    value=""
   />
 </div>
 `;
@@ -197,9 +198,9 @@ exports[`Checkbox should render with default styles 1`] = `
     disabled={false}
     id="checkbox_1"
     name="name"
-    onClick={[MockFunction]}
+    onChange={[MockFunction]}
     type="checkbox"
-    value={null}
+    value=""
   />
   <label
     checked={false}
@@ -207,7 +208,8 @@ exports[`Checkbox should render with default styles 1`] = `
     disabled={false}
     htmlFor="checkbox_1"
     name="name"
-    value={null}
+    onChange={[MockFunction]}
+    value=""
   />
 </div>
 `;
@@ -321,9 +323,9 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
     disabled={true}
     id="checkbox_3"
     name="name"
-    onClick={[MockFunction]}
+    onChange={[MockFunction]}
     type="checkbox"
-    value={null}
+    value=""
   />
   <label
     checked={false}
@@ -331,7 +333,8 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
     disabled={true}
     htmlFor="checkbox_3"
     name="name"
-    value={null}
+    onChange={[MockFunction]}
+    value=""
   />
 </div>
 `;
@@ -435,9 +438,9 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
     disabled={false}
     id="checkbox_4"
     name="name"
-    onClick={[MockFunction]}
+    onChange={[MockFunction]}
     type="checkbox"
-    value={null}
+    value=""
   />
   <label
     checked={false}
@@ -445,7 +448,8 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
     disabled={false}
     htmlFor="checkbox_4"
     name="name"
-    value={null}
+    onChange={[MockFunction]}
+    value=""
   />
 </div>
 `;


### PR DESCRIPTION
**Changes**

- Remove `onChange` prop expecting the user to decide whether to use it as controlled component or not.
- Set value type as string with default `''`

This PR tries to fix the following warnings:
- Warning: `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
- Warning: Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.