### PR TITLE
Fix storybook

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,20 @@
+{
+  "plugins": [
+    "transform-class-properties",
+    "lodash",
+    "transform-object-rest-spread",
+    [
+      "emotion",
+      {
+        "autoLabel": true,
+        "hoist": true,
+        "sourceMap": true
+      }
+    ]
+  ],
+  "presets": [
+    ["env", { "loose": true, "modules": false }],
+    "react",
+    "stage-3"
+  ]
+}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -6,6 +6,13 @@ const merge = require('webpack-merge');
 module.exports = function(storybookBaseConfig, configType) {
   const isProduction = configType === 'PRODUCTION';
 
+  const babelLoader = { ...storybookBaseConfig.module.rules[0] };
+  const babelOptions = {
+    plugins: babelLoader.query.plugins,
+    presets: babelLoader.query.presets,
+    babelrc: false
+  };
+
   const ourConfig = {
     devtool: 'eval-source-map',
     externals: {
@@ -20,7 +27,7 @@ module.exports = function(storybookBaseConfig, configType) {
         {
           test: /\.story\.jsx?$/,
           loaders: [
-            'babel-loader',
+            { loader: 'babel-loader', options: babelOptions },
             {
               loader: require.resolve('@storybook/addon-storysource/loader'),
               options: {
@@ -67,5 +74,6 @@ module.exports = function(storybookBaseConfig, configType) {
   };
 
   const baseConfig = merge(storybookBaseConfig, ourConfig);
+
   return isProduction ? merge(baseConfig, ourProdSpecificConfig) : baseConfig;
 };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -6,10 +6,14 @@ const merge = require('webpack-merge');
 module.exports = function(storybookBaseConfig, configType) {
   const isProduction = configType === 'PRODUCTION';
 
-  const babelLoader = { ...storybookBaseConfig.module.rules[0] };
   const babelOptions = {
-    plugins: babelLoader.query.plugins,
-    presets: babelLoader.query.presets,
+    plugins: [
+      'transform-class-properties',
+      'lodash',
+      'transform-object-rest-spread',
+      ['emotion', { autoLabel: true, hoist: true, sourceMap: true }]
+    ],
+    presets: [['env', { loose: true, modules: false }], 'react', 'stage-3'],
     babelrc: false
   };
 


### PR DESCRIPTION
After the new build being merge the storybook wasn't working due the different configurations in `.babelrc`. This adds a new `.babelrc` file just for storybook and hacks some loader options to make the storysource plugin working again.

The second option is kinda hacky, but this should work for now. I suggest revisiting this when we move to babel7.