### PR TITLE
Create Footer component for the Sidebar

### DIFF
--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 import Header from './components/Header';
+import Footer from './components/Footer';
 import NavList from './components/NavList';
 import NavItem from './components/NavItem';
 import Backdrop from './components/Backdrop';
@@ -12,6 +13,8 @@ const SIDEBAR_WIDTH = 256;
 
 const baseStyles = ({ theme }) => css`
   label: sidebar;
+  display: flex;
+  flex-direction: column;
   height: 100%;
   min-width: ${SIDEBAR_WIDTH}px;
   background-color: ${theme.colors.n900};
@@ -69,6 +72,7 @@ Sidebar.propTypes = {
 };
 
 Sidebar.Header = Header;
+Sidebar.Footer = Footer;
 Sidebar.NavList = NavList;
 Sidebar.NavItem = NavItem;
 

--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -43,6 +43,7 @@ storiesOf(`${GROUPS.COMPONENTS}|Sidebar`, module)
                 </Sidebar.NavItem>
               ))}
             </Sidebar.NavList>
+            <Sidebar.Footer>Footer</Sidebar.Footer>
           </Sidebar>
         </SidebarContainer>
       );

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -3,6 +3,13 @@
 exports[`<Sidebar /> should render and match snapshot when open 1`] = `
 Array [
   .circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   height: 100%;
   min-width: 256px;
   background-color: #212933;
@@ -133,6 +140,13 @@ Array [
 exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
 Array [
   .circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   height: 100%;
   min-width: 256px;
   background-color: #212933;

--- a/src/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/src/components/Sidebar/components/CloseButton/CloseButton.js
@@ -6,7 +6,7 @@ import { hideVisually } from 'polished';
 import CloseIcon from './closeIcon.svg';
 
 const baseStyles = ({ theme }) => css`
-  label: close-button;
+  label: sidebar-close-button;
   cursor: pointer;
   outline: none;
   display: flex;

--- a/src/components/Sidebar/components/Footer/Footer.js
+++ b/src/components/Sidebar/components/Footer/Footer.js
@@ -6,7 +6,6 @@ const baseStyles = ({ theme }) => css`
   display: flex;
   flex: 1;
   align-items: flex-end;
-  width: 100%;
   padding: ${theme.spacings.giga};
   background-color: ${theme.colors.n900};
   color: ${theme.colors.n100};

--- a/src/components/Sidebar/components/Footer/Footer.js
+++ b/src/components/Sidebar/components/Footer/Footer.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+
+const baseStyles = ({ theme }) => css`
+  label: sidebar-footer;
+  display: flex;
+  flex: 1;
+  align-items: flex-end;
+  width: 100%;
+  padding: ${theme.spacings.giga};
+  background-color: ${theme.colors.n900};
+  color: ${theme.colors.n100};
+`;
+
+const Footer = styled('div')(baseStyles);
+
+Footer.propTypes = {
+  /**
+   * The children component passed to the Footer
+   */
+  children: PropTypes.node
+};
+
+export default Footer;

--- a/src/components/Sidebar/components/Footer/Footer.spec.js
+++ b/src/components/Sidebar/components/Footer/Footer.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Footer from './Footer';
 
-describe('Header', () => {
+describe('Footer', () => {
   describe('styles', () => {
     it('should render with default styles', () => {
       const actual = create(<Footer />);

--- a/src/components/Sidebar/components/Footer/Footer.spec.js
+++ b/src/components/Sidebar/components/Footer/Footer.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import Footer from './Footer';
+
+describe('Header', () => {
+  describe('styles', () => {
+    it('should render with default styles', () => {
+      const actual = create(<Footer />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render children', () => {
+      const wrapper = shallow(
+        <Footer>
+          <span data-selector="child">text node</span>
+        </Footer>
+      );
+      const actual = wrapper.find('[data-selector="child"]');
+
+      expect(actual).toHaveLength(1);
+      expect(actual.text()).toEqual('text node');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<Footer />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
@@ -13,7 +13,6 @@ exports[`Footer styles should render with default styles 1`] = `
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
-  width: 100%;
   padding: 24px;
   background-color: #212933;
   color: #FAFBFC;

--- a/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header styles should render with default styles 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  width: 100%;
+  padding: 24px;
+  background-color: #212933;
+  color: #FAFBFC;
+}
+
+<div
+  className="circuit-0 circuit-1"
+/>
+`;

--- a/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Header styles should render with default styles 1`] = `
+exports[`Footer styles should render with default styles 1`] = `
 .circuit-0 {
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/components/Sidebar/components/Footer/index.js
+++ b/src/components/Sidebar/components/Footer/index.js
@@ -1,0 +1,3 @@
+import Footer from './Footer';
+
+export default Footer;

--- a/src/components/Sidebar/components/Header/Header.js
+++ b/src/components/Sidebar/components/Header/Header.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 
 const baseStyles = ({ theme }) => css`
-  label: header;
+  label: sidebar-header;
   display: flex;
   align-self: flex-start;
   align-items: center;


### PR DESCRIPTION
### Changes
* Add a `Footer` component for the `Sidebar`.
![image](https://user-images.githubusercontent.com/15806312/54704582-c69db280-4b19-11e9-879d-13c3720befd9.png)

* Fix `Sidebar` components labels.
* Add `Footer` to the `Sidebar` story.