### PR TITLE
Update emotion integration with docz

### DIFF
--- a/docs/utils/Wrapper.js
+++ b/docs/utils/Wrapper.js
@@ -5,6 +5,12 @@ import PropTypes from 'prop-types';
 import { ThemeProvider } from 'emotion-theming';
 import { circuit } from '../../src/themes';
 
+/**
+ * Current emotion version doesn't allow [object Module] as theme,
+ * only [object Object]
+ */
+const theme = { ...circuit };
+
 export const Wrapper = props => (
-  <ThemeProvider theme={circuit}>{props.children}</ThemeProvider>
+  <ThemeProvider theme={theme}>{props.children}</ThemeProvider>
 );

--- a/docs/utils/Wrapper.js
+++ b/docs/utils/Wrapper.js
@@ -3,14 +3,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from 'emotion-theming';
-import { circuit } from '../../src/themes';
-
-/**
- * Current emotion version doesn't allow [object Module] as theme,
- * only [object Object]
- */
-const theme = { ...circuit };
+import { theme } from '../../src/index';
 
 export const Wrapper = props => (
-  <ThemeProvider theme={theme}>{props.children}</ThemeProvider>
+  <ThemeProvider theme={theme.standard}>{props.children}</ThemeProvider>
 );

--- a/doczrc.js
+++ b/doczrc.js
@@ -6,7 +6,10 @@ export default {
   dest: './dist',
   base: '/',
   plugins: [babel()],
-  modifyBabelRc: config => config,
+  modifyBabelRc: config => ({
+    ...config,
+    plugins: ['emotion']
+  }),
   indexHtml: 'docs/index.html',
   hashRouter: true,
   themeConfig: {


### PR DESCRIPTION
When running `docz:dev` we have some small errors regarding emotion:

- With our current emotion version, the `ThemeProvider` doesn't allow a `object Module` (Direct import) to be used as a theme.
- The circuit components are using the `styled` shorthand, while the docz config lacked the `babel-emotion` plugin