### PR TITLE
Sliding in a new neutral

### DIFF
--- a/docs/content/styles/colors.mdx
+++ b/docs/content/styles/colors.mdx
@@ -21,6 +21,7 @@ You can refer to a color from the theme using `theme.colors.<COLOR_NAME>`.
 
 ### Neutrals
 <Swatch colorName="n100"/>
+<Swatch colorName="n200"/>
 <Swatch colorName="n300"/>
 <Swatch colorName="n500"/>
 <Swatch colorName="n700"/>

--- a/src/themes/circuit.js
+++ b/src/themes/circuit.js
@@ -5,6 +5,7 @@ const black = '#0F131A';
 
 const neutrals = {
   n100: '#FAFBFC',
+  n200: '#EEF0F2',
   n300: '#D8DDE1',
   n500: '#9DA7B1',
   n700: '#5C656F',


### PR DESCRIPTION
Adding n200 to our neutral color set.

n100 has proven to be too light in most cases for UI elements and reserves a place as our "off-white™️" canvas color. n300 is in many cases, too heavy and contrasty on white backgrounds. The introduction of n200 will allow us to produce more subdued UI elements that don't stand out too much amongst the crowd.