### PR TITLE
[TECH] Remove css source maps from build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,8 +9,7 @@
           "emotion",
           {
             "autoLabel": true,
-            "hoist": true,
-            "sourceMap": true
+            "hoist": true
           }
         ],
         "inline-react-svg"
@@ -26,8 +25,7 @@
           "emotion",
           {
             "autoLabel": true,
-            "hoist": true,
-            "sourceMap": true
+            "hoist": true
           }
         ],
         "inline-react-svg"
@@ -47,8 +45,7 @@
           "emotion",
           {
             "autoLabel": true,
-            "hoist": true,
-            "sourceMap": true
+            "hoist": true
           }
         ]
       ],


### PR DESCRIPTION
When `sourceMap=true` emotion keeps sourceMaps in js modules or bundle (eventually). This lowers the circuit size of the bundle about three times.

**Changes**
* Remove `sourceMap` option from the `.babelrc` used for the build.