### PR TITLE
fix: Add label to CloseButton

### DIFF
--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -29,10 +29,10 @@ const CardHeaderContainer = styled('header')`
   ${noHeadingStyles};
 `;
 
-const CardHeader = ({ onClose, children, ...props }) => (
+const CardHeader = ({ onClose, children, labelCloseButton, ...props }) => (
   <CardHeaderContainer {...props}>
     {children}
-    {onClose && <CloseButton onClick={onClose} />}
+    {onClose && <CloseButton onClick={onClose} label={labelCloseButton} />}
   </CardHeaderContainer>
 );
 
@@ -45,7 +45,12 @@ CardHeader.propTypes = {
    * Callback for the close button. If not specified, the button won't
    * be shown.
    */
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  /**
+   * Text label for the close button for screen readers.
+   * Important for accessibility.
+   */
+  labelCloseButton: PropTypes.string
 };
 
 CardHeader.defaultProps = {

--- a/src/components/CloseButton/CloseButton.js
+++ b/src/components/CloseButton/CloseButton.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
 import { withTheme } from 'emotion-theming';
+import { hideVisually } from 'polished';
 
 import { themePropType } from '../../util/shared-prop-types';
 import { svgKilo } from '../../styles/style-helpers';
@@ -12,17 +14,35 @@ const className = ({ theme }) => css`
   ${svgKilo({ theme })};
 `;
 
+const labelBaseStyles = () => css`
+  ${hideVisually()};
+`;
+
+// Important for accessibility
+const ButtonLabel = styled('span')`
+  ${labelBaseStyles};
+`;
+
 /**
  * A generic close button.
  */
-const CloseButton = ({ theme, ...props }) => (
+const CloseButton = ({ theme, label, ...props }) => (
   <SvgButton className={className({ theme })} {...props}>
     <Icon />
+    <ButtonLabel>{label}</ButtonLabel>
   </SvgButton>
 );
 
 CloseButton.propTypes = {
+  /**
+   * Text label for screen readers. Important for accessibility.
+   */
+  label: PropTypes.string,
   theme: themePropType.isRequired
+};
+
+CloseButton.defaultProps = {
+  label: 'close'
 };
 
 /**

--- a/src/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CloseButton should render with default styles 1`] = `
-.circuit-0 {
+.circuit-2 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -14,22 +14,42 @@ exports[`CloseButton should render with default styles 1`] = `
   width: 16px;
 }
 
-.circuit-0:focus,
-.circuit-0:active {
+.circuit-2:focus,
+.circuit-2:active {
   outline: none;
 }
 
-.circuit-0 > svg {
+.circuit-2 > svg {
   height: 100%;
   width: 100%;
 }
 
+.circuit-0 {
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 <button
-  className="circuit-0 circuit-1"
+  className="circuit-2 circuit-3"
   type="button"
 >
   <div>
     close-icon.svg
   </div>
+  <span
+    className="circuit-0 circuit-1"
+  >
+    close
+  </span>
 </button>
 `;

--- a/src/components/Modal/components/ModalHeader/ModalHeader.js
+++ b/src/components/Modal/components/ModalHeader/ModalHeader.js
@@ -5,8 +5,8 @@ import { withTheme } from 'emotion-theming';
 import { CardHeader } from '../../../Card';
 import Heading from '../../../Heading';
 
-const ModalHeader = ({ title, onClose }) => (
-  <CardHeader onClose={onClose}>
+const ModalHeader = ({ title, onClose, labelCloseButton }) => (
+  <CardHeader onClose={onClose} labelCloseButton={labelCloseButton}>
     {title && (
       <Heading size={Heading.KILO} noMargin>
         {title}
@@ -17,7 +17,12 @@ const ModalHeader = ({ title, onClose }) => (
 
 ModalHeader.propTypes = {
   onClose: PropTypes.func,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  /**
+   * Text label for the close button for screen readers.
+   * Important for accessibility.
+   */
+  labelCloseButton: PropTypes.string
 };
 
 ModalHeader.defaultProps = {

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -95,13 +95,26 @@ const TagElement = styled('span')`
 /**
  * Tag component
  */
-const Tag = ({ children, icon, onRemove, selected, ...props }) => (
+const Tag = ({
+  children,
+  icon,
+  onRemove,
+  labelRemoveButton,
+  selected,
+  ...props
+}) => (
   <TagElement {...{ selected, ...props }}>
     {!onRemove && icon && (
       <IconContainer {...{ selected }}>{icon}</IconContainer>
     )}
     {children}
-    {onRemove && <CloseButton {...{ onClick: onRemove, selected }} />}
+    {onRemove && (
+      <CloseButton
+        onClick={onRemove}
+        selected={selected}
+        label={labelRemoveButton}
+      />
+    )}
   </TagElement>
 );
 
@@ -120,6 +133,11 @@ Tag.propTypes = {
    */
   onRemove: eitherOrPropType('icon', 'onRemove', PropTypes.func),
   /**
+   * Text label for the remove icon for screen readers.
+   * Important for accessibility.
+   */
+  labelRemoveButton: PropTypes.string,
+  /**
    * Triggers selected styles on the tag.
    */
   selected: PropTypes.bool
@@ -129,7 +147,8 @@ Tag.defaultProps = {
   children: null,
   icon: null,
   onRemove: null,
-  selected: false
+  selected: false,
+  labelRemoveButton: 'remove'
 };
 
 /**

--- a/src/components/Tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.js.snap
@@ -46,7 +46,7 @@ exports[`Tag when is default should render with default styles 1`] = `
 `;
 
 exports[`Tag when is selected should change the close icon color 1`] = `
-.circuit-3 {
+.circuit-5 {
   border-radius: 4px;
   font-size: 15px;
   line-height: 24px;
@@ -59,7 +59,7 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   color: #FFFFFF;
 }
 
-.circuit-1 {
+.circuit-3 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -72,28 +72,43 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   vertical-align: middle;
 }
 
-.circuit-1:focus,
-.circuit-1:active {
+.circuit-3:focus,
+.circuit-3:active {
   outline: none;
 }
 
-.circuit-1 > svg {
+.circuit-3 > svg {
   height: 100%;
   width: 100%;
 }
 
-.circuit-1 > svg {
+.circuit-3 > svg {
   fill: #FFFFFF;
   vertical-align: inherit;
 }
 
+.circuit-0 {
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 <span
-  className="circuit-3 circuit-4"
+  className="circuit-5 circuit-6"
   selected={true}
 >
   SomeTest
   <button
-    className="circuit-0 circuit-1 circuit-2"
+    className="circuit-2 circuit-3 circuit-4"
     onClick={[MockFunction]}
     selected={true}
     type="button"
@@ -101,6 +116,11 @@ exports[`Tag when is selected should change the close icon color 1`] = `
     <div>
       close-icon.svg
     </div>
+    <span
+      className="circuit-0 circuit-1"
+    >
+      close
+    </span>
   </button>
 </span>
 `;

--- a/src/components/Tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.js.snap
@@ -119,7 +119,7 @@ exports[`Tag when is selected should change the close icon color 1`] = `
     <span
       className="circuit-0 circuit-1"
     >
-      close
+      remove
     </span>
   </button>
 </span>


### PR DESCRIPTION
## Purpose

The `CloseButton` only contains an SVG. While the SVG has a title, [most screenreaders](https://weboverhauls.github.io/demos/svg/#buttons) don't announce it as a button label. Additionally, the label should be a prop so it can be translated.

## Changes

- Add an invisible label to `CloseButton` for screen readers
- Pass through the label prop from the `Tag` and `ModalHeader` components