### PR TITLE
[BUG] Fix undefined proptype (again)

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Manager, Reference, Popper } from 'react-popper';
 import styled, { css } from 'react-emotion';
 import Portal from '../Portal';
+import HTMLElement from '../HtmlElement';
 
 import {
   TOP,


### PR DESCRIPTION
Relates to #282. 

When using the latest build from NPM (0.0.7-canary, see #266), I get the following error ([again](https://github.com/sumup/circuit-ui/pull/282)):

```
~/src/.next/server/static/development/pages/_app.js:1
ReferenceError: HTMLElement is not defined
    at Module.../node_modules/@sumup/circuit-ui/lib/es/components/Popover/Popover.js (~/src/.next/server/static/development/pages/_app.js:11765:82)
```

This PR fixes the bug by importing `HTMLElement` so it's no longer undefined.