### PR TITLE
(bugfix) Fix theme import in docz

### DIFF
--- a/docs/content/styles/components/Swatch.js
+++ b/docs/content/styles/components/Swatch.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 import { ThemeProvider } from 'emotion-theming';
-import { circuit } from '../../../../src/themes';
+import { theme } from '../../../../src';
 import { shadowSingle } from '../../../../src/styles/style-helpers';
 import Text from '../../../../src/components/Text';
 
@@ -47,12 +47,12 @@ const ColorWrapper = styled('div')`
 `;
 
 const Swatch = ({ colorName }) => (
-  <ThemeProvider theme={circuit}>
+  <ThemeProvider theme={theme.standard}>
     <ColorWrapper>
       <Color colorName={colorName} />
       <ColorName>
         <ColorHex element="span" size="kilo" noMargin>
-          {circuit.colors[colorName]}
+          {theme.standard.colors[colorName]}
         </ColorHex>
         <Text bold element="span" size="kilo" noMargin>
           {colorName}

--- a/docs/utils/PropTable.js
+++ b/docs/utils/PropTable.js
@@ -4,7 +4,7 @@ import styled, { css } from 'react-emotion';
 import { parse } from 'react-docgen';
 import Table from '../../src/components/Table';
 import Text from '../../src/components/Text';
-import { circuit } from '../../src/themes/index';
+import { theme } from '../../src';
 import { ThemeProvider } from 'emotion-theming';
 
 const TableWrapper = styled('div')`
@@ -29,7 +29,7 @@ const PropTable = ({ component }) => {
 
   if (!parsed) {
     return (
-      <ThemeProvider theme={circuit}>
+      <ThemeProvider theme={theme.standard}>
         <Text italic>
           Could not render prop table for {component.displayName}.
         </Text>
@@ -40,7 +40,7 @@ const PropTable = ({ component }) => {
   const { props, description } = parsed;
 
   return (
-    <ThemeProvider theme={circuit}>
+    <ThemeProvider theme={theme.standard}>
       <TableWrapper>
         <Table
           headers={['Name', 'Type', 'Required', 'Default Value', 'Description']}


### PR DESCRIPTION
_Follow up to #358_

> With our current emotion version, the `ThemeProvider` doesn't allow an `object Module` (direct import) to be used as a theme.

This PR fixes it in two more places.