### PR TITLE
[Docs] Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/amend-existing-component.md
+++ b/.github/ISSUE_TEMPLATE/amend-existing-component.md
@@ -1,0 +1,16 @@
+---
+name: Amend existing component
+about: Propose an improvement to an existing component
+---
+
+## Component to amend
+
+Add component name(s) here,
+
+## Visual
+
+Provide a screenshot or link to a prototype of your component amendment.
+
+## Context
+
+In what context does your amendment solve a problem?

--- a/.github/ISSUE_TEMPLATE/propose-new-component.md
+++ b/.github/ISSUE_TEMPLATE/propose-new-component.md
@@ -1,0 +1,23 @@
+---
+name: Propose new component
+about: Propose the addition of a new component
+---
+
+A component in Circuit UI needs to be flexible enough that it can be used across a wide range of scenarios and shouldn't be constrained to a specific number of applications.
+
+## Visual
+
+Provide a screenshot or link to a prototype of your component proposal.
+
+## Context
+
+Where and when might this proposed component be used?
+
+## State
+
+Does this component have state? If so, what are the different states (e.g. accordion with closed/open states)?
+
+## Progressive enhancement
+
+A component should be designed for small screens first. How does this component scale up?
+How will this component degrade on less competent browsers?

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,0 +1,31 @@
+---
+name: Report a bug
+about: Create a bug report to help us improve Circuit UI
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Specifications
+
+* Version:
+* Browser:
+* OS:
+
+## Additional context
+
+Add any other context about the problem here.


### PR DESCRIPTION
This PR adds 3 issue templates, adapted from [vanilla-framework](https://github.com/vanilla-framework/vanilla-framework/issues/new/choose):

- Amend an existing component
- Propose a new component
- Report a bug