### PR TITLE
Make Sidebar close on backdrop click

### DIFF
--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -40,7 +40,7 @@ const Drawer = styled('div')(baseStyles, openStyles);
 const Sidebar = ({ children, open, closeButtonLabel, onClose }) => (
   <Fragment>
     <Drawer open={open}>{children}</Drawer>
-    <Backdrop visible={open} />
+    <Backdrop visible={open} onClick={onClose} />
     <CloseButton
       visible={open}
       closeButtonLabel={closeButtonLabel}

--- a/src/components/Sidebar/Sidebar.spec.js
+++ b/src/components/Sidebar/Sidebar.spec.js
@@ -30,6 +30,16 @@ describe('<Sidebar />', () => {
     expect(props.onClose).toHaveBeenCalled();
   });
 
+  it('should dispatch onClose when the Backdrop is clicked', () => {
+    const props = {
+      open: true,
+      onClose: jest.fn()
+    };
+    const actual = mount(<Sidebar {...props} />);
+    actual.find('Backdrop').simulate('click');
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
   describe('accessibility', () => {
     it('should meet accessibility guidelines', async () => {
       const wrapper = renderToHtml(<Sidebar />);

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -62,6 +62,7 @@ Array [
 
 <div
     className="circuit-0 circuit-1"
+    onClick={[MockFunction]}
   />,
   .circuit-0 {
   border: 0px;
@@ -178,6 +179,7 @@ Array [
 
 <div
     className="circuit-0 circuit-1"
+    onClick={[MockFunction]}
   />,
   .circuit-2 {
   cursor: pointer;


### PR DESCRIPTION
### Changes
* Call the `onClose` prop on the `Sidebar` component when the user clicks on its backdrop.
* Update `Sidebar` snapshots.