### PR TITLE
Move animation to path instead of container for cross-browser compatibility

### DIFF
--- a/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
+++ b/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
@@ -62,6 +62,9 @@ exports[`Container Container Style tests should have default styles 1`] = `
 
 .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;

--- a/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
+++ b/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
@@ -73,6 +73,9 @@ exports[`LoadingButton Style tests should have active loading styles 1`] = `
 
 .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -199,6 +202,9 @@ exports[`LoadingButton Style tests should have default styles 1`] = `
 
 .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -276,6 +282,9 @@ exports[`LoadingButton Style tests should have isLoading styles 1`] = `
 
 .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;

--- a/src/components/LoadingButton/components/LoadingIcon/__snapshots__/index.spec.js.snap
+++ b/src/components/LoadingButton/components/LoadingIcon/__snapshots__/index.spec.js.snap
@@ -4,6 +4,9 @@ exports[`LoadingIcon Style tests should have active LoadingIcon styles 1`] = `
 Array [
   .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -55,6 +58,9 @@ exports[`LoadingIcon Style tests should have disabled LoadingIcon styles 1`] = `
 Array [
   .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -105,6 +111,9 @@ exports[`LoadingIcon Style tests should have giga LoadingIcon styles 1`] = `
 Array [
   .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -155,6 +164,9 @@ exports[`LoadingIcon Style tests should have kilo LoadingIcon styles 1`] = `
 Array [
   .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -205,6 +217,9 @@ exports[`LoadingIcon Style tests should have mega LoadingIcon styles 1`] = `
 Array [
   .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -255,6 +270,9 @@ exports[`LoadingIcon Style tests should have success LoadingIcon styles 1`] = `
 Array [
   .circuit-1 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -36,7 +36,10 @@ const darkIconStyles = ({ theme, dark }) =>
 
 const baseSpinStyles = css`
   label: spinner;
-  animation: ${spin} 1s infinite linear;
+  & > path {
+    animation: ${spin} 1s infinite linear;
+    transform-origin: 50% 50%;
+  }
 `;
 
 const SpinnerIcon = styled(SpinnerSvg)`
@@ -51,6 +54,7 @@ const SpinnerIcon = styled(SpinnerSvg)`
 
 const baseContainerStyles = css`
   opacity: 0;
+  max-width: fit-content;
   position: relative;
   transition: opacity 200ms ease-in-out;
 `;

--- a/src/components/Spinner/__snapshots__/Spinner.spec.js.snap
+++ b/src/components/Spinner/__snapshots__/Spinner.spec.js.snap
@@ -3,6 +3,9 @@
 exports[`Spinner should render with dark styles 1`] = `
 .circuit-0 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -24,6 +27,9 @@ exports[`Spinner should render with dark styles 1`] = `
 exports[`Spinner should render with default styles 1`] = `
 .circuit-0 {
   opacity: 0;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
   position: relative;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;


### PR DESCRIPTION
Our current implementation of the Spinner doesn't work on Safari. This small change enables it properly.