### PR TITLE
[Bugfix] Update Table component to handle rows update while keeping sort 

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -74,49 +74,49 @@ const Container = styled.div`
  */
 class Table extends Component {
   state = {
-    rows: this.props.rows,
     sortedRow: null,
     sortHover: null,
     sortDirection: null
   };
 
-  static getDerivedStateFromProps(nextProps) {
-    return {
-      rows: nextProps.rows
-    };
-  }
-
   onSortEnter = i => this.setState({ sortHover: i });
   onSortLeave = () => this.setState({ sortHover: null });
   onSortBy = i => {
-    const { rows, sortedRow, sortDirection } = this.state;
-    const { onSortBy } = this.props;
+    const { sortedRow, sortDirection } = this.state;
     const isActive = i === sortedRow;
     const nextDirection = getSortDirection(isActive, sortDirection);
 
-    const nextRows = onSortBy
-      ? onSortBy(i, nextDirection, rows)
-      : this.defaultSortBy(i, nextDirection, rows);
-
-    this.updateSort(i, nextDirection, nextRows);
+    this.updateSort(i, nextDirection);
   };
 
-  updateSort = (i, nextDirection, rows) =>
+  getSortedRows = () => {
+    const { rows, onSortBy } = this.props;
+    const { sortDirection, sortedRow } = this.state;
+
+    if (sortedRow === null) {
+      return rows;
+    }
+
+    return onSortBy
+      ? onSortBy(sortedRow, sortDirection, rows)
+      : this.defaultSortBy(sortedRow, sortDirection, rows);
+  };
+
+  updateSort = (i, nextDirection) =>
     this.setState({
-      rows,
       sortedRow: i,
       sortDirection: nextDirection
     });
 
-  defaultSortBy = (i, nextDirection, rows) => {
-    const nextFn = nextDirection === ASCENDING ? ascendingSort : descendingSort;
+  defaultSortBy = (i, direction, rows) => {
+    const sortFn = direction === ASCENDING ? ascendingSort : descendingSort;
 
-    return [...rows].sort(nextFn(i));
+    return [...rows].sort(sortFn(i), rows);
   };
 
   render() {
     const { rowHeaders, headers, onRowClick, noShadow } = this.props;
-    const { rows, sortDirection, sortHover, sortedRow } = this.state;
+    const { sortDirection, sortHover, sortedRow } = this.state;
 
     return (
       <Container noShadow={noShadow}>
@@ -132,7 +132,7 @@ class Table extends Component {
               rowHeaders={rowHeaders}
             />
             <TableBody
-              rows={rows}
+              rows={this.getSortedRows()}
               rowHeaders={rowHeaders}
               sortHover={sortHover}
               onRowClick={onRowClick}

--- a/src/components/Table/Table.spec.js
+++ b/src/components/Table/Table.spec.js
@@ -10,19 +10,6 @@ const items = [['1', '2', '3'], ['1', '2', '3'], ['1', '2', '3']];
 describe('Table', () => {
   beforeEach(jest.clearAllMocks);
 
-  describe('Content tests', () => {
-    it('should update state when passing an equal number of rows', () => {
-      const anotherSetOfItems = [
-        ['4', '5', '6'],
-        ['4', '5', '6'],
-        ['4', '5', '6']
-      ];
-      const actual = shallow(<Table headers={headers} rows={items} />);
-      actual.setProps({ rows: anotherSetOfItems });
-      expect(actual.state().rows).toEqual(anotherSetOfItems);
-    });
-  });
-
   describe('Style tests', () => {
     it('should render with default styles', () => {
       const actual = create(<Table headers={headers} rows={items} />);
@@ -83,13 +70,7 @@ describe('Table', () => {
 
   describe('onSortBy()', () => {
     describe('custom onSortBy', () => {
-      /**
-       * I'm skipping the next two failing tests since refactoring the component to make everything work as intended
-       * will require a lot of work. Me and @fernandofleury decided to take this course and unblock dependant releases,
-       * and decide how to refactor the code in the next few days.
-       */
-      // eslint-disable-next-line max-len
-      it.skip('should call the provided onSortBy instead of defaultSortBy with index, nextDirection and rows', () => {
+      it('should call the provided onSortBy instead of defaultSortBy with index, nextDirection and rows', () => {
         const row = ['a', 'b', 'c', 'd', 'e'];
         const rows = [row];
         const shuffledRow = shuffle(row);
@@ -102,22 +83,19 @@ describe('Table', () => {
         wrapper.instance().onSortBy(index);
 
         expect(mock).toHaveBeenCalledWith(index, nextDirection, rows);
-        expect(wrapper.state('rows')).toEqual(expected);
+        expect(wrapper.instance().getSortedRows()).toEqual(expected);
       });
     });
   });
 
   describe('updateSort()', () => {
-    // eslint-disable-next-line max-len
-    it.skip('should update the state with sortedRow, nextDirection and nextDirection', () => {
+    it('should update the state with sortedRow, nextDirection and nextDirection', () => {
       const wrapper = shallow(<Table />);
       const index = 0;
       const nextDirection = ASCENDING;
-      const rows = [['a', 'b']];
 
-      wrapper.instance().updateSort(index, nextDirection, rows);
+      wrapper.instance().updateSort(index, nextDirection);
 
-      expect(wrapper.state('rows')).toEqual(rows);
       expect(wrapper.state('sortedRow')).toBe(index);
       expect(wrapper.state('sortDirection')).toBe(nextDirection);
     });

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -12,7 +12,7 @@ import TableCell from './components/TableCell';
 
 const headers = [
   { children: 'Name', sortable: true },
-  'Created at',
+  { children: 'Created at', sortable: true },
   'Permissions',
   { children: 'Status', align: TableHeader.RIGHT }
 ];
@@ -20,19 +20,19 @@ const headers = [
 const rows = [
   [
     'Lorem ipsum dolor',
-    { children: '12/01/2017', sortByValue: '0' },
+    { children: '12/01/2017', sortByValue: 0 },
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
   ],
   [
-    'Lorem ipsum dolor sit amet',
-    { children: '13/01/2017', sortByValue: '1' },
+    'Ipsum dolor sit amet',
+    { children: '13/01/2017', sortByValue: 1 },
     'Virtual Terminal',
     { children: 'Enabled', align: TableCell.RIGHT }
   ],
   [
-    'Lorem ipsum dolor sit amet, consectetur adipiscing',
-    { children: '14/01/2017', sortByValue: '2' },
+    'Dolor sit amet, consectetur adipiscing',
+    { children: '14/01/2017', sortByValue: 2 },
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
   ]

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -1,14 +1,17 @@
 import PropTypes from 'prop-types';
-import { curry, isString } from 'lodash/fp';
+import { isString, isNumber, curry } from 'lodash/fp';
 import { ASCENDING, DESCENDING } from './constants';
 import { childrenPropType } from '../../util/shared-prop-types';
 
 export const mapProps = props =>
-  isString(props) ? { children: props } : props;
+  isString(props) || isNumber(props) ? { children: props } : props;
 
 export const getChildren = props => mapProps(props).children;
 
-export const getSortByValue = props => props.sortByValue || getChildren(props);
+export const getSortByValue = props =>
+  Object.prototype.hasOwnProperty.call(props, 'sortByValue')
+    ? props.sortByValue
+    : getChildren(props);
 
 export const getSortDirection = (isActive, currentSort) => {
   if (!currentSort || !isActive) {
@@ -18,12 +21,33 @@ export const getSortDirection = (isActive, currentSort) => {
   return currentSort === ASCENDING ? DESCENDING : ASCENDING;
 };
 
-export const ascendingSort = curry(
-  (i, a, b) => getSortByValue(a[i]) > getSortByValue(b[i])
-);
-export const descendingSort = curry(
-  (i, a, b) => getSortByValue(a[i]) < getSortByValue(b[i])
-);
+export const ascendingSort = curry((i, a, b) => {
+  const first = getSortByValue(a[i]);
+  const second = getSortByValue(b[i]);
+
+  if (first < second) {
+    return -1;
+  }
+  if (first > second) {
+    return 1;
+  }
+
+  return 0;
+});
+
+export const descendingSort = curry((i, a, b) => {
+  const first = getSortByValue(a[i]);
+  const second = getSortByValue(b[i]);
+
+  if (first > second) {
+    return -1;
+  }
+  if (first < second) {
+    return 1;
+  }
+
+  return 0;
+});
 
 export const RowPropType = PropTypes.oneOfType([
   PropTypes.string,

--- a/src/components/Table/utils.spec.js
+++ b/src/components/Table/utils.spec.js
@@ -120,10 +120,8 @@ describe('Table utils', () => {
   describe('ascendingSort', () => {
     it('should sort the array by sortByValue/children on ascending order', () => {
       const index = 0;
-      const a = ['Foo'];
-      const b = ['Bar'];
-      const arr = [a, b];
-      const expected = [b, a];
+      const arr = [[10], [7], [2]];
+      const expected = [[2], [7], [10]];
       const actual = [...arr].sort(utils.ascendingSort(index));
 
       expect(actual).toEqual(expected);
@@ -133,10 +131,8 @@ describe('Table utils', () => {
   describe('descendingSort', () => {
     it('should sort the array by sortByValue/children on descending order', () => {
       const index = 0;
-      const a = ['Bar'];
-      const b = ['Foo'];
-      const arr = [a, b];
-      const expected = [b, a];
+      const arr = [[2], [7], [10]];
+      const expected = [[10], [7], [2]];
       const actual = [...arr].sort(utils.descendingSort(index));
 
       expect(actual).toEqual(expected);


### PR DESCRIPTION
Our current implementation was buggy.

## Approach

I've revisited how we consume the rows. Now it's directly from `props`, and we apply the sort (if sorted) when rendering the Table. this allow us to change the rows on the fly and still keep it sorted.

## Downsides

As discussed, this will require leveraging (whenever needed) to the consumer of the Table.

## What's next

Our current testing strategy is too coupled to the implementation and not to the usage. We should update the specs to reflect how we render/sort the rows and not only the instance methods for that. There was a sorting bug that our current specs didn't cover cause of that.

We also need to provide proper documentation for this component. But this can come later on after we use it a while