### PR TITLE
[BUG] Fix undefined proptype

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -129,7 +129,7 @@ class Popover extends Component {
     usePortal: PropTypes.bool,
     modifiers: PropTypes.shape(),
     arrowRenderer: PropTypes.func,
-    referenceElement: PropTypes.instanceOf(HTMLElement)
+    referenceElement: PropTypes.element
   };
 
   static defaultProps = {


### PR DESCRIPTION
When using the new canary build from NPM (0.0.3-canary, see #266), I get the following error: 

```
~/src/.next/server/static/development/pages/_app.js:1
ReferenceError: HTMLElement is not defined
    at Module.../node_modules/@sumup/circuit-ui/lib/es/components/Popover/Popover.js (~/src/.next/server/static/development/pages/_app.js:11765:82)
```

This PR fixes the bug by replacing the undefined prop-type with a more appropriate one. 