### PR TITLE
Fix <Toggle /> on Edge

### DIFF
--- a/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
@@ -30,6 +30,7 @@ exports[`Toggle should render with default styles 1`] = `
   transition: background-color 200ms ease-in-out;
   height: 24px;
   width: 40px;
+  overflow: visible;
 }
 
 .circuit-4::-moz-focus-inner {
@@ -108,6 +109,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
   transition: background-color 200ms ease-in-out;
   height: 24px;
   width: 40px;
+  overflow: visible;
 }
 
 .circuit-4::-moz-focus-inner {

--- a/src/components/Toggle/components/Switch/Switch.js
+++ b/src/components/Toggle/components/Switch/Switch.js
@@ -23,6 +23,7 @@ const trackBaseStyles = ({ theme }) => css`
   position: relative;
   transition: background-color ${ANIMATION_TIMING};
   ${size(TRACK_HEIGHT, TRACK_WIDTH)};
+  overflow: visible;
 
   &::-moz-focus-inner {
     border-radius: ${TRACK_HEIGHT}px;

--- a/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
+++ b/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
@@ -19,6 +19,7 @@ exports[`Switch should have the correct default styles 1`] = `
   transition: background-color 200ms ease-in-out;
   height: 24px;
   width: 40px;
+  overflow: visible;
 }
 
 .circuit-4::-moz-focus-inner {
@@ -108,6 +109,7 @@ exports[`Switch should have the correct on styles 1`] = `
   transition: background-color 200ms ease-in-out;
   height: 24px;
   width: 40px;
+  overflow: visible;
   background-color: #3388FF;
 }
 


### PR DESCRIPTION
Issue is only on Win + Edge (perfectly fine on IE11 🥇  )

**Changes**

* Added `overflow: visible` to `<Switch />` track.

This is how it looks without:
![toggle](https://user-images.githubusercontent.com/2035446/51189791-6c019380-18e9-11e9-9b40-84f7a4107a59.jpg)
