### PR TITLE
Add type to Switch to prevent form actions being dispatched

### DIFF
--- a/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
@@ -77,6 +77,7 @@ exports[`Toggle should render with default styles 1`] = `
     className="circuit-4 circuit-5"
     onClick={undefined}
     role="switch"
+    type="button"
   >
     <span
       className="circuit-0 circuit-1"
@@ -168,6 +169,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
     className="circuit-4 circuit-5"
     onClick={undefined}
     role="switch"
+    type="button"
   >
     <span
       className="circuit-0 circuit-1"

--- a/src/components/Toggle/components/Switch/Switch.js
+++ b/src/components/Toggle/components/Switch/Switch.js
@@ -83,7 +83,13 @@ const SwitchLabel = styled('span')`
  * A simple Switch component.
  */
 const Switch = ({ on, onToggle, labelOn, labelOff }) => (
-  <SwitchTrack onClick={onToggle} on={on} role="switch" aria-checked={on}>
+  <SwitchTrack
+    type="button"
+    onClick={onToggle}
+    on={on}
+    role="switch"
+    aria-checked={on}
+  >
     <SwitchKnob {...{ on }} />
     <SwitchLabel>{on ? labelOn : labelOff}</SwitchLabel>
   </SwitchTrack>

--- a/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
+++ b/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
@@ -63,6 +63,7 @@ exports[`Switch should have the correct default styles 1`] = `
   className="circuit-4 circuit-5"
   onClick={undefined}
   role="switch"
+  type="button"
 >
   <span
     className="circuit-0 circuit-1"
@@ -143,6 +144,7 @@ exports[`Switch should have the correct on styles 1`] = `
   className="circuit-4 circuit-5"
   onClick={undefined}
   role="switch"
+  type="button"
 >
   <span
     className="circuit-0 circuit-1"


### PR DESCRIPTION
Since the `SwitchTrack` inside of `Switch` is a button, we need to add the `type` to it. Otherwise when used inside of the a form it will try execute it's event handler when the form is submitted (like pressing enter)