### PR TITLE
fix react-dom Select value prop warning

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -259,7 +259,6 @@ Select.defaultProps = {
   options: null,
   disabled: false,
   invalid: false,
-  value: null,
   placeholder: 'Select an option',
   inline: false,
   noMargin: false,

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -55,7 +55,7 @@ exports[`Select should not render with invalid styles when also passed the disab
   <select
     className="circuit-0 circuit-1"
     disabled={true}
-    value={null}
+    value={undefined}
   >
     <option
       value=""
@@ -145,7 +145,7 @@ exports[`Select should render with a prefix when passed the prefix prop 1`] = `
   <select
     className="circuit-0 circuit-1"
     disabled={false}
-    value={null}
+    value={undefined}
   >
     <option
       value=""
@@ -226,7 +226,7 @@ exports[`Select should render with default styles 1`] = `
   <select
     className="circuit-0 circuit-1"
     disabled={false}
-    value={null}
+    value={undefined}
   >
     <option
       value=""
@@ -310,7 +310,7 @@ exports[`Select should render with disabled styles when passed the disabled prop
   <select
     className="circuit-0 circuit-1"
     disabled={true}
-    value={null}
+    value={undefined}
   >
     <option
       value=""
@@ -393,7 +393,7 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
   <select
     className="circuit-0 circuit-1"
     disabled={false}
-    value={null}
+    value={undefined}
   >
     <option
       value=""
@@ -475,7 +475,7 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
   <select
     className="circuit-0 circuit-1"
     disabled={false}
-    value={null}
+    value={undefined}
   >
     <option
       value=""
@@ -557,7 +557,7 @@ exports[`Select should render with no margin styles when passed the noMargin pro
   <select
     className="circuit-0 circuit-1"
     disabled={false}
-    value={null}
+    value={undefined}
   >
     <option
       value=""


### PR DESCRIPTION
## Purpose 

Tiny improvement that addresses react-dom annoying warning (though appears mostly in storybooks):

![image](https://user-images.githubusercontent.com/974035/56909577-c98cab00-6aa8-11e9-8613-468e7b507731.png)

## Approach and changes

So there's no need to set `value` to `null` as default prop.