### PR TITLE
Make circuit-ui CRA2 compatible

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,8 @@
             "hoist": true,
             "sourceMap": true
           }
-        ]
+        ],
+        "inline-react-svg"
       ],
       "presets": [["env", { "loose": true }], "react", "stage-3"]
     },
@@ -28,7 +29,8 @@
             "hoist": true,
             "sourceMap": true
           }
-        ]
+        ],
+        "inline-react-svg"
       ],
       "presets": [
         ["env", { "loose": true, "modules": false }],

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   },
   "dependencies": {
     "babel-plugin-emotion": "^9.2.6",
+    "babel-plugin-inline-react-svg": "0.5.4",
     "babel-plugin-lodash": "^3.3.2",
     "create-react-context": "^0.2.1",
     "css-loader": "^0.28.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,6 +2418,18 @@ babel-plugin-emotion@^9.2.6:
     source-map "^0.5.7"
     touch "^1.0.0"
 
+babel-plugin-inline-react-svg@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-inline-react-svg/-/babel-plugin-inline-react-svg-0.5.4.tgz#bc818f351cd9d78f5b3bfa7cc1da5f83e7b4010a"
+  integrity sha512-Pr/J5kicFEpIvwooR3mytJWXfyGXoP4gp4QzTdN0jLoa7lU2OJVyhHMm17ekA3okxwbLaQehSc0kV/UVrj343w==
+  dependencies:
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babylon "^6.18.0"
+    lodash.isplainobject "^4.0.6"
+    resolve "^1.8.1"
+    svgo "^0.7.2"
+
 babel-plugin-istanbul@^4.1.5, babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"


### PR DESCRIPTION
`create-react-app@2` changed the SVG loader and subsequently the way svgs are being imported and used in code. This PR tries to solve this in a simple way without making the library incompatible with either one or the other (or specific webpack configs out there), by just inlining the SVGs during the build step and exporting them as pure react components (also removing a client dependency in the process).

**Changes**

* Use `inline-react-svg` babel plugin to inline/minify SVGs during build step.

**Note**: the plugin is pinpointed at version `0.5.4` as this is the last one that works with babel@6. After we switch to babel7, this should be latest.

**Note 2**: I would like to test this extensively in the dashboard, before this can be merged (mostly worried about the SVG issue with the **id**s). I've published tagged version (`@sumup/circuit-ui@svg`). Feedback from the other projects we have is also welcomed.