### PR TITLE
(bugfix) Repair babel config for static style extraction

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -53,7 +53,23 @@
       "presets": ["env", "react", "stage-3"]
     },
     "static": {
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "node": "current"
+            }
+          }
+        ],
+        "react",
+        "stage-3"
+      ],
       "plugins": [
+        "lodash",
+        "transform-es2015-modules-commonjs",
+        "transform-object-rest-spread",
+        "transform-class-properties",
         [
           "emotion",
           {

--- a/docs/content/styles/components/Swatch.js
+++ b/docs/content/styles/components/Swatch.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 import { ThemeProvider } from 'emotion-theming';
-import { theme } from '../../../../src';
+import { theme as themes } from '../../../../src';
 import { shadowSingle } from '../../../../src/styles/style-helpers';
 import Text from '../../../../src/components/Text';
 
@@ -47,12 +47,12 @@ const ColorWrapper = styled('div')`
 `;
 
 const Swatch = ({ colorName }) => (
-  <ThemeProvider theme={theme.standard}>
+  <ThemeProvider theme={themes.standard}>
     <ColorWrapper>
       <Color colorName={colorName} />
       <ColorName>
         <ColorHex element="span" size="kilo" noMargin>
-          {theme.standard.colors[colorName]}
+          {themes.standard.colors[colorName]}
         </ColorHex>
         <Text bold element="span" size="kilo" noMargin>
           {colorName}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "create-component": "foundry run plop component",
     "start": "yarn test:unit:output && start-storybook -p 6006",
     "prebuild": "yarn test:unit:output",
-    "build": "yarn build:stylesheet && yarn build:global-styles && yarn build:copy-global-styles && yarn build:storybook",
+    "build": "yarn build:global-styles && yarn build:copy-global-styles && yarn build:storybook",
     "build:storybook": "build-storybook -c .storybook -o dist/storybook",
     "build:stylesheet": "mkdir -p dist && BABEL_ENV=static node build/stylesheet > dist/circuit-ui.css",
     "build:global-styles": "mkdir -p dist && BABEL_ENV=static ./build/global-styles > dist/circuit-ui-global.css",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "yarn build:stylesheet && yarn build:global-styles && yarn build:copy-global-styles && yarn build:storybook",
     "build:storybook": "build-storybook -c .storybook -o dist/storybook",
     "build:stylesheet": "mkdir -p dist && BABEL_ENV=static node build/stylesheet > dist/circuit-ui.css",
-    "build:global-styles": "mkdir -p dist && ./build/global-styles > dist/circuit-ui-global.css",
+    "build:global-styles": "mkdir -p dist && BABEL_ENV=static ./build/global-styles > dist/circuit-ui-global.css",
     "build:copy-global-styles": "cp -f dist/circuit-ui-global.css .storybook",
     "build:js": "yarn clean:js && yarn build:js:cjs && yarn build:js:es && yarn build:svg:cjs &&  yarn build:svg:es",
     "build:js:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore *.spec.js,*.story.js",

--- a/src/styles/global-styles.js
+++ b/src/styles/global-styles.js
@@ -67,10 +67,10 @@ export const createGlobalStyles = ({ theme, custom = '' }) => `
 
   html {
     box-sizing: border-box;
+  }
 
-    [type='button'] {
-      appearance: none;
-    }
+  html [type='button'] {
+    appearance: none;
   }
 
   body {


### PR DESCRIPTION
## Changes

> It turns out the Circuit UI Storybook + `docz` haven’t been deployed since December 1. The new build task by @elanoism broke the `babel` config for @felixjung’s static style extraction.

- Fix `babel` config for _global_ static style extraction 
- Remove _component_ static style extraction from deployment task  (it's still broken, but not relevant for the deployment)