### PR TITLE
Create new Sidebar component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sumup/circuit-ui",
   "sideEffects": false,
-  "version": "0.0.20-canary",
+  "version": "0.0.21-rc",
   "description": "SumUp's React UI component library",
   "main": "lib/index.js",
   "module": "lib/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sumup/circuit-ui",
   "sideEffects": false,
-  "version": "0.0.21-rc1",
+  "version": "0.0.21-rc2",
   "description": "SumUp's React UI component library",
   "main": "lib/index.js",
   "module": "lib/es/index.js",

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -8,16 +8,18 @@ import NavItem from './components/NavItem';
 import Backdrop from './components/Backdrop';
 import CloseButton from './components/CloseButton';
 
+const SIDEBAR_WIDTH = 256;
+
 const baseStyles = ({ theme, open }) => css`
   label: sidebar;
   display: flex;
   flex-direction: column;
   height: 100%;
-  width: 256px;
+  width: ${SIDEBAR_WIDTH}px;
   background-color: ${theme.colors.n900};
   transition: transform 150ms ease-in-out;
   position: absolute;
-  transform: translateX(${open ? 0 : '-256px'});
+  transform: translateX(${open ? 0 : `-${SIDEBAR_WIDTH}px`});
   z-index: 1;
   ${theme.mq.mega`
     transform: translateX(0);

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,19 +1,38 @@
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 import Header from './components/Header';
 import NavList from './components/NavList';
 import NavItem from './components/NavItem';
+import Backdrop from './components/Backdrop';
+import CloseButton from './components/CloseButton';
 
-const baseStyles = ({ theme }) => css`
+const baseStyles = ({ theme, open }) => css`
   display: flex;
   flex-direction: column;
   height: 100%;
   width: 256px;
   background-color: ${theme.colors.n900};
+  transition: left 150ms ease-in-out;
+  position: absolute;
+  left: ${open ? 0 : '-256px'};
+  z-index: 1;
+  ${theme.mq.mega`
+    left: 0;
+    position: relative;
+  `};
 `;
 
-const Sidebar = styled('div')(baseStyles);
+const Drawer = styled('div')(baseStyles);
+
+const Sidebar = ({ children, open, onClose }) => (
+  <Fragment>
+    <Drawer open={open}>{children}</Drawer>
+    <Backdrop visible={open} />
+    <CloseButton visible={open} onClick={onClose} />
+  </Fragment>
+);
 
 Sidebar.propTypes = {
   /**
@@ -23,7 +42,11 @@ Sidebar.propTypes = {
   /**
    * Tells if the Sidebar is open
    */
-  open: PropTypes.bool
+  open: PropTypes.bool,
+  /**
+   * A function to handle the sidebar close
+   */
+  onClose: PropTypes.func
 };
 
 Sidebar.Header = Header;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -10,24 +10,32 @@ import CloseButton from './components/CloseButton';
 
 const SIDEBAR_WIDTH = 256;
 
-const baseStyles = ({ theme, open }) => css`
+const baseStyles = ({ theme }) => css`
   label: sidebar;
-  display: flex;
-  flex-direction: column;
   height: 100%;
   min-width: ${SIDEBAR_WIDTH}px;
   background-color: ${theme.colors.n900};
   transition: transform ${theme.transitions.default};
   position: absolute;
-  transform: translateX(${open ? 0 : `-${SIDEBAR_WIDTH}px`});
-  z-index: ${theme.zIndex.modal};
+  transform: translateX(-100%);
+  z-index: ${theme.zIndex.sidebar};
   ${theme.mq.mega`
     transform: translateX(0);
     position: relative;
   `};
 `;
 
-const Drawer = styled('div')(baseStyles);
+const openStyles = ({ theme, open }) =>
+  open &&
+  css`
+    label: sidebar--open;
+    transform: translateX(0);
+    ${theme.mq.mega`
+      transform: translateX(0);
+    `};
+  `;
+
+const Drawer = styled('div')(baseStyles, openStyles);
 
 const Sidebar = ({ children, open, closeButtonLabel, onClose }) => (
   <Fragment>

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -20,7 +20,7 @@ const baseStyles = ({ theme, open }) => css`
   transition: transform ${theme.transitions.default};
   position: absolute;
   transform: translateX(${open ? 0 : `-${SIDEBAR_WIDTH}px`});
-  z-index: 1;
+  z-index: ${theme.zIndex.modal};
   ${theme.mq.mega`
     transform: translateX(0);
     position: relative;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -14,12 +14,12 @@ const baseStyles = ({ theme, open }) => css`
   height: 100%;
   width: 256px;
   background-color: ${theme.colors.n900};
-  transition: left 150ms ease-in-out;
+  transition: transform 150ms ease-in-out;
   position: absolute;
-  left: ${open ? 0 : '-256px'};
+  transform: translateX(${open ? 0 : '-256px'});
   z-index: 1;
   ${theme.mq.mega`
-    left: 0;
+    transform: translateX(0);
     position: relative;
   `};
 `;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -17,7 +17,7 @@ const baseStyles = ({ theme, open }) => css`
   height: 100%;
   width: ${SIDEBAR_WIDTH}px;
   background-color: ${theme.colors.n900};
-  transition: transform 150ms ease-in-out;
+  transition: transform ${theme.transitions.default};
   position: absolute;
   transform: translateX(${open ? 0 : `-${SIDEBAR_WIDTH}px`});
   z-index: 1;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -9,6 +9,7 @@ import Backdrop from './components/Backdrop';
 import CloseButton from './components/CloseButton';
 
 const baseStyles = ({ theme, open }) => css`
+  label: sidebar;
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -15,7 +15,7 @@ const baseStyles = ({ theme, open }) => css`
   display: flex;
   flex-direction: column;
   height: 100%;
-  width: ${SIDEBAR_WIDTH}px;
+  min-width: ${SIDEBAR_WIDTH}px;
   background-color: ${theme.colors.n900};
   transition: transform ${theme.transitions.default};
   position: absolute;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+
+import Header from './components/Header';
+import NavList from './components/NavList';
+import NavItem from './components/NavItem';
+
+const baseStyles = ({ theme }) => css`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 256px;
+  background-color: ${theme.colors.n900};
+`;
+
+const Sidebar = styled('div')(baseStyles);
+
+Sidebar.propTypes = {
+  /**
+   * The children component passed to the Sidebar
+   */
+  children: PropTypes.node,
+  /**
+   * Tells if the Sidebar is open
+   */
+  open: PropTypes.bool
+};
+
+Sidebar.Header = Header;
+Sidebar.NavList = NavList;
+Sidebar.NavItem = NavItem;
+
+export default Sidebar;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -29,11 +29,15 @@ const baseStyles = ({ theme, open }) => css`
 
 const Drawer = styled('div')(baseStyles);
 
-const Sidebar = ({ children, open, onClose }) => (
+const Sidebar = ({ children, open, closeButtonLabel, onClose }) => (
   <Fragment>
     <Drawer open={open}>{children}</Drawer>
     <Backdrop visible={open} />
-    <CloseButton visible={open} onClick={onClose} />
+    <CloseButton
+      visible={open}
+      closeButtonLabel={closeButtonLabel}
+      onClick={onClose}
+    />
   </Fragment>
 );
 
@@ -46,6 +50,10 @@ Sidebar.propTypes = {
    * Tells if the Sidebar is open
    */
   open: PropTypes.bool,
+  /**
+   * Accessibility label for the CloseButton
+   */
+  closeButtonLabel: PropTypes.string.isRequired,
   /**
    * A function to handle the sidebar close
    */

--- a/src/components/Sidebar/Sidebar.spec.js
+++ b/src/components/Sidebar/Sidebar.spec.js
@@ -2,9 +2,32 @@ import React from 'react';
 import Sidebar from './Sidebar';
 
 describe('<Sidebar />', () => {
-  it('should render and match the snapshot', () => {
-    const actual = mount(<Sidebar />);
+  it('should render and match the snapshot when closed', () => {
+    const props = {
+      open: false,
+      onClose: jest.fn()
+    };
+    const actual = mount(<Sidebar {...props} />);
     expect(actual).toMatchSnapshot();
+  });
+
+  it('should render and match snapshot when open', () => {
+    const props = {
+      open: true,
+      onClose: jest.fn()
+    };
+    const actual = mount(<Sidebar {...props} />);
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('should dispatch onClose when CloseButton is clicked', () => {
+    const props = {
+      open: true,
+      onClose: jest.fn()
+    };
+    const actual = mount(<Sidebar {...props} />);
+    actual.find('CloseButton').simulate('click');
+    expect(props.onClose).toHaveBeenCalled();
   });
 
   describe('accessibility', () => {

--- a/src/components/Sidebar/Sidebar.spec.js
+++ b/src/components/Sidebar/Sidebar.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Sidebar from './Sidebar';
+
+describe('<Sidebar />', () => {
+  it('should render and match the snapshot', () => {
+    const actual = mount(<Sidebar />);
+    expect(actual).toMatchSnapshot();
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<Sidebar />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/Sidebar.spec.js
+++ b/src/components/Sidebar/Sidebar.spec.js
@@ -7,7 +7,7 @@ describe('<Sidebar />', () => {
       open: false,
       onClose: jest.fn()
     };
-    const actual = mount(<Sidebar {...props} />);
+    const actual = create(<Sidebar {...props} />);
     expect(actual).toMatchSnapshot();
   });
 
@@ -16,7 +16,7 @@ describe('<Sidebar />', () => {
       open: true,
       onClose: jest.fn()
     };
-    const actual = mount(<Sidebar {...props} />);
+    const actual = create(<Sidebar {...props} />);
     expect(actual).toMatchSnapshot();
   });
 

--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -26,7 +26,11 @@ storiesOf(`${GROUPS.COMPONENTS}|Sidebar`, module)
       const selected = select('selected', range(0, 4), 0);
       return (
         <SidebarContainer>
-          <Sidebar open={open} onClose={() => null}>
+          <Sidebar
+            open={open}
+            onClose={() => null}
+            closeButtonLabel="close-button"
+          >
             <Sidebar.Header>Header</Sidebar.Header>
             <Sidebar.NavList>
               {range(0, 4).map(i => (

--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { range } from 'lodash/fp';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
@@ -16,28 +16,33 @@ storiesOf(`${GROUPS.COMPONENTS}|Sidebar`, module)
       const open = boolean('open', false);
       const selected = select('selected', range(0, 4), 0);
       return (
-        <div
-          style={{
-            height: '600px',
-            width: '400px',
-            backgroundColor: '#FFFFFF'
-          }}
-        >
-          <Sidebar open={open} onClose={() => null}>
-            <Sidebar.Header>Header</Sidebar.Header>
-            <Sidebar.NavList>
-              {range(0, 4).map(i => (
-                <Sidebar.NavItem
-                  key={i}
-                  selected={i === Number(selected)}
-                  onClick={() => null}
-                >
-                  Item #{i}
-                </Sidebar.NavItem>
-              ))}
-            </Sidebar.NavList>
-          </Sidebar>
-        </div>
+        <Fragment>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              height: '600px',
+              width: '400px',
+              backgroundColor: '#FFFFFF'
+            }}
+          >
+            <Sidebar open={open} onClose={() => null}>
+              <Sidebar.Header>Header</Sidebar.Header>
+              <Sidebar.NavList>
+                {range(0, 4).map(i => (
+                  <Sidebar.NavItem
+                    key={i}
+                    selected={i === Number(selected)}
+                    onClick={() => null}
+                  >
+                    Item #{i}
+                  </Sidebar.NavItem>
+                ))}
+              </Sidebar.NavList>
+            </Sidebar>
+            <h1>HELLLLLLO</h1>
+          </div>
+        </Fragment>
       );
     })
   );

--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -1,4 +1,5 @@
-import React, { Fragment } from 'react';
+import React from 'react';
+import styled from 'react-emotion';
 import { range } from 'lodash/fp';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
@@ -8,6 +9,14 @@ import { GROUPS } from '../../../.storybook/hierarchySeparators';
 import withTests from '../../util/withTests';
 import Sidebar from '.';
 
+const SidebarContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  height: 600px;
+  width: 400px;
+  background-color: white;
+`;
+
 storiesOf(`${GROUPS.COMPONENTS}|Sidebar`, module)
   .addDecorator(withTests('Sidebar'))
   .add(
@@ -16,33 +25,22 @@ storiesOf(`${GROUPS.COMPONENTS}|Sidebar`, module)
       const open = boolean('open', false);
       const selected = select('selected', range(0, 4), 0);
       return (
-        <Fragment>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              height: '600px',
-              width: '400px',
-              backgroundColor: '#FFFFFF'
-            }}
-          >
-            <Sidebar open={open} onClose={() => null}>
-              <Sidebar.Header>Header</Sidebar.Header>
-              <Sidebar.NavList>
-                {range(0, 4).map(i => (
-                  <Sidebar.NavItem
-                    key={i}
-                    selected={i === Number(selected)}
-                    onClick={() => null}
-                  >
-                    Item #{i}
-                  </Sidebar.NavItem>
-                ))}
-              </Sidebar.NavList>
-            </Sidebar>
-            <h1>HELLLLLLO</h1>
-          </div>
-        </Fragment>
+        <SidebarContainer>
+          <Sidebar open={open} onClose={() => null}>
+            <Sidebar.Header>Header</Sidebar.Header>
+            <Sidebar.NavList>
+              {range(0, 4).map(i => (
+                <Sidebar.NavItem
+                  key={i}
+                  selected={i === Number(selected)}
+                  onClick={() => null}
+                >
+                  Item #{i}
+                </Sidebar.NavItem>
+              ))}
+            </Sidebar.NavList>
+          </Sidebar>
+        </SidebarContainer>
       );
     })
   );

--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -1,41 +1,43 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { range } from 'lodash/fp';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { boolean, select } from '@storybook/addon-knobs/react';
 
 import { GROUPS } from '../../../.storybook/hierarchySeparators';
 import withTests from '../../util/withTests';
 import Sidebar from '.';
 
-class SidebarContainer extends Component {
-  state = { selectedItem: 0 };
-
-  handleNavItemClick = index => {
-    this.setState({ selectedItem: index });
-  };
-
-  render() {
-    return (
-      <div style={{ height: '600px' }}>
-        <Sidebar>
-          <Sidebar.Header>Header</Sidebar.Header>
-          <Sidebar.NavList>
-            {range(1, 5).map((value, i) => (
-              <Sidebar.NavItem
-                key={i}
-                selected={this.state.selectedItem === i}
-                onClick={() => this.handleNavItemClick(i)}
-              >
-                Item #{i}
-              </Sidebar.NavItem>
-            ))}
-          </Sidebar.NavList>
-        </Sidebar>
-      </div>
-    );
-  }
-}
-
 storiesOf(`${GROUPS.COMPONENTS}|Sidebar`, module)
   .addDecorator(withTests('Sidebar'))
-  .add('Sidebar', withInfo()(() => <SidebarContainer />));
+  .add(
+    'Sidebar',
+    withInfo()(() => {
+      const open = boolean('open', false);
+      const selected = select('selected', range(0, 4), 0);
+      return (
+        <div
+          style={{
+            height: '600px',
+            width: '400px',
+            backgroundColor: '#FFFFFF'
+          }}
+        >
+          <Sidebar open={open} onClose={() => null}>
+            <Sidebar.Header>Header</Sidebar.Header>
+            <Sidebar.NavList>
+              {range(0, 4).map(i => (
+                <Sidebar.NavItem
+                  key={i}
+                  selected={i === Number(selected)}
+                  onClick={() => null}
+                >
+                  Item #{i}
+                </Sidebar.NavItem>
+              ))}
+            </Sidebar.NavList>
+          </Sidebar>
+        </div>
+      );
+    })
+  );

--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import { range } from 'lodash/fp';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import { GROUPS } from '../../../.storybook/hierarchySeparators';
+import withTests from '../../util/withTests';
+import Sidebar from '.';
+
+class SidebarContainer extends Component {
+  state = { selectedItem: 0 };
+
+  handleNavItemClick = index => {
+    this.setState({ selectedItem: index });
+  };
+
+  render() {
+    return (
+      <div style={{ height: '600px' }}>
+        <Sidebar>
+          <Sidebar.Header>Header</Sidebar.Header>
+          <Sidebar.NavList>
+            {range(1, 5).map((value, i) => (
+              <Sidebar.NavItem
+                key={i}
+                selected={this.state.selectedItem === i}
+                onClick={() => this.handleNavItemClick(i)}
+              >
+                Item #{i}
+              </Sidebar.NavItem>
+            ))}
+          </Sidebar.NavList>
+        </Sidebar>
+      </div>
+    );
+  }
+}
+
+storiesOf(`${GROUPS.COMPONENTS}|Sidebar`, module)
+  .addDecorator(withTests('Sidebar'))
+  .add('Sidebar', withInfo()(() => <SidebarContainer />));

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -11,7 +11,7 @@ Array [
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  width: 256px;
+  min-width: 256px;
   background-color: #212933;
   -webkit-transition: -webkit-transform 200ms ease-in-out;
   -webkit-transition: transform 200ms ease-in-out;
@@ -20,7 +20,7 @@ Array [
   -webkit-transform: translateX(0);
   -ms-transform: translateX(0);
   transform: translateX(0);
-  z-index: 1;
+  z-index: 1000;
 }
 
 @media (min-width:768px) {
@@ -45,7 +45,7 @@ Array [
   transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: visible;
   opacity: 0.56;
-  z-index: 0;
+  z-index: 900;
 }
 
 @media (min-width:768px) {
@@ -73,6 +73,7 @@ Array [
 }
 
 .circuit-2 {
+  cursor: pointer;
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -97,7 +98,7 @@ Array [
   transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
   visibility: visible;
   opacity: 1;
-  z-index: 1;
+  z-index: 1000;
 }
 
 @media (min-width:768px) {
@@ -131,7 +132,7 @@ Array [
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  width: 256px;
+  min-width: 256px;
   background-color: #212933;
   -webkit-transition: -webkit-transform 200ms ease-in-out;
   -webkit-transition: transform 200ms ease-in-out;
@@ -140,7 +141,7 @@ Array [
   -webkit-transform: translateX(-256px);
   -ms-transform: translateX(-256px);
   transform: translateX(-256px);
-  z-index: 1;
+  z-index: 1000;
 }
 
 @media (min-width:768px) {
@@ -165,7 +166,7 @@ Array [
   transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: hidden;
   opacity: 0;
-  z-index: 0;
+  z-index: 900;
 }
 
 @media (min-width:768px) {
@@ -178,6 +179,7 @@ Array [
     className="circuit-0 circuit-1"
   />,
   .circuit-2 {
+  cursor: pointer;
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -202,7 +204,7 @@ Array [
   transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
   visibility: hidden;
   opacity: 0;
-  z-index: 1;
+  z-index: 1000;
 }
 
 @media (min-width:768px) {

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Sidebar /> should render and match the snapshot 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  width: 256px;
+  background-color: #212933;
+}
+
+<Sidebar>
+  <div
+    className="circuit-0 circuit-1"
+  />
+</Sidebar>
+`;

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -58,6 +58,21 @@ Array [
     className="circuit-0 circuit-1"
   />,
   .circuit-0 {
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-2 {
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -86,15 +101,18 @@ Array [
 }
 
 @media (min-width:768px) {
-  .circuit-0 {
+  .circuit-2 {
     visibility: hidden;
   }
 }
 
 <button
-    className="circuit-0 circuit-1"
+    className="circuit-2 circuit-3"
     onClick={[MockFunction]}
   >
+    <span
+      className="circuit-0 circuit-1"
+    />
     <div>
       closeIcon.svg
     </div>
@@ -159,7 +177,7 @@ Array [
 <div
     className="circuit-0 circuit-1"
   />,
-  .circuit-0 {
+  .circuit-2 {
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -188,15 +206,33 @@ Array [
 }
 
 @media (min-width:768px) {
-  .circuit-0 {
+  .circuit-2 {
     visibility: hidden;
   }
 }
 
+.circuit-0 {
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 <button
-    className="circuit-0 circuit-1"
+    className="circuit-2 circuit-3"
     onClick={[MockFunction]}
   >
+    <span
+      className="circuit-0 circuit-1"
+    />
     <div>
       closeIcon.svg
     </div>

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -51,6 +51,18 @@ exports[`<Sidebar /> should render and match snapshot when open 1`] = `
 
 .circuit-4 {
   outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   height: 40px;
   width: 40px;
   border-radius: 50%;
@@ -94,10 +106,21 @@ exports[`<Sidebar /> should render and match snapshot when open 1`] = `
     onClick={[MockFunction]}
     visible={true}
   >
-    <button
-      className="circuit-4 circuit-5"
+    <FloatingButton
       onClick={[MockFunction]}
-    />
+      visible={true}
+    >
+      <button
+        className="circuit-4 circuit-5"
+        onClick={[MockFunction]}
+      >
+        <Component>
+          <div>
+            closeIcon.svg
+          </div>
+        </Component>
+      </button>
+    </FloatingButton>
   </CloseButton>
 </Sidebar>
 `;
@@ -153,6 +176,18 @@ exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
 
 .circuit-4 {
   outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   height: 40px;
   width: 40px;
   border-radius: 50%;
@@ -196,10 +231,21 @@ exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
     onClick={[MockFunction]}
     visible={false}
   >
-    <button
-      className="circuit-4 circuit-5"
+    <FloatingButton
       onClick={[MockFunction]}
-    />
+      visible={false}
+    >
+      <button
+        className="circuit-4 circuit-5"
+        onClick={[MockFunction]}
+      >
+        <Component>
+          <div>
+            closeIcon.svg
+          </div>
+        </Component>
+      </button>
+    </FloatingButton>
   </CloseButton>
 </Sidebar>
 `;

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Sidebar /> should render and match the snapshot 1`] = `
+exports[`<Sidebar /> should render and match snapshot when open 1`] = `
 .circuit-0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -12,11 +12,194 @@ exports[`<Sidebar /> should render and match the snapshot 1`] = `
   height: 100%;
   width: 256px;
   background-color: #212933;
+  -webkit-transition: -webkit-transform 150ms ease-in-out;
+  -webkit-transition: transform 150ms ease-in-out;
+  transition: transform 150ms ease-in-out;
+  position: absolute;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+  z-index: 1;
 }
 
-<Sidebar>
-  <div
-    className="circuit-0 circuit-1"
-  />
+@media (min-width:768px) {
+  .circuit-0 {
+    -webkit-transform: translateX(0);
+    -ms-transform: translateX(0);
+    transform: translateX(0);
+    position: relative;
+  }
+}
+
+.circuit-2 {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  background-color: black;
+  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: visible;
+  opacity: 0.56;
+  z-index: 0;
+}
+
+@media (min-width:768px) {
+  .circuit-2 {
+    visibility: hidden;
+  }
+}
+
+.circuit-4 {
+  outline: none;
+  height: 40px;
+  width: 40px;
+  border-radius: 50%;
+  background-color: #FAFBFC;
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: visible;
+  opacity: 1;
+  z-index: 1;
+}
+
+@media (min-width:768px) {
+  .circuit-4 {
+    visibility: hidden;
+  }
+}
+
+<Sidebar
+  onClose={[MockFunction]}
+  open={true}
+>
+  <Drawer
+    open={true}
+  >
+    <div
+      className="circuit-0 circuit-1"
+      open={true}
+    />
+  </Drawer>
+  <Backdrop
+    visible={true}
+  >
+    <div
+      className="circuit-2 circuit-3"
+    />
+  </Backdrop>
+  <CloseButton
+    onClick={[MockFunction]}
+    visible={true}
+  >
+    <button
+      className="circuit-4 circuit-5"
+      onClick={[MockFunction]}
+    />
+  </CloseButton>
+</Sidebar>
+`;
+
+exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  width: 256px;
+  background-color: #212933;
+  -webkit-transition: -webkit-transform 150ms ease-in-out;
+  -webkit-transition: transform 150ms ease-in-out;
+  transition: transform 150ms ease-in-out;
+  position: absolute;
+  -webkit-transform: translateX(-256px);
+  -ms-transform: translateX(-256px);
+  transform: translateX(-256px);
+  z-index: 1;
+}
+
+@media (min-width:768px) {
+  .circuit-0 {
+    -webkit-transform: translateX(0);
+    -ms-transform: translateX(0);
+    transform: translateX(0);
+    position: relative;
+  }
+}
+
+.circuit-2 {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  background-color: black;
+  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 0;
+}
+
+@media (min-width:768px) {
+  .circuit-2 {
+    visibility: hidden;
+  }
+}
+
+.circuit-4 {
+  outline: none;
+  height: 40px;
+  width: 40px;
+  border-radius: 50%;
+  background-color: #FAFBFC;
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 1;
+}
+
+@media (min-width:768px) {
+  .circuit-4 {
+    visibility: hidden;
+  }
+}
+
+<Sidebar
+  onClose={[MockFunction]}
+  open={false}
+>
+  <Drawer
+    open={false}
+  >
+    <div
+      className="circuit-0 circuit-1"
+      open={false}
+    />
+  </Drawer>
+  <Backdrop
+    visible={false}
+  >
+    <div
+      className="circuit-2 circuit-3"
+    />
+  </Backdrop>
+  <CloseButton
+    onClick={[MockFunction]}
+    visible={false}
+  >
+    <button
+      className="circuit-4 circuit-5"
+      onClick={[MockFunction]}
+    />
+  </CloseButton>
 </Sidebar>
 `;

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -3,13 +3,6 @@
 exports[`<Sidebar /> should render and match snapshot when open 1`] = `
 Array [
   .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   height: 100%;
   min-width: 256px;
   background-color: #212933;
@@ -17,10 +10,13 @@ Array [
   -webkit-transition: transform 200ms ease-in-out;
   transition: transform 200ms ease-in-out;
   position: absolute;
+  -webkit-transform: translateX(-100%);
+  -ms-transform: translateX(-100%);
+  transform: translateX(-100%);
+  z-index: 800;
   -webkit-transform: translateX(0);
   -ms-transform: translateX(0);
   transform: translateX(0);
-  z-index: 1000;
 }
 
 @media (min-width:768px) {
@@ -32,6 +28,14 @@ Array [
   }
 }
 
+@media (min-width:768px) {
+  .circuit-0 {
+    -webkit-transform: translateX(0);
+    -ms-transform: translateX(0);
+    transform: translateX(0);
+  }
+}
+
 <div
     className="circuit-0 circuit-1"
     open={true}
@@ -40,12 +44,14 @@ Array [
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: black;
+  background-color: #212933;
   -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 700;
   visibility: visible;
   opacity: 0.56;
-  z-index: 900;
 }
 
 @media (min-width:768px) {
@@ -96,9 +102,11 @@ Array [
   right: 16px;
   -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
   transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 800;
   visibility: visible;
   opacity: 1;
-  z-index: 1000;
 }
 
 @media (min-width:768px) {
@@ -124,13 +132,6 @@ Array [
 exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
 Array [
   .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   height: 100%;
   min-width: 256px;
   background-color: #212933;
@@ -138,10 +139,10 @@ Array [
   -webkit-transition: transform 200ms ease-in-out;
   transition: transform 200ms ease-in-out;
   position: absolute;
-  -webkit-transform: translateX(-256px);
-  -ms-transform: translateX(-256px);
-  transform: translateX(-256px);
-  z-index: 1000;
+  -webkit-transform: translateX(-100%);
+  -ms-transform: translateX(-100%);
+  transform: translateX(-100%);
+  z-index: 800;
 }
 
 @media (min-width:768px) {
@@ -161,12 +162,12 @@ Array [
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: black;
+  background-color: #212933;
   -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: hidden;
   opacity: 0;
-  z-index: 900;
+  z-index: 700;
 }
 
 @media (min-width:768px) {
@@ -204,7 +205,7 @@ Array [
   transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
   visibility: hidden;
   opacity: 0;
-  z-index: 1000;
+  z-index: 800;
 }
 
 @media (min-width:768px) {

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Sidebar /> should render and match snapshot when open 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12,9 +13,9 @@ exports[`<Sidebar /> should render and match snapshot when open 1`] = `
   height: 100%;
   width: 256px;
   background-color: #212933;
-  -webkit-transition: -webkit-transform 150ms ease-in-out;
-  -webkit-transition: transform 150ms ease-in-out;
-  transition: transform 150ms ease-in-out;
+  -webkit-transition: -webkit-transform 200ms ease-in-out;
+  -webkit-transition: transform 200ms ease-in-out;
+  transition: transform 200ms ease-in-out;
   position: absolute;
   -webkit-transform: translateX(0);
   -ms-transform: translateX(0);
@@ -31,25 +32,32 @@ exports[`<Sidebar /> should render and match snapshot when open 1`] = `
   }
 }
 
-.circuit-2 {
+<div
+    className="circuit-0 circuit-1"
+    open={true}
+  />,
+  .circuit-0 {
   width: 100%;
   height: 100%;
   position: absolute;
   background-color: black;
-  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
-  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: visible;
   opacity: 0.56;
   z-index: 0;
 }
 
 @media (min-width:768px) {
-  .circuit-2 {
+  .circuit-0 {
     visibility: hidden;
   }
 }
 
-.circuit-4 {
+<div
+    className="circuit-0 circuit-1"
+  />,
+  .circuit-0 {
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -78,55 +86,25 @@ exports[`<Sidebar /> should render and match snapshot when open 1`] = `
 }
 
 @media (min-width:768px) {
-  .circuit-4 {
+  .circuit-0 {
     visibility: hidden;
   }
 }
 
-<Sidebar
-  onClose={[MockFunction]}
-  open={true}
->
-  <Drawer
-    open={true}
-  >
-    <div
-      className="circuit-0 circuit-1"
-      open={true}
-    />
-  </Drawer>
-  <Backdrop
-    visible={true}
-  >
-    <div
-      className="circuit-2 circuit-3"
-    />
-  </Backdrop>
-  <CloseButton
+<button
+    className="circuit-0 circuit-1"
     onClick={[MockFunction]}
-    visible={true}
   >
-    <FloatingButton
-      onClick={[MockFunction]}
-      visible={true}
-    >
-      <button
-        className="circuit-4 circuit-5"
-        onClick={[MockFunction]}
-      >
-        <Component>
-          <div>
-            closeIcon.svg
-          </div>
-        </Component>
-      </button>
-    </FloatingButton>
-  </CloseButton>
-</Sidebar>
+    <div>
+      closeIcon.svg
+    </div>
+  </button>,
+]
 `;
 
 exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
-.circuit-0 {
+Array [
+  .circuit-0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -137,9 +115,9 @@ exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
   height: 100%;
   width: 256px;
   background-color: #212933;
-  -webkit-transition: -webkit-transform 150ms ease-in-out;
-  -webkit-transition: transform 150ms ease-in-out;
-  transition: transform 150ms ease-in-out;
+  -webkit-transition: -webkit-transform 200ms ease-in-out;
+  -webkit-transition: transform 200ms ease-in-out;
+  transition: transform 200ms ease-in-out;
   position: absolute;
   -webkit-transform: translateX(-256px);
   -ms-transform: translateX(-256px);
@@ -156,25 +134,32 @@ exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
   }
 }
 
-.circuit-2 {
+<div
+    className="circuit-0 circuit-1"
+    open={false}
+  />,
+  .circuit-0 {
   width: 100%;
   height: 100%;
   position: absolute;
   background-color: black;
-  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
-  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: hidden;
   opacity: 0;
   z-index: 0;
 }
 
 @media (min-width:768px) {
-  .circuit-2 {
+  .circuit-0 {
     visibility: hidden;
   }
 }
 
-.circuit-4 {
+<div
+    className="circuit-0 circuit-1"
+  />,
+  .circuit-0 {
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -203,49 +188,18 @@ exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
 }
 
 @media (min-width:768px) {
-  .circuit-4 {
+  .circuit-0 {
     visibility: hidden;
   }
 }
 
-<Sidebar
-  onClose={[MockFunction]}
-  open={false}
->
-  <Drawer
-    open={false}
-  >
-    <div
-      className="circuit-0 circuit-1"
-      open={false}
-    />
-  </Drawer>
-  <Backdrop
-    visible={false}
-  >
-    <div
-      className="circuit-2 circuit-3"
-    />
-  </Backdrop>
-  <CloseButton
+<button
+    className="circuit-0 circuit-1"
     onClick={[MockFunction]}
-    visible={false}
   >
-    <FloatingButton
-      onClick={[MockFunction]}
-      visible={false}
-    >
-      <button
-        className="circuit-4 circuit-5"
-        onClick={[MockFunction]}
-      >
-        <Component>
-          <div>
-            closeIcon.svg
-          </div>
-        </Component>
-      </button>
-    </FloatingButton>
-  </CloseButton>
-</Sidebar>
+    <div>
+      closeIcon.svg
+    </div>
+  </button>,
+]
 `;

--- a/src/components/Sidebar/components/Backdrop/Backdrop.js
+++ b/src/components/Sidebar/components/Backdrop/Backdrop.js
@@ -11,7 +11,7 @@ const baseStyles = ({ theme, visible }) => css`
     visibility ${theme.transitions.default};
   visibility: ${visible ? 'visible' : 'hidden'};
   opacity: ${visible ? 0.56 : 0};
-  z-index: 0;
+  z-index: ${theme.zIndex.backdrop};
   ${theme.mq.mega`
     visibility: hidden;  
   `};

--- a/src/components/Sidebar/components/Backdrop/Backdrop.js
+++ b/src/components/Sidebar/components/Backdrop/Backdrop.js
@@ -2,12 +2,13 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 const baseStyles = ({ theme, visible }) => css`
-  label: backdrop;
+  label: sidebar-backdrop;
   width: 100%;
   height: 100%;
   position: absolute;
   background-color: black;
-  transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
+  transition: opacity ${theme.transitions.default},
+    visibility ${theme.transitions.default};
   visibility: ${visible ? 'visible' : 'hidden'};
   opacity: ${visible ? 0.56 : 0};
   z-index: 0;

--- a/src/components/Sidebar/components/Backdrop/Backdrop.js
+++ b/src/components/Sidebar/components/Backdrop/Backdrop.js
@@ -1,23 +1,31 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
-const baseStyles = ({ theme, visible }) => css`
+const baseStyles = ({ theme }) => css`
   label: sidebar-backdrop;
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: black;
+  background-color: ${theme.colors.n900};
   transition: opacity ${theme.transitions.default},
     visibility ${theme.transitions.default};
-  visibility: ${visible ? 'visible' : 'hidden'};
-  opacity: ${visible ? 0.56 : 0};
+  visibility: hidden;
+  opacity: 0;
   z-index: ${theme.zIndex.backdrop};
   ${theme.mq.mega`
     visibility: hidden;  
   `};
 `;
 
-const Backdrop = styled('div')(baseStyles);
+const visibleStyles = ({ visible }) =>
+  visible &&
+  css`
+    label: sidebar-backdrop--visible;
+    visibility: visible;
+    opacity: 0.56;
+  `;
+
+const Backdrop = styled('div')(baseStyles, visibleStyles);
 
 Backdrop.propTypes = {
   /**

--- a/src/components/Sidebar/components/Backdrop/Backdrop.js
+++ b/src/components/Sidebar/components/Backdrop/Backdrop.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 const baseStyles = ({ theme, visible }) => css`
+  label: backdrop;
   width: 100%;
   height: 100%;
   position: absolute;

--- a/src/components/Sidebar/components/Backdrop/Backdrop.js
+++ b/src/components/Sidebar/components/Backdrop/Backdrop.js
@@ -4,7 +4,7 @@ import styled, { css } from 'react-emotion';
 const baseStyles = ({ theme, visible }) => css`
   width: 100%;
   height: 100%;
-  position: relative;
+  position: absolute;
   background-color: black;
   transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
   visibility: ${visible ? 'visible' : 'hidden'};

--- a/src/components/Sidebar/components/Backdrop/Backdrop.js
+++ b/src/components/Sidebar/components/Backdrop/Backdrop.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+
+const baseStyles = ({ theme, visible }) => css`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  background-color: black;
+  transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
+  visibility: ${visible ? 'visible' : 'hidden'};
+  opacity: ${visible ? 0.56 : 0};
+  z-index: 0;
+  ${theme.mq.mega`
+    visibility: hidden;  
+  `};
+`;
+
+const Backdrop = styled('div')(baseStyles);
+
+Backdrop.propTypes = {
+  /**
+   * The children component passed to the Sidebar
+   */
+  children: PropTypes.node,
+  /**
+   * Tells if the Backdrop is visible
+   */
+  visible: PropTypes.bool
+};
+
+export default Backdrop;

--- a/src/components/Sidebar/components/Backdrop/Backdrop.spec.js
+++ b/src/components/Sidebar/components/Backdrop/Backdrop.spec.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import Backdrop from './Backdrop';
+
+describe.skip('Backdrop', () => {
+  // !TODO: write your tests.
+  describe('styles', () => {
+    it('should render with default styles', () => {
+      const actual = create(<Backdrop />);
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('business logic', () => {
+    it('should have tests');
+  });
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<Backdrop />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/components/Backdrop/Backdrop.spec.js
+++ b/src/components/Sidebar/components/Backdrop/Backdrop.spec.js
@@ -2,18 +2,19 @@ import React from 'react';
 
 import Backdrop from './Backdrop';
 
-describe.skip('Backdrop', () => {
-  // !TODO: write your tests.
+describe('Backdrop', () => {
   describe('styles', () => {
-    it('should render with default styles', () => {
-      const actual = create(<Backdrop />);
+    it('should render with default styles when not visible', () => {
+      const actual = create(<Backdrop visible={false} />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with default styles when visible', () => {
+      const actual = create(<Backdrop visible={true} />);
       expect(actual).toMatchSnapshot();
     });
   });
 
-  describe('business logic', () => {
-    it('should have tests');
-  });
   describe('accessibility', () => {
     it('should meet accessibility guidelines', async () => {
       const wrapper = renderToHtml(<Backdrop />);

--- a/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
+++ b/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
@@ -10,7 +10,7 @@ exports[`Backdrop styles should render with default styles when not visible 1`] 
   transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: hidden;
   opacity: 0;
-  z-index: 0;
+  z-index: 900;
 }
 
 @media (min-width:768px) {
@@ -34,7 +34,7 @@ exports[`Backdrop styles should render with default styles when visible 1`] = `
   transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: visible;
   opacity: 0.56;
-  z-index: 0;
+  z-index: 900;
 }
 
 @media (min-width:768px) {

--- a/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
+++ b/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
@@ -6,8 +6,8 @@ exports[`Backdrop styles should render with default styles when not visible 1`] 
   height: 100%;
   position: absolute;
   background-color: black;
-  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
-  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: hidden;
   opacity: 0;
   z-index: 0;
@@ -30,8 +30,8 @@ exports[`Backdrop styles should render with default styles when visible 1`] = `
   height: 100%;
   position: absolute;
   background-color: black;
-  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
-  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: visible;
   opacity: 0.56;
   z-index: 0;

--- a/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
+++ b/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
@@ -5,12 +5,12 @@ exports[`Backdrop styles should render with default styles when not visible 1`] 
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: black;
+  background-color: #212933;
   -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   visibility: hidden;
   opacity: 0;
-  z-index: 900;
+  z-index: 700;
 }
 
 @media (min-width:768px) {
@@ -29,12 +29,14 @@ exports[`Backdrop styles should render with default styles when visible 1`] = `
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: black;
+  background-color: #212933;
   -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
   transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 700;
   visibility: visible;
   opacity: 0.56;
-  z-index: 900;
 }
 
 @media (min-width:768px) {

--- a/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
+++ b/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Backdrop styles should render with default styles when not visible 1`] = `
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  background-color: black;
+  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 0;
+}
+
+@media (min-width:768px) {
+  .circuit-0 {
+    visibility: hidden;
+  }
+}
+
+<div
+  className="circuit-0 circuit-1"
+/>
+`;
+
+exports[`Backdrop styles should render with default styles when visible 1`] = `
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  background-color: black;
+  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: visible;
+  opacity: 0.56;
+  z-index: 0;
+}
+
+@media (min-width:768px) {
+  .circuit-0 {
+    visibility: hidden;
+  }
+}
+
+<div
+  className="circuit-0 circuit-1"
+/>
+`;

--- a/src/components/Sidebar/components/Backdrop/index.js
+++ b/src/components/Sidebar/components/Backdrop/index.js
@@ -1,0 +1,3 @@
+import Backdrop from './Backdrop';
+
+export default Backdrop;

--- a/src/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.js
@@ -1,0 +1,23 @@
+import styled, { css } from 'react-emotion';
+
+const baseStyles = ({ theme, visible }) => css`
+  outline: none;
+  height: 40px;
+  width: 40px;
+  border-radius: 50%;
+  background-color: ${theme.colors.n100};
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
+  visibility: ${visible ? 'visible' : 'hidden'};
+  opacity: ${visible ? 1 : 0};
+  z-index: 1;
+  ${theme.mq.mega`
+    visibility: hidden;  
+  `};
+`;
+
+const CloseButton = styled('button')(baseStyles);
+
+export default CloseButton;

--- a/src/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.js
@@ -8,8 +8,8 @@ const baseStyles = ({ theme, visible }) => css`
   border-radius: 50%;
   background-color: ${theme.colors.n100};
   position: absolute;
-  bottom: 16px;
-  right: 16px;
+  bottom: ${theme.spacings.mega};
+  right: ${theme.spacings.mega};
   transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
   visibility: ${visible ? 'visible' : 'hidden'};
   opacity: ${visible ? 1 : 0};

--- a/src/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'react-emotion';
+import PropTypes from 'prop-types';
 
 const baseStyles = ({ theme, visible }) => css`
   outline: none;
@@ -19,5 +20,12 @@ const baseStyles = ({ theme, visible }) => css`
 `;
 
 const CloseButton = styled('button')(baseStyles);
+
+CloseButton.propTypes = {
+  /**
+   * Tells if the CloseButton is visible
+   */
+  visible: PropTypes.bool
+};
 
 export default CloseButton;

--- a/src/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.js
@@ -7,6 +7,7 @@ import CloseIcon from './closeIcon.svg';
 
 const baseStyles = ({ theme, visible }) => css`
   label: close-button;
+  cursor: pointer;
   outline: none;
   display: flex;
   align-items: center;
@@ -21,7 +22,7 @@ const baseStyles = ({ theme, visible }) => css`
   transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
   visibility: ${visible ? 'visible' : 'hidden'};
   opacity: ${visible ? 1 : 0};
-  z-index: 1;
+  z-index: ${theme.zIndex.modal};
   ${theme.mq.mega`
     visibility: hidden;  
   `};

--- a/src/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.js
@@ -1,8 +1,15 @@
+import React from 'react';
 import styled, { css } from 'react-emotion';
 import PropTypes from 'prop-types';
 
+import CloseIcon from './closeIcon.svg';
+
 const baseStyles = ({ theme, visible }) => css`
+  label: close-button;
   outline: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   height: 40px;
   width: 40px;
   border-radius: 50%;
@@ -19,13 +26,23 @@ const baseStyles = ({ theme, visible }) => css`
   `};
 `;
 
-const CloseButton = styled('button')(baseStyles);
+const FloatingButton = styled('button')(baseStyles);
+
+const CloseButton = ({ visible, onClick }) => (
+  <FloatingButton visible={visible} onClick={onClick}>
+    <CloseIcon />
+  </FloatingButton>
+);
 
 CloseButton.propTypes = {
   /**
    * Tells if the CloseButton is visible
    */
-  visible: PropTypes.bool
+  visible: PropTypes.bool,
+  /**
+   * A function to handle the the click on the CloseButton
+   */
+  onClick: PropTypes.func
 };
 
 export default CloseButton;

--- a/src/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled, { css } from 'react-emotion';
 import PropTypes from 'prop-types';
 
+import { hideVisually } from 'polished';
 import CloseIcon from './closeIcon.svg';
 
 const baseStyles = ({ theme, visible }) => css`
@@ -26,11 +27,16 @@ const baseStyles = ({ theme, visible }) => css`
   `};
 `;
 
+const AccessibilityLabel = styled.span`
+  ${hideVisually()};
+`;
+
 const FloatingButton = styled('button')(baseStyles);
 
-const CloseButton = ({ visible, onClick }) => (
+const CloseButton = ({ visible, closeButtonLabel, onClick }) => (
   <FloatingButton visible={visible} onClick={onClick}>
-    <CloseIcon />
+    <AccessibilityLabel>{closeButtonLabel}</AccessibilityLabel>
+    <CloseIcon aria-hidden="true" />
   </FloatingButton>
 );
 
@@ -39,6 +45,10 @@ CloseButton.propTypes = {
    * Tells if the CloseButton is visible
    */
   visible: PropTypes.bool,
+  /**
+   * Accessibility label for the CloseButton
+   */
+  closeButtonLabel: PropTypes.string.isRequired,
   /**
    * A function to handle the the click on the CloseButton
    */

--- a/src/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { hideVisually } from 'polished';
 import CloseIcon from './closeIcon.svg';
 
-const baseStyles = ({ theme, visible }) => css`
+const baseStyles = ({ theme }) => css`
   label: close-button;
   cursor: pointer;
   outline: none;
@@ -20,19 +20,27 @@ const baseStyles = ({ theme, visible }) => css`
   bottom: ${theme.spacings.mega};
   right: ${theme.spacings.mega};
   transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
-  visibility: ${visible ? 'visible' : 'hidden'};
-  opacity: ${visible ? 1 : 0};
-  z-index: ${theme.zIndex.modal};
+  visibility: hidden;
+  opacity: 0;
+  z-index: ${theme.zIndex.sidebar};
   ${theme.mq.mega`
     visibility: hidden;  
   `};
 `;
 
+const visibleStyles = ({ visible }) =>
+  visible &&
+  css`
+    label: close-button--visible;
+    visibility: visible;
+    opacity: 1;
+  `;
+
 const AccessibilityLabel = styled.span`
   ${hideVisually()};
 `;
 
-const FloatingButton = styled('button')(baseStyles);
+const FloatingButton = styled('button')(baseStyles, visibleStyles);
 
 const CloseButton = ({ visible, closeButtonLabel, onClick }) => (
   <FloatingButton visible={visible} onClick={onClick}>

--- a/src/components/Sidebar/components/CloseButton/CloseButton.spec.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.spec.js
@@ -2,18 +2,19 @@ import React from 'react';
 
 import CloseButton from './CloseButton';
 
-describe.skip('CloseButton', () => {
-  // !TODO: write your tests.
+describe('CloseButton', () => {
   describe('styles', () => {
-    it('should render with default styles', () => {
-      const actual = create(<CloseButton />);
+    it('should render and match snapshot when not visible', () => {
+      const actual = create(<CloseButton visible={false} />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render and match snapshot when visible', () => {
+      const actual = create(<CloseButton visible={true} />);
       expect(actual).toMatchSnapshot();
     });
   });
 
-  describe('business logic', () => {
-    it('should have tests');
-  });
   describe('accessibility', () => {
     it('should meet accessibility guidelines', async () => {
       const wrapper = renderToHtml(<CloseButton />);

--- a/src/components/Sidebar/components/CloseButton/CloseButton.spec.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.spec.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import CloseButton from './CloseButton';
+
+describe.skip('CloseButton', () => {
+  // !TODO: write your tests.
+  describe('styles', () => {
+    it('should render with default styles', () => {
+      const actual = create(<CloseButton />);
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('business logic', () => {
+    it('should have tests');
+  });
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<CloseButton />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -27,7 +27,7 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
   transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
   visibility: hidden;
   opacity: 0;
-  z-index: 1000;
+  z-index: 800;
 }
 
 @media (min-width:768px) {
@@ -104,9 +104,11 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
   right: 16px;
   -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
   transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 800;
   visibility: visible;
   opacity: 1;
-  z-index: 1000;
 }
 
 @media (min-width:768px) {

--- a/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CloseButton styles should render and match snapshot when not visible 1`] = `
+.circuit-0 {
+  outline: none;
+  height: 40px;
+  width: 40px;
+  border-radius: 50%;
+  background-color: #FAFBFC;
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 1;
+}
+
+@media (min-width:768px) {
+  .circuit-0 {
+    visibility: hidden;
+  }
+}
+
+<button
+  className="circuit-0 circuit-1"
+/>
+`;
+
+exports[`CloseButton styles should render and match snapshot when visible 1`] = `
+.circuit-0 {
+  outline: none;
+  height: 40px;
+  width: 40px;
+  border-radius: 50%;
+  background-color: #FAFBFC;
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: visible;
+  opacity: 1;
+  z-index: 1;
+}
+
+@media (min-width:768px) {
+  .circuit-0 {
+    visibility: hidden;
+  }
+}
+
+<button
+  className="circuit-0 circuit-1"
+/>
+`;

--- a/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -3,6 +3,18 @@
 exports[`CloseButton styles should render and match snapshot when not visible 1`] = `
 .circuit-0 {
   outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   height: 40px;
   width: 40px;
   border-radius: 50%;
@@ -25,12 +37,29 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
 
 <button
   className="circuit-0 circuit-1"
-/>
+  onClick={undefined}
+>
+  <div>
+    closeIcon.svg
+  </div>
+</button>
 `;
 
 exports[`CloseButton styles should render and match snapshot when visible 1`] = `
 .circuit-0 {
   outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   height: 40px;
   width: 40px;
   border-radius: 50%;
@@ -53,5 +82,10 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
 
 <button
   className="circuit-0 circuit-1"
-/>
+  onClick={undefined}
+>
+  <div>
+    closeIcon.svg
+  </div>
+</button>
 `;

--- a/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CloseButton styles should render and match snapshot when not visible 1`] = `
-.circuit-0 {
+.circuit-2 {
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -30,15 +30,33 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
 }
 
 @media (min-width:768px) {
-  .circuit-0 {
+  .circuit-2 {
     visibility: hidden;
   }
 }
 
+.circuit-0 {
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 <button
-  className="circuit-0 circuit-1"
+  className="circuit-2 circuit-3"
   onClick={undefined}
 >
+  <span
+    className="circuit-0 circuit-1"
+  />
   <div>
     closeIcon.svg
   </div>
@@ -47,6 +65,21 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
 
 exports[`CloseButton styles should render and match snapshot when visible 1`] = `
 .circuit-0 {
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-2 {
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -75,15 +108,18 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
 }
 
 @media (min-width:768px) {
-  .circuit-0 {
+  .circuit-2 {
     visibility: hidden;
   }
 }
 
 <button
-  className="circuit-0 circuit-1"
+  className="circuit-2 circuit-3"
   onClick={undefined}
 >
+  <span
+    className="circuit-0 circuit-1"
+  />
   <div>
     closeIcon.svg
   </div>

--- a/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`CloseButton styles should render and match snapshot when not visible 1`] = `
 .circuit-2 {
+  cursor: pointer;
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -26,7 +27,7 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
   transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
   visibility: hidden;
   opacity: 0;
-  z-index: 1;
+  z-index: 1000;
 }
 
 @media (min-width:768px) {
@@ -80,6 +81,7 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
 }
 
 .circuit-2 {
+  cursor: pointer;
   outline: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -104,7 +106,7 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
   transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
   visibility: visible;
   opacity: 1;
-  z-index: 1;
+  z-index: 1000;
 }
 
 @media (min-width:768px) {

--- a/src/components/Sidebar/components/CloseButton/closeIcon.svg
+++ b/src/components/Sidebar/components/CloseButton/closeIcon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="#212933" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>

--- a/src/components/Sidebar/components/CloseButton/index.js
+++ b/src/components/Sidebar/components/CloseButton/index.js
@@ -1,0 +1,3 @@
+import CloseButton from './CloseButton';
+
+export default CloseButton;

--- a/src/components/Sidebar/components/Header/Header.js
+++ b/src/components/Sidebar/components/Header/Header.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+
+const baseStyles = ({ theme }) => css`
+  display: flex;
+  align-self: flex-start;
+  align-items: center;
+  justify-content: flex-start;
+  height: 64px;
+  width: 100%;
+  padding: 20px;
+  background-color: ${theme.colors.bodyColor};
+  color: ${theme.colors.n100};
+`;
+
+const Header = styled('div')(baseStyles);
+
+Header.propTypes = {
+  /**
+   * The children component passed to the Sidebar
+   */
+  children: PropTypes.node
+};
+
+export default Header;

--- a/src/components/Sidebar/components/Header/Header.js
+++ b/src/components/Sidebar/components/Header/Header.js
@@ -8,7 +8,7 @@ const baseStyles = ({ theme }) => css`
   justify-content: flex-start;
   height: 64px;
   width: 100%;
-  padding: 20px;
+  padding: ${theme.spacings.giga};
   background-color: ${theme.colors.bodyColor};
   color: ${theme.colors.n100};
 `;

--- a/src/components/Sidebar/components/Header/Header.js
+++ b/src/components/Sidebar/components/Header/Header.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 const baseStyles = ({ theme }) => css`
+  label: header;
   display: flex;
   align-self: flex-start;
   align-items: center;

--- a/src/components/Sidebar/components/Header/Header.spec.js
+++ b/src/components/Sidebar/components/Header/Header.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import Header from './Header';
+
+describe('Header', () => {
+  describe('styles', () => {
+    it('should render with default styles', () => {
+      const actual = create(<Header />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render children', () => {
+      const wrapper = shallow(
+        <Header>
+          <span data-selector="child">text node</span>
+        </Header>
+      );
+      const actual = wrapper.find('[data-selector="child"]');
+
+      expect(actual).toHaveLength(1);
+      expect(actual.text()).toEqual('text node');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<Header />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
@@ -19,7 +19,7 @@ exports[`Header styles should render with default styles 1`] = `
   justify-content: flex-start;
   height: 64px;
   width: 100%;
-  padding: 20px;
+  padding: 24px;
   background-color: #0F131A;
   color: #FAFBFC;
 }

--- a/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header styles should render with default styles 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  height: 64px;
+  width: 100%;
+  padding: 20px;
+  background-color: #0F131A;
+  color: #FAFBFC;
+}
+
+<div
+  className="circuit-0 circuit-1"
+/>
+`;

--- a/src/components/Sidebar/components/Header/index.js
+++ b/src/components/Sidebar/components/Header/index.js
@@ -1,0 +1,3 @@
+import Header from './Header';
+
+export default Header;

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -7,8 +7,8 @@ const baseStyles = ({ theme }) => css`
   align-items: center;
   justify-content: flex-start;
   height: auto;
-  margin: 16px;
-  padding: 4px;
+  margin: ${theme.spacings.mega};
+  padding: ${theme.spacings.bit};
   cursor: pointer;
   color: ${theme.colors.n500};
 `;
@@ -23,15 +23,15 @@ const hoverStyles = ({ theme, selected }) => css`
 
 const activeStyles = ({ theme, selected }) => css`
   color: ${selected && theme.colors.n100};
-  font-weight: ${selected && 'bold'};
+  font-weight: ${selected && theme.fontWeight.bold};
   &:active {
     color: ${theme.colors.n100};
-    font-weight: bold;
+    font-weight: ${theme.fontWeight.bold};
   }
 `;
 
-const iconWrapperStyles = () => css`
-  margin-right: 12px;
+const iconWrapperStyles = ({ theme }) => css`
+  margin-right: ${theme.spacings.kilo};
 `;
 
 const ListItem = styled('li')(baseStyles, hoverStyles, activeStyles);

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -15,25 +15,25 @@ const baseStyles = ({ theme }) => css`
   fill: ${theme.colors.n500};
 `;
 
-const hoverStyles = ({ theme, selected }) => css`
-  label: nav-item__hover;
-  @media (hover: hover) {
-    &:hover {
-      color: ${!selected && theme.colors.n300};
-      fill: ${!selected && theme.colors.n300};
+const hoverStyles = ({ theme, selected }) =>
+  !selected &&
+  css`
+    label: nav-item__hover;
+    @media (hover: hover) {
+      &:hover {
+        color: ${theme.colors.n300};
+        fill: ${theme.colors.n300};
+      }
     }
-  }
-`;
+  `;
 
-const activeStyles = ({ theme, selected }) => css`
-  label: nav-item__active;
-  color: ${selected && theme.colors.n100};
-  font-weight: ${selected && theme.fontWeight.bold};
-  &:active {
+const activeStyles = ({ theme, selected }) =>
+  selected &&
+  css`
+    label: nav-item__active;
     color: ${theme.colors.n100};
     font-weight: ${theme.fontWeight.bold};
-  }
-`;
+  `;
 
 const ListItem = styled('li')(baseStyles, hoverStyles, activeStyles);
 

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+
+const baseStyles = ({ theme }) => css`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: auto;
+  margin: 16px;
+  padding: 4px;
+  cursor: pointer;
+  color: ${theme.colors.n500};
+`;
+
+const hoverStyles = ({ theme, selected }) => css`
+  @media (hover: hover) {
+    &:hover {
+      color: ${!selected && theme.colors.n300};
+    }
+  }
+`;
+
+const activeStyles = ({ theme, selected }) => css`
+  color: ${selected && theme.colors.n100};
+  font-weight: ${selected && 'bold'};
+  &:active {
+    color: ${theme.colors.n100};
+    font-weight: bold;
+  }
+`;
+
+const iconWrapperStyles = () => css`
+  margin-right: 12px;
+`;
+
+const ListItem = styled('li')(baseStyles, hoverStyles, activeStyles);
+const IconWrapper = styled('div')(iconWrapperStyles);
+
+const NavItem = ({ children, icon, selected, onClick }) => (
+  <ListItem selected={selected} onClick={onClick}>
+    {icon && <IconWrapper>{icon}</IconWrapper>}
+    {children}
+  </ListItem>
+);
+
+NavItem.propTypes = {
+  /**
+   * The children component passed to the Sidebar
+   */
+  children: PropTypes.node,
+  /**
+   * The icon to be shown befor the Item title
+   */
+  icon: PropTypes.node,
+  /**
+   * Tells if the item is selected
+   */
+  selected: PropTypes.bool,
+  /**
+   * The onClick method to handle the click event on NavItems
+   */
+  onClick: PropTypes.func
+};
+
+export default NavItem;

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -19,11 +19,9 @@ const hoverStyles = ({ theme, selected }) =>
   !selected &&
   css`
     label: nav-item__hover;
-    @media (hover: hover) {
-      &:hover {
-        color: ${theme.colors.n300};
-        fill: ${theme.colors.n300};
-      }
+    &:hover {
+      color: ${theme.colors.n300};
+      fill: ${theme.colors.n300};
     }
   `;
 

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -18,7 +18,7 @@ const baseStyles = ({ theme }) => css`
 const hoverStyles = ({ theme, selected }) =>
   !selected &&
   css`
-    label: nav-item__hover;
+    label: nav-item--hover;
     &:hover {
       color: ${theme.colors.n300};
       fill: ${theme.colors.n300};
@@ -28,7 +28,7 @@ const hoverStyles = ({ theme, selected }) =>
 const activeStyles = ({ theme, selected }) =>
   selected &&
   css`
-    label: nav-item__active;
+    label: nav-item--active;
     color: ${theme.colors.n100};
     font-weight: ${theme.fontWeight.bold};
   `;
@@ -36,6 +36,7 @@ const activeStyles = ({ theme, selected }) =>
 const ListItem = styled('li')(baseStyles, hoverStyles, activeStyles);
 
 const labelWrapperStyles = ({ theme }) => css`
+  label: nav-item__label-wrapper;
   margin-left: ${theme.spacings.kilo};
 `;
 

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 const baseStyles = ({ theme }) => css`
+  label: nav-item;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -11,17 +12,21 @@ const baseStyles = ({ theme }) => css`
   padding: ${theme.spacings.bit};
   cursor: pointer;
   color: ${theme.colors.n500};
+  fill: ${theme.colors.n500};
 `;
 
 const hoverStyles = ({ theme, selected }) => css`
+  label: nav-item__hover;
   @media (hover: hover) {
     &:hover {
       color: ${!selected && theme.colors.n300};
+      fill: ${!selected && theme.colors.n300};
     }
   }
 `;
 
 const activeStyles = ({ theme, selected }) => css`
+  label: nav-item__active;
   color: ${selected && theme.colors.n100};
   font-weight: ${selected && theme.fontWeight.bold};
   &:active {
@@ -30,17 +35,24 @@ const activeStyles = ({ theme, selected }) => css`
   }
 `;
 
-const iconWrapperStyles = ({ theme }) => css`
-  margin-right: ${theme.spacings.kilo};
+const ListItem = styled('li')(baseStyles, hoverStyles, activeStyles);
+
+const labelWrapperStyles = ({ theme }) => css`
+  margin-left: ${theme.spacings.kilo};
 `;
 
-const ListItem = styled('li')(baseStyles, hoverStyles, activeStyles);
-const IconWrapper = styled('div')(iconWrapperStyles);
+const LabelWrapper = styled('div')(labelWrapperStyles);
 
-const NavItem = ({ children, icon, selected, onClick }) => (
+const NavItem = ({
+  children,
+  defaultIcon,
+  selectedIcon,
+  selected,
+  onClick
+}) => (
   <ListItem selected={selected} onClick={onClick}>
-    {icon && <IconWrapper>{icon}</IconWrapper>}
-    {children}
+    {defaultIcon && selectedIcon && selected ? selectedIcon : defaultIcon}
+    <LabelWrapper>{children}</LabelWrapper>
   </ListItem>
 );
 
@@ -50,9 +62,13 @@ NavItem.propTypes = {
    */
   children: PropTypes.node,
   /**
-   * The icon to be shown befor the Item title
+   * The icon to be shown when the NavItem is not selected
    */
-  icon: PropTypes.node,
+  defaultIcon: PropTypes.node,
+  /**
+   * The icon to be shown when the NavItem is selected
+   */
+  selectedIcon: PropTypes.node,
   /**
    * Tells if the item is selected
    */

--- a/src/components/Sidebar/components/NavItem/NavItem.spec.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.spec.js
@@ -37,11 +37,11 @@ describe('NavItem', () => {
 
     it('should render an icon', () => {
       const wrapper = shallow(
-        <NavItem icon={<div />}>
+        <NavItem defaultIcon={<div data-selector="icon" />}>
           <span data-selector="child">text node</span>
         </NavItem>
       );
-      const actual = wrapper.find('IconWrapper');
+      const actual = wrapper.find('[data-selector="icon"]');
 
       expect(actual).toHaveLength(1);
     });

--- a/src/components/Sidebar/components/NavItem/NavItem.spec.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.spec.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import NavList from '../NavList';
+import NavItem from './NavItem';
+
+describe('NavItem', () => {
+  describe('styles', () => {
+    it('should render with default styles and match the snapshot', () => {
+      const props = {
+        selected: false,
+        onClick: jest.fn()
+      };
+      const actual = create(<NavItem {...props} />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with selected state styles and match the snapshot', () => {
+      const props = {
+        selected: true,
+        onClick: jest.fn()
+      };
+      const actual = create(<NavItem {...props} />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render children', () => {
+      const wrapper = shallow(
+        <NavItem>
+          <span data-selector="child">text node</span>
+        </NavItem>
+      );
+      const actual = wrapper.find('[data-selector="child"]');
+
+      expect(actual).toHaveLength(1);
+      expect(actual.text()).toEqual('text node');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(
+        <NavList>
+          <NavItem />
+        </NavList>
+      );
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/components/NavItem/NavItem.spec.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.spec.js
@@ -34,6 +34,17 @@ describe('NavItem', () => {
       expect(actual).toHaveLength(1);
       expect(actual.text()).toEqual('text node');
     });
+
+    it('should render an icon', () => {
+      const wrapper = shallow(
+        <NavItem icon={<div />}>
+          <span data-selector="child">text node</span>
+        </NavItem>
+      );
+      const actual = wrapper.find('IconWrapper');
+
+      expect(actual).toHaveLength(1);
+    });
   });
 
   describe('accessibility', () => {

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -29,11 +29,6 @@ exports[`NavItem styles should render with default styles and match the snapshot
   }
 }
 
-.circuit-2:active {
-  color: #FAFBFC;
-  font-weight: 700;
-}
-
 .circuit-0 {
   margin-left: 12px;
 }
@@ -73,15 +68,6 @@ exports[`NavItem styles should render with selected state styles and match the s
   cursor: pointer;
   color: #9DA7B1;
   fill: #9DA7B1;
-  color: #FAFBFC;
-  font-weight: 700;
-}
-
-@media (hover:hover) {
-
-}
-
-.circuit-2:active {
   color: #FAFBFC;
   font-weight: 700;
 }

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -22,11 +22,9 @@ exports[`NavItem styles should render with default styles and match the snapshot
   fill: #9DA7B1;
 }
 
-@media (hover:hover) {
-  .circuit-2:hover {
-    color: #D8DDE1;
-    fill: #D8DDE1;
-  }
+.circuit-2:hover {
+  color: #D8DDE1;
+  fill: #D8DDE1;
 }
 
 .circuit-0 {

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavItem styles should render with default styles and match the snapshot 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  height: auto;
+  margin: 16px;
+  padding: 4px;
+  cursor: pointer;
+  color: #9DA7B1;
+}
+
+@media (hover:hover) {
+  .circuit-0:hover {
+    color: #D8DDE1;
+  }
+}
+
+.circuit-0:active {
+  color: #FAFBFC;
+  font-weight: bold;
+}
+
+<li
+  className="circuit-0 circuit-1"
+  onClick={[MockFunction]}
+  selected={false}
+/>
+`;
+
+exports[`NavItem styles should render with selected state styles and match the snapshot 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  height: auto;
+  margin: 16px;
+  padding: 4px;
+  cursor: pointer;
+  color: #9DA7B1;
+  color: #FAFBFC;
+  font-weight: bold;
+}
+
+@media (hover:hover) {
+
+}
+
+.circuit-0:active {
+  color: #FAFBFC;
+  font-weight: bold;
+}
+
+<li
+  className="circuit-0 circuit-1"
+  onClick={[MockFunction]}
+  selected={true}
+/>
+`;

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NavItem styles should render with default styles and match the snapshot 1`] = `
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -19,28 +19,42 @@ exports[`NavItem styles should render with default styles and match the snapshot
   padding: 4px;
   cursor: pointer;
   color: #9DA7B1;
+  fill: #9DA7B1;
 }
 
 @media (hover:hover) {
-  .circuit-0:hover {
+  .circuit-2:hover {
     color: #D8DDE1;
+    fill: #D8DDE1;
   }
 }
 
-.circuit-0:active {
+.circuit-2:active {
   color: #FAFBFC;
-  font-weight: bold;
+  font-weight: 700;
+}
+
+.circuit-0 {
+  margin-left: 12px;
 }
 
 <li
-  className="circuit-0 circuit-1"
+  className="circuit-2 circuit-3"
   onClick={[MockFunction]}
   selected={false}
-/>
+>
+  <div
+    className="circuit-0 circuit-1"
+  />
+</li>
 `;
 
 exports[`NavItem styles should render with selected state styles and match the snapshot 1`] = `
 .circuit-0 {
+  margin-left: 12px;
+}
+
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -58,22 +72,27 @@ exports[`NavItem styles should render with selected state styles and match the s
   padding: 4px;
   cursor: pointer;
   color: #9DA7B1;
+  fill: #9DA7B1;
   color: #FAFBFC;
-  font-weight: bold;
+  font-weight: 700;
 }
 
 @media (hover:hover) {
 
 }
 
-.circuit-0:active {
+.circuit-2:active {
   color: #FAFBFC;
-  font-weight: bold;
+  font-weight: 700;
 }
 
 <li
-  className="circuit-0 circuit-1"
+  className="circuit-2 circuit-3"
   onClick={[MockFunction]}
   selected={true}
-/>
+>
+  <div
+    className="circuit-0 circuit-1"
+  />
+</li>
 `;

--- a/src/components/Sidebar/components/NavItem/index.js
+++ b/src/components/Sidebar/components/NavItem/index.js
@@ -1,0 +1,3 @@
+import NavItem from './NavItem';
+
+export default NavItem;

--- a/src/components/Sidebar/components/NavList/NavList.js
+++ b/src/components/Sidebar/components/NavList/NavList.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+
+const baseStyles = () => css`
+  height: auto;
+  justify-self: flex-start;
+  overflow-y: auto;
+  width: 100%;
+`;
+
+const NavList = styled('ul')(baseStyles);
+
+NavList.propTypes = {
+  /**
+   * The children component passed to the Sidebar
+   */
+  children: PropTypes.node
+};
+
+export default NavList;

--- a/src/components/Sidebar/components/NavList/NavList.js
+++ b/src/components/Sidebar/components/NavList/NavList.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 const baseStyles = () => css`
+  label: nav-list;
   height: auto;
   justify-self: flex-start;
   overflow-y: auto;

--- a/src/components/Sidebar/components/NavList/NavList.spec.js
+++ b/src/components/Sidebar/components/NavList/NavList.spec.js
@@ -2,11 +2,23 @@ import React from 'react';
 
 import NavList from './NavList';
 
-describe.skip('NavList', () => {
+describe('NavList', () => {
   describe('styles', () => {
     it('should render with default styles', () => {
       const actual = create(<NavList />);
       expect(actual).toMatchSnapshot();
+    });
+
+    it('should render children', () => {
+      const wrapper = shallow(
+        <NavList>
+          <li data-selector="child">text node</li>
+        </NavList>
+      );
+      const actual = wrapper.find('[data-selector="child"]');
+
+      expect(actual).toHaveLength(1);
+      expect(actual.text()).toEqual('text node');
     });
   });
 

--- a/src/components/Sidebar/components/NavList/NavList.spec.js
+++ b/src/components/Sidebar/components/NavList/NavList.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import NavList from './NavList';
+
+describe.skip('NavList', () => {
+  describe('styles', () => {
+    it('should render with default styles', () => {
+      const actual = create(<NavList />);
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<NavList />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/components/NavList/__snapshots__/NavList.spec.js.snap
+++ b/src/components/Sidebar/components/NavList/__snapshots__/NavList.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavList styles should render with default styles 1`] = `
+.circuit-0 {
+  height: auto;
+  justify-self: flex-start;
+  overflow-y: auto;
+  width: 100%;
+}
+
+<ul
+  className="circuit-0 circuit-1"
+/>
+`;

--- a/src/components/Sidebar/components/NavList/index.js
+++ b/src/components/Sidebar/components/NavList/index.js
@@ -1,0 +1,3 @@
+import NavList from './NavList';
+
+export default NavList;

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -1,0 +1,3 @@
+import Sidebar from './Sidebar';
+
+export default Sidebar;

--- a/src/index.js
+++ b/src/index.js
@@ -155,6 +155,7 @@ export {
 export { default as SideNav } from './components/SideNav';
 export { Menu } from './components/SideNav/components';
 export { Drawer } from './components/SideNav/components';
+export { default as Sidebar } from './components/Sidebar';
 
 // Helpers
 export { default as State } from './components/State';

--- a/src/themes/circuit.js
+++ b/src/themes/circuit.js
@@ -270,7 +270,8 @@ export const zIndex = {
   select: 20,
   popover: 30,
   tooltip: 31,
-  backdrop: 900,
+  backdrop: 700,
+  sidebar: 800,
   modal: 1000
 };
 

--- a/src/themes/circuit.js
+++ b/src/themes/circuit.js
@@ -50,7 +50,6 @@ const oranges = {
   o900: '#66391B'
 };
 
-
 const yellows = {
   y100: '#F2E9C7',
   y200: '#EDDD8E',
@@ -271,6 +270,7 @@ export const zIndex = {
   select: 20,
   popover: 30,
   tooltip: 31,
+  backdrop: 900,
   modal: 1000
 };
 


### PR DESCRIPTION
## Purpose
This PR aims to start the work on the new `Sidebar` component with initial implementation.

## Side notes
This is a work in progress and features/fixes will be added to it when needed. For now, it supports a single level list of navigation items, a header and a responsive mode for mobile devices.

For desktops, the `Sidebar` should be always visible on the left side, and for mobile devices, it should be able to be visible (with a backdrop and a close button, as designed) or hidden.

## Screenshots
Here are some screenshots of the `Sidebar` modes.

### Sidebar on desktops
![Desktop mode](https://user-images.githubusercontent.com/15806312/52142374-a4baa000-263f-11e9-8b88-caae024490c3.png)

### Sidebar on mobile devices
![Mobile mode](https://user-images.githubusercontent.com/15806312/52142452-d29fe480-263f-11e9-866d-c9104023bb8d.png)

