### PR TITLE
Add fixed width/height for Table sorting arrows

### DIFF
--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -81,6 +81,7 @@ tbody .circuit-11:last-child td {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -90,6 +91,7 @@ tbody .circuit-11:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,
@@ -476,6 +478,7 @@ tbody .circuit-11:last-child td {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -485,6 +488,7 @@ tbody .circuit-11:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,
@@ -847,6 +851,7 @@ tbody .circuit-11:last-child td {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -856,6 +861,7 @@ tbody .circuit-11:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,
@@ -1214,6 +1220,7 @@ tbody .circuit-11:last-child td {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -1223,6 +1230,7 @@ tbody .circuit-11:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,

--- a/src/components/Table/components/SortArrow/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/SortArrow/__snapshots__/index.spec.js.snap
@@ -17,6 +17,7 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -26,6 +27,7 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,
@@ -65,6 +67,7 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -74,6 +77,7 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,
@@ -116,6 +120,7 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -125,6 +130,7 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,

--- a/src/components/Table/components/SortArrow/index.js
+++ b/src/components/Table/components/SortArrow/index.js
@@ -3,18 +3,20 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 import ArrowIcon from './arrow.svg';
 
-import SvgButton from '../../../../components/SvgButton';
+import SvgButton from '../../../SvgButton';
 import { ASCENDING, DESCENDING } from '../../constants';
 
 const baseStyles = ({ theme }) => css`
   display: flex;
   flex-direction: column;
+  height: 10px;
   left: ${theme.spacings.kilo};
   opacity: 0;
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
   transition: opacity ${theme.transitions.default};
+  width: 5px;
 `;
 
 const StyledWrapper = styled(SvgButton)`

--- a/src/components/Table/components/TableHead/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableHead/__snapshots__/index.spec.js.snap
@@ -56,6 +56,7 @@ tbody .circuit-9:last-child td {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -65,6 +66,7 @@ tbody .circuit-9:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,
@@ -197,6 +199,7 @@ tbody .circuit-9:last-child td {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -206,6 +209,7 @@ tbody .circuit-9:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -39,12 +39,11 @@ const TableHead = ({
                 sortDirection={sortedRow === i ? sortDirection : null}
                 isSorted={sortedRow === i}
               />
-              {rowHeaders &&
-                i === 0 && (
-                  <TableCell role="presentation" aria-hidden="true" header>
-                    {getChildren(header)}
-                  </TableCell>
-                )}
+              {rowHeaders && i === 0 && (
+                <TableCell role="presentation" aria-hidden="true" header>
+                  {getChildren(header)}
+                </TableCell>
+              )}
             </Fragment>
           );
         })}

--- a/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
@@ -118,6 +118,7 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -127,6 +128,7 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,
@@ -176,6 +178,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -185,6 +188,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,
@@ -265,6 +269,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 10px;
   left: 12px;
   opacity: 0;
   position: absolute;
@@ -274,6 +279,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   transform: translateY(-50%);
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
+  width: 5px;
 }
 
 .circuit-1:focus,


### PR DESCRIPTION
Safari has a "small" issue with the sorting arrows wrapper:

![what](https://user-images.githubusercontent.com/2780941/57613484-432b9b00-7577-11e9-905d-cc8bf413a3c4.gif)
