### PR TITLE
Remove border width for flat button

### DIFF
--- a/src/components/Button/components/RegularButton/RegularButton.js
+++ b/src/components/Button/components/RegularButton/RegularButton.js
@@ -131,6 +131,10 @@ const flatStyles = ({ theme, flat, secondary, ...otherProps }) =>
         0 0 1px 0 rgba(12, 15, 20, 0.06), 0 2px 2px 0 rgba(12, 15, 20, 0.06);
     }
 
+    &:hover {
+      border-width: 0;
+    }
+
     &:active:focus,
     &:hover:focus {
       border-width: 0;

--- a/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
+++ b/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
@@ -195,6 +195,10 @@ exports[`RegularButton should have flat button styles 1`] = `
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02),0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
+.circuit-0:hover {
+  border-width: 0;
+}
+
 .circuit-0:active:focus,
 .circuit-0:hover:focus {
   border-width: 0;
@@ -277,6 +281,10 @@ exports[`RegularButton should have flat disabled button styles 1`] = `
 .circuit-0:active {
   background-color: #1641AC;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02),0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
+.circuit-0:hover {
+  border-width: 0;
 }
 
 .circuit-0:active:focus,


### PR DESCRIPTION
Relates to: [issue-234](https://github.com/sumup/circuit-ui/issues/234)

In **flat** state on **hover** the button is not supposed to have a border.
It is also causing a shift in the layout.

![3 primary flat state](https://user-images.githubusercontent.com/6113581/42702068-a5acc694-86c8-11e8-9e32-d8ef555964b2.gif)