### PR TITLE
[Bug] Fix value for Select placeholder

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -126,7 +126,11 @@ const Select = ({
 }) => (
   <SelectContainer {...{ noMargin, inline, disabled }}>
     <SelectElement {...{ ...props, value, disabled }}>
-      {!value && <option key="placeholder">{placeholder}</option>}
+      {!value && (
+        <option key="placeholder" value="">
+          {placeholder}
+        </option>
+      )}
       {children ||
         (options &&
           options.map(({ label, ...rest }) => (

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -54,7 +54,9 @@ exports[`Select should not render with invalid styles when also passed the disab
     disabled={true}
     value={null}
   >
-    <option>
+    <option
+      value=""
+    >
       Select an option
     </option>
     <option
@@ -130,7 +132,9 @@ exports[`Select should render with default styles 1`] = `
     disabled={false}
     value={null}
   >
-    <option>
+    <option
+      value=""
+    >
       Select an option
     </option>
     <option
@@ -209,7 +213,9 @@ exports[`Select should render with disabled styles when passed the disabled prop
     disabled={true}
     value={null}
   >
-    <option>
+    <option
+      value=""
+    >
       Select an option
     </option>
     <option
@@ -287,7 +293,9 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
     disabled={false}
     value={null}
   >
-    <option>
+    <option
+      value=""
+    >
       Select an option
     </option>
     <option
@@ -364,7 +372,9 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
     disabled={false}
     value={null}
   >
-    <option>
+    <option
+      value=""
+    >
       Select an option
     </option>
     <option
@@ -441,7 +451,9 @@ exports[`Select should render with no margin styles when passed the noMargin pro
     disabled={false}
     value={null}
   >
-    <option>
+    <option
+      value=""
+    >
       Select an option
     </option>
     <option


### PR DESCRIPTION
## Purpose

The `<Select>` component shows a placeholder option in its initial state. This option does not have an explicit value attribute set, so the option label is used instead: 

> The value attribute provides a value for element. The value of an option element is the value of the value content attribute, if there is one, or, if there is not, the value of the element's text IDL attribute.

From https://html.spec.whatwg.org/multipage/forms.html#the-option-element

This is rarely what we want, as the user might end up submitting the placeholder text.

## Approach and changes

Change the value of the placeholder option to `""` (an empty string).

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements