### PR TITLE
Extend Popover with referenceElement prop

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -104,7 +104,7 @@ class Popover extends Component {
     /**
      * function rendering the reference (button or something clickable)
      */
-    renderReference: PropTypes.func.isRequired,
+    renderReference: PropTypes.func,
     /**
      * placement of the popover relative to the reference
      */
@@ -128,18 +128,21 @@ class Popover extends Component {
     onClose: PropTypes.func,
     usePortal: PropTypes.bool,
     modifiers: PropTypes.shape(),
-    arrowRenderer: PropTypes.func
+    arrowRenderer: PropTypes.func,
+    referenceElement: PropTypes.instanceOf(HTMLElement)
   };
 
   static defaultProps = {
     isOpen: false,
     position: Popover.BOTTOM,
     align: Popover.START,
-    zIndex: false,
+    zIndex: null,
     onClose: () => {},
     usePortal: false,
     modifiers: {},
-    arrowRenderer: () => null
+    arrowRenderer: () => null,
+    renderReference: () => null,
+    referenceElement: null
   };
 
   componentDidMount() {
@@ -155,7 +158,7 @@ class Popover extends Component {
     const isWithinButton = this.buttonRef && this.buttonRef.contains(target);
 
     if (this.props.isOpen && !isWithinButton && !isWithinPopover) {
-      this.props.onOutsideClickClose();
+      this.props.onOutsideClickClose(target);
     }
   };
 
@@ -182,6 +185,7 @@ class Popover extends Component {
       arrowRenderer,
       renderPopover,
       renderReference,
+      referenceElement,
       position,
       align,
       isOpen,
@@ -191,9 +195,23 @@ class Popover extends Component {
       ...others
     } = this.props;
 
+    const reference = !referenceElement && (
+      <Reference>
+        {({ ref }) => (
+          <ReferenceWrapper
+            innerRef={this.receiveButtonRef}
+            onClick={this.handleReferenceClick}
+          >
+            <div ref={ref}>{renderReference()}</div>
+          </ReferenceWrapper>
+        )}
+      </Reference>
+    );
+
     const popper = isOpen && (
       <Popper
         {...others}
+        referenceElement={referenceElement}
         placement={toPopperPlacement(position, align)}
         modifiers={{ ...modifiers, ...popperModifiers }}
       >
@@ -217,16 +235,7 @@ class Popover extends Component {
 
     return (
       <Manager>
-        <Reference>
-          {({ ref }) => (
-            <ReferenceWrapper
-              innerRef={this.receiveButtonRef}
-              onClick={this.handleReferenceClick}
-            >
-              <div ref={ref}>{renderReference()}</div>
-            </ReferenceWrapper>
-          )}
-        </Reference>
+        {reference}
         {usePortal ? <Portal>{popper}</Portal> : popper}
       </Manager>
     );

--- a/src/components/Popover/Popover.spec.js
+++ b/src/components/Popover/Popover.spec.js
@@ -75,6 +75,15 @@ describe('Popover', () => {
     expect(onReferenceClickClose).toHaveBeenCalledTimes(1);
   });
 
+  it('should not render <Reference> component when referenceElement is passed', () => {
+    const dummyElement = document.createElement('div');
+    const actual = shallow(
+      <Popover isOpen {...defaultProps} referenceElement={dummyElement} />
+    );
+    expect(actual.find('Reference')).toHaveLength(0);
+    expect(actual.find('Popper').prop('referenceElement')).toBe(dummyElement);
+  });
+
   /**
    * Accessibility tests.
    */


### PR DESCRIPTION
`referenceElement` is needed so that the popover gets bound to an element that is not the toggle/reference itself.