### PR TITLE
Move react-modal overflow to html instead of body

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "react-dom": "^16.3.1",
     "react-emotion": "^9.2.6",
     "react-event-listener": "^0.6.2",
-    "react-modal": "^3.3.2",
+    "react-modal": "^3.8.1",
     "react-popper": "^1.0.0-beta.6",
     "react-text-mask": "5.4.0",
     "react-transition-group": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "lodash": "^4.17.4",
     "markdown-to-jsx": "^6.6.5",
     "moment": "^2.18.1",
+    "no-scroll": "^2.1.1",
     "polished": "^1.9.0",
     "prop-types": "^15.6.0",
     "prop-types-exact": "^1.2.0",

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -155,6 +155,7 @@ const Modal = ({
     overlayClassName: getClassValues(overlayClassName),
     contentLabel,
     onAfterOpen: () => IS_IOS && noScroll.on(),
+    onAfterClose: () => IS_IOS && noScroll.off(),
     onRequestClose: onClose,
     htmlOpenClassName: 'ReactModal__Html--open',
     closeTimeoutMS: TRANSITION_DURATION,

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 import { injectGlobal, css } from 'react-emotion';
 import { withTheme } from 'emotion-theming';
+import noScroll from 'no-scroll';
 
 import { transparentize } from 'polished';
 import { themePropType } from '../../util/shared-prop-types';
@@ -153,6 +154,7 @@ const Modal = ({
     className: getClassValues(modalClassName),
     overlayClassName: getClassValues(overlayClassName),
     contentLabel,
+    onAfterOpen: () => IS_IOS && noScroll.on(),
     onRequestClose: onClose,
     htmlOpenClassName: 'ReactModal__Html--open',
     closeTimeoutMS: TRANSITION_DURATION,

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -123,26 +123,15 @@ const overlayClassName = {
  * Global body styles
  */
 
-/* eslint-disable no-unused-expressions */
+/* eslint-disable-next-line no-unused-expressions */
 injectGlobal`
    /* Remove scroll on the body when react-modal is open */
-  .ReactModal__Body--open {
+  .ReactModal__Html--open {
     height: 100%;
-    overflow: hidden;
+    overflow-y: hidden;
     -webkit-overflow-scrolling: auto;
-    width: 100vw;
-    /* Supposed to prevent scrolling and maintaining scroll
-     * position on iOS as per this Issue:
-     * https://github.com/reactjs/react-modal/issues/191
-     * Default solution would be to set position: fixed;
-     * but that still scrolls to the top and requires
-     * scrolling back to the original scroll position
-     * onClose. Nasty hack and we don't want that.
-     */
-    ${IS_IOS ? 'position: absolute;' : ''};
   }
 `;
-/* eslint-enable no-unused-expressions */
 
 /**
  * Circuit UI's wrapper component for ReactModal. Uses the Card component
@@ -165,6 +154,7 @@ const Modal = ({
     overlayClassName: getClassValues(overlayClassName),
     contentLabel,
     onRequestClose: onClose,
+    htmlOpenClassName: 'ReactModal__Html--open',
     closeTimeoutMS: TRANSITION_DURATION,
     ...otherProps
   };

--- a/src/components/Modal/ModalProvider.js
+++ b/src/components/Modal/ModalProvider.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import createReactContext from 'create-react-context';
-import noScroll from 'no-scroll';
 
 import Modal, { TRANSITION_DURATION } from './Modal';
 import { childrenPropType } from '../../util/shared-prop-types';
@@ -62,7 +61,6 @@ export class ModalProvider extends Component {
     // some reason.
     const { onClose = () => {}, children, ...otherProps } = modal || {};
     const handleClose = () => {
-      noScroll.off();
       onClose();
       this.closeModal();
     };

--- a/src/components/Modal/ModalProvider.js
+++ b/src/components/Modal/ModalProvider.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import createReactContext from 'create-react-context';
+import noScroll from 'no-scroll';
 
 import Modal, { TRANSITION_DURATION } from './Modal';
 import { childrenPropType } from '../../util/shared-prop-types';
@@ -61,6 +62,7 @@ export class ModalProvider extends Component {
     // some reason.
     const { onClose = () => {}, children, ...otherProps } = modal || {};
     const handleClose = () => {
+      noScroll.off();
       onClose();
       this.closeModal();
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9688,6 +9688,11 @@ no-case@^2.2.0, no-case@^2.3.2:
   dependencies:
     lower-case "^1.1.1"
 
+no-scroll@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/no-scroll/-/no-scroll-2.1.1.tgz#f37e08cb159b75a5bdbfc0a87cd9223e120e6e27"
+  integrity sha512-YTzGAJOo/B6hkodeT5SKKHpOhAzjMfkUCCXjLJwjWk2F4/InIg+HbdH9kmT7bKpleDuqLZDTRy2OdNtAj0IVyQ==
+
 node-dir@^0.1.10:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11407,6 +11407,16 @@ react-modal@^3.3.2:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
+react-modal@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.8.1.tgz#7300f94a6f92a2e17994de0be6ccb61734464c9e"
+  integrity sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^3.0.0"
+
 react-moment-proptypes@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/react-moment-proptypes/-/react-moment-proptypes-1.5.0.tgz#4a448cd6479efc5dd509283f361f3753c3abe60e"


### PR DESCRIPTION
## Purpose

The current Modal overflow strategy is not working properly:

![image](https://media.giphy.com/media/bqycl3uOXdiv8Em3YN/giphy.gif)

## Approach

- Move the react-modal openClassName to html as `ReactModal__Html--open`
- Preserve `ReactModal__Body--open` to allow 3rds to style body if they require to do so.
- Introduce [no-scroll](https://github.com/davidtheclark/no-scroll) library to handle the `iOS` issue in a more centralised manner

~~I've also opened a PR on https://github.com/reactjs/react-modal/pull/724 to move the `noScroll.off()` call on the Modal directly~~ (Done)

This PR addresses #211 
