### PR TITLE
Export additional table components

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -1,3 +1,8 @@
 import Table from './Table';
+import TableRow from './components/TableRow';
+import TableCell from './components/TableCell';
+import TableHeader from './components/TableHeader';
+
+export { TableRow, TableCell, TableHeader };
 
 export default Table;

--- a/src/index.js
+++ b/src/index.js
@@ -147,6 +147,8 @@ export {
 export { default as Picture } from './components/Picture';
 export { default as AutoCompleteInput } from './components/AutoCompleteInput';
 export { default as AutoCompleteTags } from './components/AutoCompleteTags';
+
+export { TableRow, TableCell, TableHeader } from './components/Table';
 export { default as Table } from './components/Table';
 export { default as CardSchemes } from './components/CardSchemes';
 export {


### PR DESCRIPTION
## Purpose
 
Export table building blocks in order to provide a way to create tables with circuit components. 

