### PR TITLE
[Bugfix] Handle text overflow in Select

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:lint-js:watch": "onchange \"src/**/**/*.js\" -- yarn test:lint-js",
     "test:unit:verbose": "jest --coverage --no-cache",
     "test:unit": "yarn test:unit:verbose --silent",
-    "test:unit:watch": "yarn test:unit:output -- --watch",
+    "test:unit:watch": "yarn test:unit:output --watch",
     "test:unit:output": "jest --json --outputFile=jest-test-results.json --no-cache --silent",
     "create-component": "foundry run plop component",
     "start": "yarn test:unit:output && start-storybook -p 6006",

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -26,6 +26,7 @@ const selectBaseStyles = ({ theme }) => css`
   position: relative;
   width: 100%;
   z-index: ${theme.zIndex.select};
+  text-overflow: ellipsis;
   ${textMega({ theme })};
 
   &:focus,

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -26,7 +26,9 @@ const selectBaseStyles = ({ theme }) => css`
   position: relative;
   width: 100%;
   z-index: ${theme.zIndex.select};
+  overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   ${textMega({ theme })};
 
   &:focus,

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -16,6 +16,7 @@ exports[`Select should not render with invalid styles when also passed the disab
   position: relative;
   width: 100%;
   z-index: 20;
+  text-overflow: ellipsis;
   font-size: 15px;
   line-height: 24px;
 }
@@ -104,6 +105,7 @@ exports[`Select should render with default styles 1`] = `
   position: relative;
   width: 100%;
   z-index: 20;
+  text-overflow: ellipsis;
   font-size: 15px;
   line-height: 24px;
 }
@@ -175,6 +177,7 @@ exports[`Select should render with disabled styles when passed the disabled prop
   position: relative;
   width: 100%;
   z-index: 20;
+  text-overflow: ellipsis;
   font-size: 15px;
   line-height: 24px;
 }
@@ -256,6 +259,7 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
   position: relative;
   width: 100%;
   z-index: 20;
+  text-overflow: ellipsis;
   font-size: 15px;
   line-height: 24px;
 }
@@ -343,6 +347,7 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
   position: relative;
   width: 100%;
   z-index: 20;
+  text-overflow: ellipsis;
   font-size: 15px;
   line-height: 24px;
   border-color: #FFAF9F;
@@ -415,6 +420,7 @@ exports[`Select should render with no margin styles when passed the noMargin pro
   position: relative;
   width: 100%;
   z-index: 20;
+  text-overflow: ellipsis;
   font-size: 15px;
   line-height: 24px;
 }

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -16,7 +16,9 @@ exports[`Select should not render with invalid styles when also passed the disab
   position: relative;
   width: 100%;
   z-index: 20;
+  overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
 }
@@ -105,7 +107,9 @@ exports[`Select should render with default styles 1`] = `
   position: relative;
   width: 100%;
   z-index: 20;
+  overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
 }
@@ -177,7 +181,9 @@ exports[`Select should render with disabled styles when passed the disabled prop
   position: relative;
   width: 100%;
   z-index: 20;
+  overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
 }
@@ -259,7 +265,9 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
   position: relative;
   width: 100%;
   z-index: 20;
+  overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
 }
@@ -347,7 +355,9 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
   position: relative;
   width: 100%;
   z-index: 20;
+  overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
   border-color: #FFAF9F;
@@ -420,7 +430,9 @@ exports[`Select should render with no margin styles when passed the noMargin pro
   position: relative;
   width: 100%;
   z-index: 20;
+  overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 15px;
   line-height: 24px;
 }


### PR DESCRIPTION
## Purpose

When the label of the selected option exceeds the width of the `<Select>` component, the text is currently cut off: 

![Text overflow of Select component is cut off](https://user-images.githubusercontent.com/11017722/49735450-88c20000-fc87-11e8-9c90-0cf901bd6f5e.png)

## Approach and changes

A more beautiful way to handle the overflow is to add an ellipsis at the end:

![Text overflow of Select component is indicated with ellipsis](https://user-images.githubusercontent.com/11017722/49735536-bad36200-fc87-11e8-914e-05b331660fc3.png)

This improves usability as it indicates to the user that some text is hidden.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements