### PR TITLE
Make Header sticky and increase Sidebar breakpoints for better screen fit

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -13,7 +13,7 @@ const baseStyles = ({ theme }) => css`
   padding: ${theme.spacings.mega};
   position: sticky;
   top: 0;
-  ${theme.mq.mega`
+  ${theme.mq.giga`
     display: none;
   `}
 `;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -11,6 +11,8 @@ const baseStyles = ({ theme }) => css`
   min-height: 64px;
   background-color: ${theme.colors.n900};
   padding: ${theme.spacings.mega};
+  position: sticky;
+  top: 0;
   ${theme.mq.mega`
     display: none;
   `}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -11,6 +11,7 @@ const baseStyles = ({ theme }) => css`
   min-height: 64px;
   background-color: ${theme.colors.n900};
   padding: ${theme.spacings.mega};
+  z-index: ${theme.zIndex.header};
   position: sticky;
   top: 0;
   ${theme.mq.giga`

--- a/src/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Header/__snapshots__/Header.spec.js.snap
@@ -14,9 +14,12 @@ exports[`Header styles should render with default styles 1`] = `
   min-height: 64px;
   background-color: #212933;
   padding: 16px;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-2 {
     display: none;
   }

--- a/src/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Header/__snapshots__/Header.spec.js.snap
@@ -14,6 +14,7 @@ exports[`Header styles should render with default styles 1`] = `
   min-height: 64px;
   background-color: #212933;
   padding: 16px;
+  z-index: 600;
   position: -webkit-sticky;
   position: sticky;
   top: 0;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -19,7 +19,7 @@ const baseStyles = ({ theme }) => css`
   position: absolute;
   transform: translateX(-100%);
   z-index: ${theme.zIndex.sidebar};
-  ${theme.mq.mega`
+  ${theme.mq.giga`
     transform: translateX(0);
     position: relative;
   `};
@@ -30,7 +30,7 @@ const openStyles = ({ theme, open }) =>
   css`
     label: sidebar--open;
     transform: translateX(0);
-    ${theme.mq.mega`
+    ${theme.mq.giga`
       transform: translateX(0);
     `};
   `;

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -19,7 +19,7 @@ Array [
   transform: translateX(0);
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-0 {
     -webkit-transform: translateX(0);
     -ms-transform: translateX(0);
@@ -28,7 +28,7 @@ Array [
   }
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-0 {
     -webkit-transform: translateX(0);
     -ms-transform: translateX(0);
@@ -54,7 +54,7 @@ Array [
   opacity: 0.56;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-0 {
     visibility: hidden;
   }
@@ -109,7 +109,7 @@ Array [
   opacity: 1;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-2 {
     visibility: hidden;
   }
@@ -145,7 +145,7 @@ Array [
   z-index: 800;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-0 {
     -webkit-transform: translateX(0);
     -ms-transform: translateX(0);
@@ -170,7 +170,7 @@ Array [
   z-index: 700;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-0 {
     visibility: hidden;
   }
@@ -208,7 +208,7 @@ Array [
   z-index: 800;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-2 {
     visibility: hidden;
   }

--- a/src/components/Sidebar/components/Backdrop/Backdrop.js
+++ b/src/components/Sidebar/components/Backdrop/Backdrop.js
@@ -12,7 +12,7 @@ const baseStyles = ({ theme }) => css`
   visibility: hidden;
   opacity: 0;
   z-index: ${theme.zIndex.backdrop};
-  ${theme.mq.mega`
+  ${theme.mq.giga`
     visibility: hidden;  
   `};
 `;

--- a/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
+++ b/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
@@ -13,7 +13,7 @@ exports[`Backdrop styles should render with default styles when not visible 1`] 
   z-index: 700;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-0 {
     visibility: hidden;
   }
@@ -39,7 +39,7 @@ exports[`Backdrop styles should render with default styles when visible 1`] = `
   opacity: 0.56;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-0 {
     visibility: hidden;
   }

--- a/src/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.js
@@ -23,7 +23,7 @@ const baseStyles = ({ theme }) => css`
   visibility: hidden;
   opacity: 0;
   z-index: ${theme.zIndex.sidebar};
-  ${theme.mq.mega`
+  ${theme.mq.giga`
     visibility: hidden;  
   `};
 `;

--- a/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -30,7 +30,7 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
   z-index: 800;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-2 {
     visibility: hidden;
   }
@@ -111,7 +111,7 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
   opacity: 1;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .circuit-2 {
     visibility: hidden;
   }

--- a/src/themes/circuit.js
+++ b/src/themes/circuit.js
@@ -270,6 +270,7 @@ export const zIndex = {
   select: 20,
   popover: 30,
   tooltip: 31,
+  header: 600,
   backdrop: 700,
   sidebar: 800,
   modal: 1000


### PR DESCRIPTION
# Changes

* Make `Header` sticky so it scrolls with the page, as seen bellow.

![sticky_header](https://user-images.githubusercontent.com/15806312/52637930-db05e400-2eb7-11e9-9d53-ff390a405074.gif)

* Increase the breakpoints on `Sidebar` and `Header` from `mq.mega` to `mq.giga` for better fit on medium sized screens. With this, the `Sidebar` will be hidden on devices like tablets on portrait mode and the `Header` will be visible to toggle the `Sidebar`.
* Update snapshots related to `Sidebar` and `Header` components.