### PR TITLE
Add fallback for unsupported currencies

### DIFF
--- a/src/util/__snapshots__/currency.spec.js.snap
+++ b/src/util/__snapshots__/currency.spec.js.snap
@@ -6,17 +6,6 @@ exports[`currency currencyRegex() should return a regex for 'CLP' currency and '
 
 exports[`currency currencyRegex() should return a regex for 'USD' currency and 'en-US' locale 1`] = `"^(\\\\d{0,2}(?:(?:,)?\\\\d{3})*)(?:(?:\\\\.)(\\\\d{0,2}))?$"`;
 
-exports[`currency getCurrencyFormat() should fall back to the default format for a currency, if locale is not found. 1`] = `
-Object {
-  "addSpace": true,
-  "currencyPrecision": 2,
-  "decimalSep": ".",
-  "prepend": false,
-  "symbol": "€",
-  "thousandSep": ",",
-}
-`;
-
 exports[`currency getCurrencyFormat() should return a format object for a currency and locale. 1`] = `
 Object {
   "addSpace": true,
@@ -25,5 +14,16 @@ Object {
   "prepend": false,
   "symbol": "€",
   "thousandSep": ".",
+}
+`;
+
+exports[`currency getCurrencyFormat() when no locale-specific format exists for a currency should fall back to the default format 1`] = `
+Object {
+  "addSpace": true,
+  "currencyPrecision": 2,
+  "decimalSep": ".",
+  "prepend": false,
+  "symbol": "€",
+  "thousandSep": ",",
 }
 `;

--- a/src/util/currency.js
+++ b/src/util/currency.js
@@ -130,13 +130,10 @@ export function getCurrencyFormat(currency, locale) {
     defaultTo(currency),
     get(currency)
   )(CURRENCY_SYMBOLS);
+
   const { decimal: decimalSep, thousand: thousandSep } = getNumberFormat(
     locale
   );
-
-  if (!decimalSep || !thousandSep) {
-    throw new TypeError(`No number format available for ${locale}`);
-  }
 
   const currencyFormats =
     get(currency.toUpperCase(), CURRENCY_FORMATS) ||

--- a/src/util/currency.js
+++ b/src/util/currency.js
@@ -1,4 +1,4 @@
-import { get, isNumber, isString } from 'lodash/fp';
+import { getOr, isNumber, isString } from 'lodash/fp';
 import { get as _get } from 'lodash';
 
 import { NUMBER_SEPARATORS, formatNumber, getNumberFormat } from './numbers';
@@ -127,18 +127,18 @@ function addSymbol(amount, symbol, { addSpace = true, prepend = false } = {}) {
 }
 
 export function getCurrencyFormat(currency, locale) {
-  const symbol = _get(CURRENCY_SYMBOLS, currency, '');
+  const symbol = _get(CURRENCY_SYMBOLS, currency, currency);
   const { decimal: decimalSep, thousand: thousandSep } = getNumberFormat(
     locale
   );
+
   if (!decimalSep || !thousandSep) {
     throw new TypeError(`No number format available for ${locale}`);
   }
-  const currencyFormats = _get(CURRENCY_FORMATS, currency.toUpperCase());
 
-  if (!currencyFormats) {
-    throw new TypeError(`Currency ${currency} is invalid.`);
-  }
+  const currencyFormats =
+    _get(CURRENCY_FORMATS, currency.toUpperCase()) ||
+    _get(CURRENCY_FORMATS, 'EUR');
 
   const {
     prependSymbol: prepend,
@@ -162,7 +162,7 @@ export function shouldPrependSymbol(currency, locale) {
 }
 
 export function formatCurrency(amount, currency, locale) {
-  const currencySymbol = get(currency, CURRENCY_SYMBOLS);
+  const currencySymbol = getOr(currency, currency, CURRENCY_SYMBOLS);
   const currencyFormat = getCurrencyFormat(currency, locale);
   const formattedAmount = toCurrencyNumberFormat(amount, currencyFormat);
   const currencyString = addSymbol(

--- a/src/util/currency.js
+++ b/src/util/currency.js
@@ -1,5 +1,4 @@
-import { getOr, isNumber, isString } from 'lodash/fp';
-import { get as _get } from 'lodash';
+import { compose, defaultTo, get, isNumber, isString } from 'lodash/fp';
 
 import { NUMBER_SEPARATORS, formatNumber, getNumberFormat } from './numbers';
 import { currencyToRegex } from './regex';
@@ -127,7 +126,10 @@ function addSymbol(amount, symbol, { addSpace = true, prepend = false } = {}) {
 }
 
 export function getCurrencyFormat(currency, locale) {
-  const symbol = _get(CURRENCY_SYMBOLS, currency, currency);
+  const symbol = compose(
+    defaultTo(currency),
+    get(currency)
+  )(CURRENCY_SYMBOLS);
   const { decimal: decimalSep, thousand: thousandSep } = getNumberFormat(
     locale
   );
@@ -137,14 +139,14 @@ export function getCurrencyFormat(currency, locale) {
   }
 
   const currencyFormats =
-    _get(CURRENCY_FORMATS, currency.toUpperCase()) ||
-    _get(CURRENCY_FORMATS, 'EUR');
+    get(currency.toUpperCase(), CURRENCY_FORMATS) ||
+    get('EUR', CURRENCY_FORMATS);
 
   const {
     prependSymbol: prepend,
     fractionalPrecision: currencyPrecision,
     addSpace
-  } = _get(currencyFormats, locale, currencyFormats.default);
+  } = get(locale, currencyFormats) || currencyFormats.default;
 
   return {
     decimalSep,
@@ -162,7 +164,10 @@ export function shouldPrependSymbol(currency, locale) {
 }
 
 export function formatCurrency(amount, currency, locale) {
-  const currencySymbol = getOr(currency, currency, CURRENCY_SYMBOLS);
+  const currencySymbol = compose(
+    defaultTo(currency),
+    get(currency)
+  )(CURRENCY_SYMBOLS);
   const currencyFormat = getCurrencyFormat(currency, locale);
   const formattedAmount = toCurrencyNumberFormat(amount, currencyFormat);
   const currencyString = addSymbol(
@@ -194,12 +199,12 @@ export function formatAmountForLocale(number, currency, locale) {
 }
 
 export function currencyRegex(currency, locale) {
-  const currencyFormat = _get(CURRENCY_FORMATS, currency);
-  const currencyLocaleFormat = _get(currencyFormat, locale);
-  const currencyDefaultFormat = _get(currencyFormat, 'default');
-  const { fractionalPrecision } = currencyLocaleFormat || currencyDefaultFormat;
+  const currencyFormat = get(currency, CURRENCY_FORMATS);
+  const currencyLocaleFormat = get(locale, currencyFormat);
+  const { fractionalPrecision } =
+    currencyLocaleFormat || currencyFormat.default;
 
-  const numberFormat = _get(NUMBER_SEPARATORS, locale);
+  const numberFormat = get(locale, NUMBER_SEPARATORS);
   const { decimal, thousand } = numberFormat;
 
   return currencyToRegex([thousand], fractionalPrecision, [decimal]);

--- a/src/util/currency.spec.js
+++ b/src/util/currency.spec.js
@@ -9,11 +9,41 @@ describe('currency', () => {
       expect(actual).toMatchSnapshot();
     });
 
-    it('should fall back to the default format for a currency, if locale is not found.', () => {
-      const ccy = 'EUR';
-      const locale = 'en-GB';
-      const actual = currency.getCurrencyFormat(ccy, locale);
-      expect(actual).toMatchSnapshot();
+    describe('when a currency is not supported', () => {
+      it('should use the currency code as symbol', () => {
+        const ccy = 'UYU';
+        const locale = 'en-GB';
+        const actual = currency.getCurrencyFormat(ccy, locale);
+        expect(actual).toEqual(
+          expect.objectContaining({
+            symbol: 'UYU'
+          })
+        );
+      });
+
+      it('should fall back to EUR currency formatting', () => {
+        const ccy = 'UYU';
+        const locale = 'en-GB';
+        const actual = currency.getCurrencyFormat(ccy, locale);
+        expect(actual).toEqual(
+          expect.objectContaining({
+            addSpace: true,
+            currencyPrecision: 2,
+            decimalSep: '.',
+            prepend: false,
+            thousandSep: ','
+          })
+        );
+      });
+    });
+
+    describe('when no locale-specific format exists for a currency', () => {
+      it('should fall back to the default format', () => {
+        const ccy = 'EUR';
+        const locale = 'en-GB';
+        const actual = currency.getCurrencyFormat(ccy, locale);
+        expect(actual).toMatchSnapshot();
+      });
     });
   });
 
@@ -221,6 +251,31 @@ describe('currency', () => {
           `0,98\xA0${ccy}`
         ];
         testCurrency(inputs, ccy, 'de-DE', outputs);
+      });
+    });
+  });
+
+  describe('formatAmountForLocale()', () => {
+    describe('when passed a non-string or non-number input', () => {
+      it('should return the input as is', () => {
+        const notANumber = {};
+        const ccy = 'EUR';
+        const locale = 'de-DE';
+        const actual = currency.formatAmountForLocale(notANumber, ccy, locale);
+        expect(actual).toBe(notANumber);
+      });
+    });
+
+    describe('when given a currency and locale', () => {
+      const inputs = [11.23, 1000, 0.98];
+      const ccy = 'CHF';
+      const locale = 'de-CH';
+      const expected = ['11.23', "1'000.00", '0.98'];
+
+      inputs.forEach((number, i) => {
+        expect(currency.formatAmountForLocale(number, ccy, locale)).toBe(
+          expected[i]
+        );
       });
     });
   });

--- a/src/util/currency.spec.js
+++ b/src/util/currency.spec.js
@@ -15,14 +15,8 @@ describe('currency', () => {
       const actual = currency.getCurrencyFormat(ccy, locale);
       expect(actual).toMatchSnapshot();
     });
-
-    it('should throw a TypeError if currency is not supported.', () => {
-      const ccy = 'BITCOIN';
-      const locale = 'de-DE';
-      const actual = () => currency.getCurrencyFormat(ccy, locale);
-      expect(actual).toThrow();
-    });
   });
+
   describe('formatCurrency()', () => {
     const inputs = ['11.23', 1000, 0.98];
 
@@ -208,6 +202,26 @@ describe('currency', () => {
     it('should localize HRK', () => {
       const outputs = ['11,23\xA0kn', '1.000,00\xA0kn', '0,98\xA0kn'];
       testCurrency(inputs, 'HRK', 'hr-HR', outputs);
+    });
+
+    describe('handling non-configured currencies', () => {
+      it('should not throw an error', () => {
+        const amount = 10;
+        const ccy = 'UYU';
+        expect(() => {
+          currency.formatCurrency(amount, ccy, 'en-GB');
+        }).not.toThrow();
+      });
+
+      it('should fall back to the default EUR format', () => {
+        const ccy = 'UYU';
+        const outputs = [
+          `11,23\xA0${ccy}`,
+          `1.000,00\xA0${ccy}`,
+          `0,98\xA0${ccy}`
+        ];
+        testCurrency(inputs, ccy, 'de-DE', outputs);
+      });
     });
   });
 


### PR DESCRIPTION
Previously, number formatting would throw a `TypeError` if a currency was unsupported. This PR adds fallback behavior.