### PR TITLE
Popover: allow passed modifiers to overwrite default ones

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -195,7 +195,7 @@ class Popover extends Component {
       <Popper
         {...others}
         placement={toPopperPlacement(position, align)}
-        modifiers={{ ...modifiers, ...popperModifiers }}
+        modifiers={{ ...popperModifiers, ...modifiers }}
       >
         {({ ref, style, placement }) =>
           isOpen && (


### PR DESCRIPTION
**Changes**
- Destruct props in a way that allows the user of the lib to overwrite the default modifiers.