### PR TITLE
Add strike through option to Text

### DIFF
--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -46,6 +46,13 @@ const italicStyles = ({ italic }) =>
     font-style: italic;
   `;
 
+const strikeThroughStyles = ({ strike }) =>
+  strike &&
+  css`
+    label: text--strike-through;
+    text-decoration: line-through;
+  `;
+
 const marginStyles = ({ noMargin }) =>
   noMargin &&
   css`
@@ -59,6 +66,7 @@ const StyledText = styled(HtmlElement)`
   ${marginStyles};
   ${boldStyles};
   ${italicStyles};
+  ${strikeThroughStyles};
 `;
 
 export { StyledText };
@@ -110,6 +118,10 @@ Text.propTypes = {
    * Bolds the text.
    */
   italic: PropTypes.bool,
+  /**
+   * Strikes through the text.
+   */
+  strike: PropTypes.bool,
   /**
    * The HTML element to render.
    */

--- a/src/components/Text/Text.spec.js
+++ b/src/components/Text/Text.spec.js
@@ -41,6 +41,11 @@ describe('Text', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render struck through text when passed the strike prop', () => {
+    const actual = create(<Text strike />);
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Accessibility tests.
    */

--- a/src/components/Text/Text.story.js
+++ b/src/components/Text/Text.story.js
@@ -25,6 +25,7 @@ storiesOf(`${GROUPS.TYPOGRAPHY}|Text`, module)
           noMargin={boolean('No margin')}
           bold={boolean('Bold')}
           italic={boolean('Italic')}
+          strike={boolean('Strike through')}
         >
           {content}
         </Text>

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -108,6 +108,29 @@ exports[`Text should render italic text when passed the italic prop 1`] = `
 />
 `;
 
+exports[`Text should render struck through text when passed the strike prop 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 15px;
+  line-height: 24px;
+  -webkit-text-decoration: line-through;
+  text-decoration: line-through;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 15px;
+    line-height: 24px;
+  }
+}
+
+<p
+  className="circuit-0 circuit-1"
+  strike={true}
+/>
+`;
+
 exports[`Text should render with no margin styles when passed the noMargin prop 1`] = `
 .circuit-0 {
   font-weight: 400;


### PR DESCRIPTION
## Changes

- Adds a `strike` prop to the `<Text />` component that renders a `line-through` the text. 

<img width="518" alt="screenshot 2019-02-11 at 18 20 50" src="https://user-images.githubusercontent.com/11017722/52607081-d692ea00-2e29-11e9-88ca-ed6609103b5b.png">
