### PR TITLE
Switch popover and select z-index

### DIFF
--- a/src/components/Popover/__snapshots__/Popover.spec.js.snap
+++ b/src/components/Popover/__snapshots__/Popover.spec.js.snap
@@ -19,7 +19,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -60,7 +60,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -101,7 +101,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -142,7 +142,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -183,7 +183,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -224,7 +224,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -265,7 +265,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -306,7 +306,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -347,7 +347,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -388,7 +388,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -429,7 +429,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -470,7 +470,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div
@@ -511,7 +511,7 @@ Array [
     </div>
   </div>,
   .circuit-0 {
-  z-index: 20;
+  z-index: 30;
 }
 
 <div

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -22,7 +22,7 @@ exports[`Select should render with default styles 1`] = `
   padding: 8px 32px 8px 12px;
   position: relative;
   width: 100%;
-  z-index: 30;
+  z-index: 20;
   font-size: 15px;
   line-height: 24px;
 }
@@ -91,7 +91,7 @@ exports[`Select should render with disabled styles when passed the disabled prop
   padding: 8px 32px 8px 12px;
   position: relative;
   width: 100%;
-  z-index: 30;
+  z-index: 20;
   font-size: 15px;
   line-height: 24px;
 }
@@ -170,7 +170,7 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
   padding: 8px 32px 8px 12px;
   position: relative;
   width: 100%;
-  z-index: 30;
+  z-index: 20;
   font-size: 15px;
   line-height: 24px;
 }
@@ -248,7 +248,7 @@ exports[`Select should render with no margin styles when passed the noMargin pro
   padding: 8px 32px 8px 12px;
   position: relative;
   width: 100%;
-  z-index: 30;
+  z-index: 20;
   font-size: 15px;
   line-height: 24px;
 }

--- a/src/themes/circuit.js
+++ b/src/themes/circuit.js
@@ -230,8 +230,8 @@ export const zIndex = {
   default: 0,
   absolute: 1,
   drawer: 10,
-  popover: 20,
-  select: 30,
+  select: 20,
+  popover: 30,
   tooltip: 31,
   modal: 1000
 };


### PR DESCRIPTION
This was causing issues with the `Select` component in forms overlaying the `Popover` component, for example when the `UserMenu` is opened while filling out the signup form in the Account screen.

Any concerns about this? The previous choices for the values seemed somewhat arbitrary and I don't see a reason why the Select should have a higher `z-index` than a popover.