### PR TITLE
[Bug] "Text is not defined" in ListView

### DIFF
--- a/src/components/ListView/components/Item/components/Wrapper/Wrapper.js
+++ b/src/components/ListView/components/Item/components/Wrapper/Wrapper.js
@@ -68,7 +68,7 @@ Wrapper.propTypes = {
   /**
    * Circuit UI spacing size.
    */
-  padding: PropTypes.oneOf([Text.KILO, Text.MEGA, Text.GIGA])
+  padding: PropTypes.oneOf([KILO, MEGA, GIGA])
 };
 
 Wrapper.defaultProps = {


### PR DESCRIPTION
Circuit UI `v0.0.13-canary` throws the following error:

```
ReferenceError: Text is not defined
    at Module.../node_modules/@sumup/circuit-ui/lib/es/compon
ents/ListView/components/Item/components/Wrapper/Wrapper.js (
/Users/connorbaer/Code/GitHub/connor.li/github/src/.next/serv
er/static/development/pages/_app.js:9739:69)
```

## Changes

- Remove reference to Text component and use size constants directly. 

