### PR TITLE
(chore) Remove symlink files that are no longer used

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -1,5 +1,5 @@
 import { babel } from 'docz-plugin-babel6';
-import { circuit as theme } from './themes';
+import { circuit as theme } from './src/themes';
 
 export default {
   title: 'Circuit UI',

--- a/styles.js
+++ b/styles.js
@@ -1,1 +1,0 @@
-./src/styles/index.js

--- a/themes.js
+++ b/themes.js
@@ -1,1 +1,0 @@
-./src/themes/index.js

--- a/utils.js
+++ b/utils.js
@@ -1,1 +1,0 @@
-./src/util/index.js


### PR DESCRIPTION
These symlinked files were used when installing Circuit UI from GitHub. They were made obsolete by #266.