### PR TITLE
Fix Hamburger styles on IE11

### DIFF
--- a/src/components/Hamburger/Hamburger.js
+++ b/src/components/Hamburger/Hamburger.js
@@ -50,12 +50,12 @@ const layersBaseStyles = ({ theme }) => css`
   }
 
   &::before {
-    transform: translateY(calc((${theme.spacings.bit}) * -1));
+    transform: translateY(-${theme.spacings.bit});
     width: ${HAMBURGUER_WIDTH};
   }
 
   &::after {
-    transform: translateY(calc(${theme.spacings.bit}));
+    transform: translateY(${theme.spacings.bit});
     width: ${HAMBURGUER_WIDTH};
   }
 `;
@@ -123,9 +123,9 @@ const Hamburger = ({
   labelActive,
   labelInActive,
   light,
-  className
+  ...rest
 }) => (
-  <HamburgerButton className={className} onClick={onClick} light={light}>
+  <HamburgerButton {...rest} onClick={onClick} light={light}>
     <HamburgerLayers isActive={isActive} light={light} />
     <HamburgerLabel>{isActive ? labelActive : labelInActive}</HamburgerLabel>
   </HamburgerButton>
@@ -159,8 +159,7 @@ Hamburger.defaultProps = {
   onClick: () => {},
   isActive: false,
   labelActive: 'Close menu',
-  labelInActive: 'Open menu',
-  className: ''
+  labelInActive: 'Open menu'
 };
 
 /**

--- a/src/components/Hamburger/__snapshots__/Hamburger.spec.js.snap
+++ b/src/components/Hamburger/__snapshots__/Hamburger.spec.js.snap
@@ -62,16 +62,16 @@ exports[`Hamburger should render with active styles when passed the isActive pro
 }
 
 .circuit-0::before {
-  -webkit-transform: translateY(calc((4px) * -1));
-  -ms-transform: translateY(calc((4px) * -1));
-  transform: translateY(calc((4px) * -1));
+  -webkit-transform: translateY(-4px);
+  -ms-transform: translateY(-4px);
+  transform: translateY(-4px);
   width: 12px;
 }
 
 .circuit-0::after {
-  -webkit-transform: translateY(calc(4px));
-  -ms-transform: translateY(calc(4px));
-  transform: translateY(calc(4px));
+  -webkit-transform: translateY(4px);
+  -ms-transform: translateY(4px);
+  transform: translateY(4px);
   width: 12px;
 }
 
@@ -156,16 +156,16 @@ exports[`Hamburger should render with default styles 1`] = `
 }
 
 .circuit-0::before {
-  -webkit-transform: translateY(calc((4px) * -1));
-  -ms-transform: translateY(calc((4px) * -1));
-  transform: translateY(calc((4px) * -1));
+  -webkit-transform: translateY(-4px);
+  -ms-transform: translateY(-4px);
+  transform: translateY(-4px);
   width: 12px;
 }
 
 .circuit-0::after {
-  -webkit-transform: translateY(calc(4px));
-  -ms-transform: translateY(calc(4px));
-  transform: translateY(calc(4px));
+  -webkit-transform: translateY(4px);
+  -ms-transform: translateY(4px);
+  transform: translateY(4px);
   width: 12px;
 }
 


### PR DESCRIPTION
## Purpose 

IE11 doesn't support `calc()` inside `translate()`, so the hamburger is currently displayed as a single line.

## Approach and changes

- Simplify arithmetic to calculate the position of the hamburger buns 🍔
-  Spread additional props on the hamburger, such as `className` or `data-selector` (crucial for unit tests)