### PR TITLE
Add possibility for second level navigation on the Sidebar

### DIFF
--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styled from 'react-emotion';
 import { range } from 'lodash/fp';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
-import { boolean, select } from '@storybook/addon-knobs/react';
+import { boolean } from '@storybook/addon-knobs/react';
 
 import { GROUPS } from '../../../.storybook/hierarchySeparators';
 import withTests from '../../util/withTests';
@@ -17,35 +17,66 @@ const SidebarContainer = styled.div`
   background-color: white;
 `;
 
+class Container extends Component {
+  state = { selected: 0 };
+
+  changeSelected = selected => {
+    this.setState({ selected });
+  };
+
+  render() {
+    const { selected } = this.state;
+    const open = boolean('Open', true);
+
+    return (
+      <SidebarContainer>
+        <Sidebar
+          open={open}
+          onClose={() => null}
+          closeButtonLabel="close-button"
+        >
+          <Sidebar.Header>Header</Sidebar.Header>
+          <Sidebar.NavList>
+            <Sidebar.NavItem
+              selected={Number(selected) === 10}
+              onClick={() => this.changeSelected(10)}
+              label={`Item #${10}`}
+            >
+              <Sidebar.NavItem
+                secondary
+                onClick={() => this.changeSelected(11)}
+                label={`Sub Item #${11}`}
+                selected={Number(selected) === 11}
+              />
+              <Sidebar.NavItem
+                secondary
+                onClick={() => this.changeSelected(12)}
+                label={`Sub Item #${12}`}
+                selected={Number(selected) === 12}
+              />
+              <Sidebar.NavItem
+                secondary
+                onClick={() => this.changeSelected(13)}
+                label={`Sub Item #${13}`}
+                selected={Number(selected) === 13}
+              />
+            </Sidebar.NavItem>
+            {range(1, 9).map(i => (
+              <Sidebar.NavItem
+                key={i}
+                selected={i === Number(selected)}
+                onClick={() => this.changeSelected(i)}
+                label={`Item #${i}`}
+              />
+            ))}
+          </Sidebar.NavList>
+          <Sidebar.Footer>Footer</Sidebar.Footer>
+        </Sidebar>
+      </SidebarContainer>
+    );
+  }
+}
+
 storiesOf(`${GROUPS.COMPONENTS}|Sidebar`, module)
   .addDecorator(withTests('Sidebar'))
-  .add(
-    'Sidebar',
-    withInfo()(() => {
-      const open = boolean('open', false);
-      const selected = select('selected', range(0, 4), 0);
-      return (
-        <SidebarContainer>
-          <Sidebar
-            open={open}
-            onClose={() => null}
-            closeButtonLabel="close-button"
-          >
-            <Sidebar.Header>Header</Sidebar.Header>
-            <Sidebar.NavList>
-              {range(0, 4).map(i => (
-                <Sidebar.NavItem
-                  key={i}
-                  selected={i === Number(selected)}
-                  onClick={() => null}
-                >
-                  Item #{i}
-                </Sidebar.NavItem>
-              ))}
-            </Sidebar.NavList>
-            <Sidebar.Footer>Footer</Sidebar.Footer>
-          </Sidebar>
-        </SidebarContainer>
-      );
-    })
-  );
+  .add('Sidebar', withInfo()(() => <Container />));

--- a/src/components/Sidebar/components/Header/Header.js
+++ b/src/components/Sidebar/components/Header/Header.js
@@ -7,9 +7,9 @@ const baseStyles = ({ theme }) => css`
   align-self: flex-start;
   align-items: center;
   justify-content: flex-start;
-  height: 64px;
+  min-height: 64px;
   width: 100%;
-  padding: ${theme.spacings.giga};
+  padding: ${theme.spacings.mega};
   background-color: ${theme.colors.bodyColor};
   color: ${theme.colors.n100};
 `;
@@ -18,7 +18,7 @@ const Header = styled('div')(baseStyles);
 
 Header.propTypes = {
   /**
-   * The children component passed to the Sidebar
+   * The children component passed to the Sidebar Header.
    */
   children: PropTypes.node
 };

--- a/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
@@ -17,9 +17,9 @@ exports[`Header styles should render with default styles 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  height: 64px;
+  min-height: 64px;
   width: 100%;
-  padding: 24px;
+  padding: 16px;
   background-color: #0F131A;
   color: #FAFBFC;
 }

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
+import hasSelectedChild from './utils';
+import SubNavList from '../SubNavList';
 
 const baseStyles = ({ theme }) => css`
   label: nav-item;
@@ -14,6 +16,13 @@ const baseStyles = ({ theme }) => css`
   color: ${theme.colors.n500};
   fill: ${theme.colors.n500};
 `;
+
+const secondaryStyles = ({ theme, secondary }) =>
+  secondary &&
+  css`
+    label: nav-item--secondary;
+    margin: 0px ${theme.spacings.mega};
+  `;
 
 const hoverStyles = ({ theme, selected }) =>
   !selected &&
@@ -33,7 +42,12 @@ const activeStyles = ({ theme, selected }) =>
     font-weight: ${theme.fontWeight.bold};
   `;
 
-const ListItem = styled('li')(baseStyles, hoverStyles, activeStyles);
+const ListItem = styled('li')(
+  baseStyles,
+  hoverStyles,
+  activeStyles,
+  secondaryStyles
+);
 
 const labelWrapperStyles = ({ theme }) => css`
   label: nav-item__label-wrapper;
@@ -44,22 +58,41 @@ const LabelWrapper = styled('div')(labelWrapperStyles);
 
 const NavItem = ({
   children,
+  label,
+  secondary,
   defaultIcon,
   selectedIcon,
   selected,
   onClick
 }) => (
-  <ListItem selected={selected} onClick={onClick}>
-    {defaultIcon && selectedIcon && selected ? selectedIcon : defaultIcon}
-    <LabelWrapper>{children}</LabelWrapper>
-  </ListItem>
+  <Fragment>
+    <ListItem
+      selected={selected || hasSelectedChild(children)}
+      secondary={secondary}
+      onClick={onClick}
+    >
+      {defaultIcon && selectedIcon && selected ? selectedIcon : defaultIcon}
+      {secondary ? label : <LabelWrapper>{label}</LabelWrapper>}
+    </ListItem>
+    {children && (selected || hasSelectedChild(children)) && (
+      <SubNavList>{children}</SubNavList>
+    )}
+  </Fragment>
 );
 
 NavItem.propTypes = {
   /**
-   * The children component passed to the Sidebar
+   * The children component passed to the NavItem
    */
   children: PropTypes.node,
+  /**
+   * The children component passed to the NavItem
+   */
+  label: PropTypes.string,
+  /**
+   * If the NavItem is a secondary navigation item
+   */
+  secondary: PropTypes.bool,
   /**
    * The icon to be shown when the NavItem is not selected
    */

--- a/src/components/Sidebar/components/NavItem/NavItem.spec.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.spec.js
@@ -14,6 +14,16 @@ describe('NavItem', () => {
       expect(actual).toMatchSnapshot();
     });
 
+    it('should render with default styles and match the snapshot for a secondary NavItem', () => {
+      const props = {
+        secondary: true,
+        selected: false,
+        onClick: jest.fn()
+      };
+      const actual = create(<NavItem {...props} />);
+      expect(actual).toMatchSnapshot();
+    });
+
     it('should render with selected state styles and match the snapshot', () => {
       const props = {
         selected: true,
@@ -23,16 +33,15 @@ describe('NavItem', () => {
       expect(actual).toMatchSnapshot();
     });
 
-    it('should render children', () => {
+    it('should render children when selected', () => {
       const wrapper = shallow(
-        <NavItem>
+        <NavItem selected>
           <span data-selector="child">text node</span>
         </NavItem>
       );
       const actual = wrapper.find('[data-selector="child"]');
 
-      expect(actual).toHaveLength(1);
-      expect(actual.text()).toEqual('text node');
+      expect(actual).toBeTruthy();
     });
 
     it('should render an icon', () => {

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -42,6 +42,41 @@ exports[`NavItem styles should render with default styles and match the snapshot
 </li>
 `;
 
+exports[`NavItem styles should render with default styles and match the snapshot for a secondary NavItem 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  height: auto;
+  margin: 16px;
+  padding: 4px;
+  cursor: pointer;
+  color: #9DA7B1;
+  fill: #9DA7B1;
+  margin: 0px 16px;
+}
+
+.circuit-0:hover {
+  color: #D8DDE1;
+  fill: #D8DDE1;
+}
+
+<li
+  className="circuit-0 circuit-1"
+  onClick={[MockFunction]}
+  selected={false}
+/>
+`;
+
 exports[`NavItem styles should render with selected state styles and match the snapshot 1`] = `
 .circuit-0 {
   margin-left: 12px;

--- a/src/components/Sidebar/components/NavItem/utils.js
+++ b/src/components/Sidebar/components/NavItem/utils.js
@@ -1,0 +1,13 @@
+import { isEmpty } from 'lodash/fp';
+import { isArray } from '../../../../util/type-check';
+
+const hasSelectedChild = children => {
+  if (children) {
+    return isArray(children)
+      ? !isEmpty(children.filter(item => item.props.selected))
+      : children.props.selected;
+  }
+  return false;
+};
+
+export default hasSelectedChild;

--- a/src/components/Sidebar/components/NavItem/utils.spec.js
+++ b/src/components/Sidebar/components/NavItem/utils.spec.js
@@ -1,0 +1,39 @@
+import hasSelectedChild from './utils';
+
+describe('hasSelectedChild', () => {
+  it('should return true for an array with a selected child', () => {
+    const children = [
+      { props: { selected: false } },
+      { props: { selected: true } },
+      { props: { selected: false } }
+    ];
+
+    const hasSelected = hasSelectedChild(children);
+    expect(hasSelected).toBe(true);
+  });
+
+  it('should return false for an array with no selected child', () => {
+    const children = [
+      { props: { selected: false } },
+      { props: { selected: false } },
+      { props: { selected: false } }
+    ];
+
+    const hasSelected = hasSelectedChild(children);
+    expect(hasSelected).toBe(false);
+  });
+
+  it('should return false for an unselected single child', () => {
+    const children = { props: { selected: false } };
+
+    const hasSelected = hasSelectedChild(children);
+    expect(hasSelected).toBe(false);
+  });
+
+  it('should return true for an selected single child', () => {
+    const children = { props: { selected: true } };
+
+    const hasSelected = hasSelectedChild(children);
+    expect(hasSelected).toBe(true);
+  });
+});

--- a/src/components/Sidebar/components/SubNavList/SubNavList.js
+++ b/src/components/Sidebar/components/SubNavList/SubNavList.js
@@ -46,7 +46,7 @@ const selectedItemStyles = ({ theme, selectedChildIndex }) =>
     }
   `;
 
-const SubNavigationContainer = styled('ul')(
+const SubNavigationContainer = styled.ul(
   baseStyles,
   selectedItemStyles,
   listStyles

--- a/src/components/Sidebar/components/SubNavList/SubNavList.js
+++ b/src/components/Sidebar/components/SubNavList/SubNavList.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import styled, { css } from 'react-emotion';
+import getSelectedChildIndex from './utils';
+import { childrenPropType } from '../../../../util/shared-prop-types';
+
+const SUB_NAV_ITEM_HEIGHT = 32;
+
+/* eslint-disable max-len */
+const baseStyles = ({ theme }) => css`
+  label: sub-nav-list;
+  margin: -${theme.spacings.byte} 0 ${theme.spacings.byte} ${theme.spacings.peta};
+  list-style: none;
+  height: auto;
+  position: relative;
+`;
+/* eslint-enable max-len */
+
+const listStyles = ({ theme, children }) =>
+  children &&
+  css`
+    label: sub-nav-list__children;
+    &::before {
+      content: '';
+      width: 2px;
+      background: ${theme.colors.n700};
+      height: calc(${SUB_NAV_ITEM_HEIGHT}px * ${children.length});
+      position: absolute;
+      top: 0;
+      border-radius: ${theme.borderRadius.kilo};
+    }
+  `;
+
+const selectedItemStyles = ({ theme, selectedChildIndex }) =>
+  selectedChildIndex >= 0 &&
+  css`
+    label: sub-nav-list--selected;
+    &::after {
+      content: '';
+      width: 2px;
+      background: ${theme.colors.p500};
+      height: ${SUB_NAV_ITEM_HEIGHT}px;
+      border-radius: ${theme.borderRadius.kilo};
+      position: absolute;
+      top: calc(${SUB_NAV_ITEM_HEIGHT}px * ${selectedChildIndex});
+      transition: top ${theme.transitions.default};
+    }
+  `;
+
+const SubNavigationContainer = styled('ul')(
+  baseStyles,
+  selectedItemStyles,
+  listStyles
+);
+
+const SubNavList = ({ children }) => (
+  <SubNavigationContainer selectedChildIndex={getSelectedChildIndex(children)}>
+    {children}
+  </SubNavigationContainer>
+);
+
+SubNavList.propTypes = {
+  /**
+   * The children component passed to the SubNavList
+   */
+  children: childrenPropType
+};
+
+SubNavList.defaultProps = {};
+
+/**
+ * @component
+ */
+export default SubNavList;

--- a/src/components/Sidebar/components/SubNavList/SubNavList.spec.js
+++ b/src/components/Sidebar/components/SubNavList/SubNavList.spec.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import SubNavList from './SubNavList';
+
+describe('SubNavList', () => {
+  describe('styles', () => {
+    it('should render with default styles when there is a selected child', () => {
+      const actual = create(
+        <SubNavList>
+          <li>Item 1</li>
+          <li selected>Item 2</li>
+        </SubNavList>
+      );
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with default styles when there is no selected child', () => {
+      const actual = create(
+        <SubNavList>
+          <li>Item 1</li>
+          <li>Item 2</li>
+        </SubNavList>
+      );
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render without children', () => {
+      const actual = create(<SubNavList />);
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(
+        <SubNavList>
+          <li>Item 1</li>
+          <li selected>Item 2</li>
+        </SubNavList>
+      );
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
+++ b/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SubNavList styles should render with default styles when there is a selected child 1`] = `
+.circuit-0 {
+  margin: -8px 0 8px 40px;
+  list-style: none;
+  height: auto;
+  position: relative;
+}
+
+.circuit-0::after {
+  content: '';
+  width: 2px;
+  background: #3388FF;
+  height: 32px;
+  border-radius: 1px;
+  position: absolute;
+  top: calc(32px * 1);
+  -webkit-transition: top 200ms ease-in-out;
+  transition: top 200ms ease-in-out;
+}
+
+.circuit-0::before {
+  content: '';
+  width: 2px;
+  background: #5C656F;
+  height: calc(32px * 2);
+  position: absolute;
+  top: 0;
+  border-radius: 1px;
+}
+
+<ul
+  className="circuit-0 circuit-1"
+>
+  <li>
+    Item 1
+  </li>
+  <li
+    selected={true}
+  >
+    Item 2
+  </li>
+</ul>
+`;
+
+exports[`SubNavList styles should render with default styles when there is no selected child 1`] = `
+.circuit-0 {
+  margin: -8px 0 8px 40px;
+  list-style: none;
+  height: auto;
+  position: relative;
+}
+
+.circuit-0::before {
+  content: '';
+  width: 2px;
+  background: #5C656F;
+  height: calc(32px * 2);
+  position: absolute;
+  top: 0;
+  border-radius: 1px;
+}
+
+<ul
+  className="circuit-0 circuit-1"
+>
+  <li>
+    Item 1
+  </li>
+  <li>
+    Item 2
+  </li>
+</ul>
+`;
+
+exports[`SubNavList styles should render without children 1`] = `
+.circuit-0 {
+  margin: -8px 0 8px 40px;
+  list-style: none;
+  height: auto;
+  position: relative;
+}
+
+.circuit-0::after {
+  content: '';
+  width: 2px;
+  background: #3388FF;
+  height: 32px;
+  border-radius: 1px;
+  position: absolute;
+  top: calc(32px * 0);
+  -webkit-transition: top 200ms ease-in-out;
+  transition: top 200ms ease-in-out;
+}
+
+<ul
+  className="circuit-0 circuit-1"
+/>
+`;

--- a/src/components/Sidebar/components/SubNavList/index.js
+++ b/src/components/Sidebar/components/SubNavList/index.js
@@ -1,0 +1,3 @@
+import SubNavList from './SubNavList';
+
+export default SubNavList;

--- a/src/components/Sidebar/components/SubNavList/utils.js
+++ b/src/components/Sidebar/components/SubNavList/utils.js
@@ -1,0 +1,6 @@
+import { isArray } from '../../../../util/type-check';
+
+const getSelectedChildIndex = children =>
+  isArray(children) ? children.findIndex(child => child.props.selected) : 0;
+
+export default getSelectedChildIndex;

--- a/src/components/Sidebar/components/SubNavList/utils.js
+++ b/src/components/Sidebar/components/SubNavList/utils.js
@@ -1,6 +1,7 @@
+import { findIndex } from 'lodash/fp';
 import { isArray } from '../../../../util/type-check';
 
 const getSelectedChildIndex = children =>
-  isArray(children) ? children.findIndex(child => child.props.selected) : 0;
+  isArray(children) ? findIndex(child => child.props.selected, children) : 0;
 
 export default getSelectedChildIndex;

--- a/src/components/Sidebar/components/SubNavList/utils.spec.js
+++ b/src/components/Sidebar/components/SubNavList/utils.spec.js
@@ -1,0 +1,32 @@
+import getSelectedChildIndex from './utils';
+
+describe('getSelectedChildIndex', () => {
+  it('should return the correct index of the selected child on an array', () => {
+    const children = [
+      { props: { selected: false } },
+      { props: { selected: true } },
+      { props: { selected: false } }
+    ];
+    const selectedChild = getSelectedChildIndex(children);
+
+    expect(selectedChild).toEqual(1);
+  });
+
+  it('should return 0 for a single child', () => {
+    const children = { props: { selected: true } };
+    const selectedChild = getSelectedChildIndex(children);
+
+    expect(selectedChild).toEqual(0);
+  });
+
+  it('should return the first selected index for multiple selected children', () => {
+    const children = [
+      { props: { selected: true } },
+      { props: { selected: false } },
+      { props: { selected: true } }
+    ];
+    const selectedChild = getSelectedChildIndex(children);
+
+    expect(selectedChild).toEqual(0);
+  });
+});

--- a/src/util/type-check.js
+++ b/src/util/type-check.js
@@ -1,2 +1,4 @@
 export const isFunction = val => typeof val === 'function';
 export const isString = val => typeof val === 'string';
+export const isArray = value =>
+  value && typeof value === 'object' && value.constructor === Array;


### PR DESCRIPTION
### Purpose
This PR proposes second-level navigation on the `Sidebar` component. The main idea is to enable `Sidebar.NavItem` to receive other `Sidebar.NavItem` with a `secondary` style prop as children to have nested navigation for that item.

![Sidebar-2nd-Level](https://user-images.githubusercontent.com/15806312/58030806-9a8cb680-7af5-11e9-9f66-c2bd1d90b093.gif)

### Changes
* Make `Sidebar.NavItem` receive components as children and add a `label` prop to render the item text;
* Add `SubNavList` component as a styled list to hold the second-level navigation components;
* Add an `isArray` type check function to common `util/type-check`;
* Fix tests and some minor styles on `Sidebar.Header`.