### PR TITLE
Update flat button active styles

### DIFF
--- a/src/components/Button/components/RegularButton/RegularButton.js
+++ b/src/components/Button/components/RegularButton/RegularButton.js
@@ -126,9 +126,7 @@ const flatStyles = ({ theme, flat, secondary, ...otherProps }) =>
       0 2px 2px 0 rgba(12, 15, 20, 0.06), 0 4px 4px 0 rgba(12, 15, 20, 0.06);
 
     &:active {
-      background-color: ${theme.colors.p900};
-      box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.02),
-        0 0 1px 0 rgba(12, 15, 20, 0.06), 0 2px 2px 0 rgba(12, 15, 20, 0.06);
+      box-shadow: inset 0 4px 8px 0 rgba(12, 15, 20, 0.3);
     }
 
     &:hover {

--- a/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
+++ b/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
@@ -191,8 +191,7 @@ exports[`RegularButton should have flat button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #1641AC;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02),0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:hover {
@@ -279,8 +278,7 @@ exports[`RegularButton should have flat disabled button styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #1641AC;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02),0 0 1px 0 rgba(12,15,20,0.06),0 2px 2px 0 rgba(12,15,20,0.06);
+  box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
 .circuit-0:hover {

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Select should not render with invalid styles when also passed the disab
   padding: 8px 32px 8px 12px;
   position: relative;
   width: 100%;
-  z-index: 30;
+  z-index: 20;
   font-size: 15px;
   line-height: 24px;
 }
@@ -334,7 +334,7 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
   padding: 8px 32px 8px 12px;
   position: relative;
   width: 100%;
-  z-index: 30;
+  z-index: 20;
   font-size: 15px;
   line-height: 24px;
   border-color: #FFAF9F;


### PR DESCRIPTION
Relates to: [issue-234](https://github.com/sumup/circuit-ui/issues/234)

In **flat** button style state on **active** state the button is having a dark blue background.

![currentactivestyles](https://user-images.githubusercontent.com/6113581/47020328-6b762700-d159-11e8-944d-ff71e8719b1e.gif)

I think it should look more like this:
![newactivestyles](https://user-images.githubusercontent.com/6113581/47020347-75982580-d159-11e8-8a99-9e39ee0d30ea.gif)
