### PR TITLE
Update mega font-size to prevent input zoom on iOS

### DIFF
--- a/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
+++ b/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
@@ -25,7 +25,7 @@ exports[`AutoCompleteInput should render with default styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
 }

--- a/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
+++ b/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
@@ -25,7 +25,7 @@ exports[`AutoCompleteTags should render with default styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
 }

--- a/src/components/Blockquote/__snapshots__/Blockquote.spec.js.snap
+++ b/src/components/Blockquote/__snapshots__/Blockquote.spec.js.snap
@@ -33,7 +33,7 @@ exports[`Blockquote should render with giga styles 1`] = `
 .circuit-1 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   font-style: italic;
   padding-left: 12px;
@@ -64,7 +64,7 @@ exports[`Blockquote should render with mega styles 1`] = `
 .circuit-1 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   font-style: italic;
   padding-left: 12px;
@@ -73,7 +73,7 @@ exports[`Blockquote should render with mega styles 1`] = `
 
 @media (min-width:480px) {
   .circuit-1 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }

--- a/src/components/Button/components/PlainButton/__snapshots__/PlainButton.spec.js.snap
+++ b/src/components/Button/components/PlainButton/__snapshots__/PlainButton.spec.js.snap
@@ -4,7 +4,7 @@ exports[`PlainButton should have giga link styles 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   margin-bottom: 0;
   box-shadow: none;
@@ -90,7 +90,7 @@ exports[`PlainButton should have mega link styles 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   margin-bottom: 0;
   box-shadow: none;
@@ -105,7 +105,7 @@ exports[`PlainButton should have mega link styles 1`] = `
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -133,7 +133,7 @@ exports[`PlainButton should have primary styles 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   margin-bottom: 0;
   box-shadow: none;
@@ -149,7 +149,7 @@ exports[`PlainButton should have primary styles 1`] = `
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -181,7 +181,7 @@ exports[`PlainButton should render with default styles 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   margin-bottom: 0;
   box-shadow: none;
@@ -196,7 +196,7 @@ exports[`PlainButton should render with default styles 1`] = `
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -224,7 +224,7 @@ exports[`PlainButton should render with href 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   margin-bottom: 0;
   box-shadow: none;
@@ -239,7 +239,7 @@ exports[`PlainButton should render with href 1`] = `
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }

--- a/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
+++ b/src/components/Button/components/RegularButton/__snapshots__/RegularButton.spec.js.snap
@@ -17,7 +17,7 @@ exports[`RegularButton should have button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -83,7 +83,7 @@ exports[`RegularButton should have disabled button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -149,7 +149,7 @@ exports[`RegularButton should have flat button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
   border-width: 0px;
@@ -236,7 +236,7 @@ exports[`RegularButton should have flat disabled button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
   border-width: 0px;
@@ -323,7 +323,7 @@ exports[`RegularButton should have giga button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(12px - 0px) calc(32px - 0px);
 }
@@ -389,7 +389,7 @@ exports[`RegularButton should have kilo button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(4px - 0px) calc(16px - 0px);
 }
@@ -455,7 +455,7 @@ exports[`RegularButton should have mega button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -521,7 +521,7 @@ exports[`RegularButton should have secondary button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
   background-color: transparent;
@@ -633,7 +633,7 @@ exports[`RegularButton should have secondary disabled button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
   background-color: transparent;
@@ -745,7 +745,7 @@ exports[`RegularButton should have secondary flat button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
   background-color: transparent;
@@ -857,7 +857,7 @@ exports[`RegularButton should have stretch button styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
   width: 100%;

--- a/src/components/Calendar/__snapshots__/RangePicker.spec.js.snap
+++ b/src/components/Calendar/__snapshots__/RangePicker.spec.js.snap
@@ -1060,7 +1060,7 @@ exports[`RangePicker should render with default styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
@@ -1096,7 +1096,7 @@ exports[`RangePicker should render with default styles 1`] = `
 
 .circuit-2 .DateInput_input {
   color: #212933;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   font-weight: 200;
   background-color: inherit;

--- a/src/components/Calendar/__snapshots__/SingleDayPicker.spec.js.snap
+++ b/src/components/Calendar/__snapshots__/SingleDayPicker.spec.js.snap
@@ -1060,7 +1060,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
@@ -1096,7 +1096,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 
 .circuit-0 .DateInput_input {
   color: #212933;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   font-weight: 200;
   background-color: inherit;

--- a/src/components/Calendar/components/CalendarWrapper/__snapshots__/CalendarWrapper.spec.js.snap
+++ b/src/components/Calendar/components/CalendarWrapper/__snapshots__/CalendarWrapper.spec.js.snap
@@ -1060,7 +1060,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
@@ -1096,7 +1096,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 
 .circuit-0 .DateInput_input {
   color: #212933;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   font-weight: 200;
   background-color: inherit;

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`CalendarTag should render with default styles 1`] = `
 .circuit-0 {
   border-radius: 4px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`CalendarTagTwoStep should render with default styles 1`] = `
 .circuit-0 {
   border-radius: 4px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;

--- a/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
+++ b/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
@@ -74,7 +74,7 @@ Array [
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -304,7 +304,7 @@ Array [
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -505,7 +505,7 @@ Array [
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }

--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
@@ -19,7 +19,7 @@ exports[`SimpleCurrencyInput should adjust input padding and postfix width to ma
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -109,7 +109,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over error styles 1`] = 
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -196,7 +196,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over warning styles 1`] 
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -328,7 +328,7 @@ exports[`SimpleCurrencyInput should render with default styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -414,7 +414,7 @@ exports[`SimpleCurrencyInput should render with error styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -524,7 +524,7 @@ exports[`SimpleCurrencyInput should render with warning styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -647,7 +647,7 @@ exports[`SimpleCurrencyInput should support rendering symbols on the left 1`] = 
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   text-align: right;

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -12,7 +12,7 @@ exports[`Input should prioritize disabled over error styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -103,7 +103,7 @@ exports[`Input should prioritize disabled over warning styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -231,7 +231,7 @@ exports[`Input should prioritize error over optional styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   background-color: #FAFBFC;
   border-style: dashed;
@@ -328,7 +328,7 @@ exports[`Input should render with a Tooltip when passed the validationHint prop 
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -470,7 +470,7 @@ exports[`Input should render with a prefix when passed the prefix prop 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
@@ -549,7 +549,7 @@ exports[`Input should render with a suffix when passed the suffix prop 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -624,7 +624,7 @@ exports[`Input should render with default styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -700,7 +700,7 @@ exports[`Input should render with disabled styles when passed the disabled prop 
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -770,7 +770,7 @@ exports[`Input should render with inline styles when passed the inline prop 1`] 
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -876,7 +876,7 @@ exports[`Input should render with invalid styles when passed the invalid prop 1`
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -963,7 +963,7 @@ exports[`Input should render with no margin styles when passed the noMargin prop
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -1067,7 +1067,7 @@ exports[`Input should render with optional styles when passed the optional prop 
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   background-color: #FAFBFC;
   border-style: dashed;
@@ -1153,7 +1153,7 @@ exports[`Input should render with right aligned text 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   text-align: right;
   padding-right: calc( 12px + 16px + 12px );
@@ -1224,7 +1224,7 @@ exports[`Input should render with valid styles when passed the showValid prop 1`
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -1311,7 +1311,7 @@ exports[`Input should render with warning styles when passed the hasWarning prop
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
 }

--- a/src/components/List/__snapshots__/List.spec.js.snap
+++ b/src/components/List/__snapshots__/List.spec.js.snap
@@ -89,7 +89,7 @@ exports[`List should render a mega unordered List 1`] = `
   font-weight: 400;
   margin-bottom: 16px;
   padding-left: 12px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 

--- a/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
+++ b/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
@@ -17,7 +17,7 @@ exports[`Container Container Style tests should have default styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }

--- a/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
+++ b/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
@@ -17,7 +17,7 @@ exports[`LoadingButton Style tests should have active loading styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -157,7 +157,7 @@ exports[`LoadingButton Style tests should have default styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
@@ -335,7 +335,7 @@ exports[`LoadingButton Style tests should have isLoading styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(8px - 0px) calc(24px - 0px);
   overflow-y: hidden;

--- a/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
+++ b/src/components/Markdown/__snapshots__/Markdown.spec.js.snap
@@ -4,13 +4,13 @@ exports[`Markdown should override HTML tags with React components 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }

--- a/src/components/Pagination/PageButton/__snapshots__/PageButton.spec.js.snap
+++ b/src/components/Pagination/PageButton/__snapshots__/PageButton.spec.js.snap
@@ -17,7 +17,7 @@ exports[`PageButton styles should render with default styles 1`] = `
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: calc(4px - 0px) calc(16px - 0px);
   border-radius: 0;

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
@@ -12,7 +12,7 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
@@ -94,7 +94,7 @@ exports[`SearchInput should render with default styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -19,7 +19,7 @@ exports[`Select should not render with invalid styles when also passed the disab
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
@@ -110,7 +110,7 @@ exports[`Select should render with a prefix when passed the prefix prop 1`] = `
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
 }
@@ -200,7 +200,7 @@ exports[`Select should render with default styles 1`] = `
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
@@ -274,7 +274,7 @@ exports[`Select should render with disabled styles when passed the disabled prop
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
@@ -358,7 +358,7 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
@@ -448,7 +448,7 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   border-color: #EA7A7A;
 }
@@ -523,7 +523,7 @@ exports[`Select should render with no margin styles when passed the noMargin pro
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -36,7 +36,7 @@ exports[`Tabs styles should render with default styles 1`] = `
 }
 
 .circuit-0 {
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
   color: #9DA7B1;
@@ -67,7 +67,7 @@ exports[`Tabs styles should render with default styles 1`] = `
 }
 
 .circuit-2 {
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
   color: #9DA7B1;
@@ -149,7 +149,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 }
 
 .circuit-0 {
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
   color: #9DA7B1;
@@ -180,7 +180,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 }
 
 .circuit-2 {
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
   color: #9DA7B1;

--- a/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
+++ b/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Tab styles should render with default styles 1`] = `
 .circuit-0 {
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
   color: #9DA7B1;
@@ -44,7 +44,7 @@ exports[`Tab styles should render with default styles 1`] = `
 
 exports[`Tab styles should render with selected styles 1`] = `
 .circuit-0 {
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
   color: #9DA7B1;

--- a/src/components/Tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Tag when is clickable should render with clickable styles 1`] = `
 .circuit-0 {
   border-radius: 4px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
@@ -29,7 +29,7 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
 exports[`Tag when is default should render with default styles 1`] = `
 .circuit-0 {
   border-radius: 4px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
@@ -48,7 +48,7 @@ exports[`Tag when is default should render with default styles 1`] = `
 exports[`Tag when is selected should change the close icon color 1`] = `
 .circuit-5 {
   border-radius: 4px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
@@ -128,7 +128,7 @@ exports[`Tag when is selected should change the close icon color 1`] = `
 exports[`Tag when is selected should change the given icon color 1`] = `
 .circuit-2 {
   border-radius: 4px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
@@ -177,7 +177,7 @@ exports[`Tag when is selected should change the given icon color 1`] = `
 exports[`Tag when is selected should render with selected styles 1`] = `
 .circuit-0 {
   border-radius: 4px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;

--- a/src/components/Text/__snapshots__/Text.spec.js.snap
+++ b/src/components/Text/__snapshots__/Text.spec.js.snap
@@ -4,13 +4,13 @@ exports[`Text should render as article element, when passed "article" for the el
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -26,13 +26,13 @@ exports[`Text should render as div element, when passed "div" for the element pr
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -48,13 +48,13 @@ exports[`Text should render as p element, when passed "p" for the element prop 1
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -70,14 +70,14 @@ exports[`Text should render bold text when passed the bold prop 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   font-weight: 700;
 }
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -91,14 +91,14 @@ exports[`Text should render italic text when passed the italic prop 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   font-style: italic;
 }
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -112,7 +112,7 @@ exports[`Text should render struck through text when passed the strike prop 1`] 
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   -webkit-text-decoration: line-through;
   text-decoration: line-through;
@@ -120,7 +120,7 @@ exports[`Text should render struck through text when passed the strike prop 1`] 
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -135,14 +135,14 @@ exports[`Text should render with no margin styles when passed the noMargin prop 
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   margin-bottom: 0;
 }
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }
@@ -156,7 +156,7 @@ exports[`Text should render with size giga, when passed "giga" for the size prop
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
@@ -200,13 +200,13 @@ exports[`Text should render with size mega, when passed "mega" for the size prop
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 
 @media (min-width:480px) {
   .circuit-0 {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 }

--- a/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
@@ -12,7 +12,7 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -105,7 +105,7 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -235,7 +235,7 @@ exports[`TextArea should prioritize error over optional styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   background-color: #FAFBFC;
   border-style: dashed;
@@ -334,7 +334,7 @@ exports[`TextArea should render with a Tooltip when passed the validationHint pr
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -465,7 +465,7 @@ exports[`TextArea should render with a prefix when passed the prefix prop 1`] = 
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -551,7 +551,7 @@ exports[`TextArea should render with a suffix when passed the suffix prop 1`] = 
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -637,7 +637,7 @@ exports[`TextArea should render with default styles 1`] = `
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -715,7 +715,7 @@ exports[`TextArea should render with disabled styled when passed the disabled pr
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -787,7 +787,7 @@ exports[`TextArea should render with inline styles when passed the inline prop 1
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -895,7 +895,7 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -984,7 +984,7 @@ exports[`TextArea should render with no margin styles when passed the noMargin p
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -1090,7 +1090,7 @@ exports[`TextArea should render with optional styles when passed the optional pr
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   background-color: #FAFBFC;
   border-style: dashed;
@@ -1165,7 +1165,7 @@ exports[`TextArea should render with valid styles when passed the showValid prop
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
@@ -1254,7 +1254,7 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
   -webkit-transition: border-color 200ms ease-in-out;
   transition: border-color 200ms ease-in-out;
   width: 100%;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;

--- a/src/themes/circuit.js
+++ b/src/themes/circuit.js
@@ -178,7 +178,7 @@ export const typography = {
       lineHeight: '20px'
     },
     mega: {
-      fontSize: '15px',
+      fontSize: '16px',
       lineHeight: '24px'
     },
     giga: {


### PR DESCRIPTION
This is an old one. we have two ways of fixing this:
- Set the font size to `16px`.
- Disable page zooming, by adding `maximum-scale=1.0` and/or `user-scalable=no` to the `<meta name="viewport">` tag.

I've decided to use the font-size solution, since circuit-ui is introducing this problem, and not the application consuming it.

Using 16px:
![Screenshot 2019-05-13 at 11 14 56](https://user-images.githubusercontent.com/2780941/57610718-98fd4480-7571-11e9-91be-bedbed0e7769.png)

Using 15px:
![Screenshot 2019-05-13 at 11 15 04](https://user-images.githubusercontent.com/2780941/57610731-9e5a8f00-7571-11e9-8abc-efa5b6802bff.png)


