### PR TITLE
Fix Sidebar styles to match new design constraints

### DIFF
--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -22,7 +22,8 @@ const secondaryStyles = ({ theme, secondary }) =>
   secondary &&
   css`
     label: nav-item--secondary;
-    margin: 0px ${theme.spacings.mega};
+    margin: 0px ${theme.spacings.giga};
+    padding: ${theme.spacings.bit} 0px;
   `;
 
 const hoverStyles = ({ theme, selected }) =>
@@ -65,21 +66,19 @@ const NavItem = ({
   selectedIcon,
   selected,
   onClick
-}) => (
-  <Fragment>
-    <ListItem
-      selected={selected || hasSelectedChild(children)}
-      secondary={secondary}
-      onClick={onClick}
-    >
-      {defaultIcon && selectedIcon && selected ? selectedIcon : defaultIcon}
-      {secondary ? label : <LabelWrapper>{label}</LabelWrapper>}
-    </ListItem>
-    {children && (selected || hasSelectedChild(children)) && (
-      <SubNavList>{children}</SubNavList>
-    )}
-  </Fragment>
-);
+}) => {
+  const isSelected = selected || hasSelectedChild(children);
+
+  return (
+    <Fragment>
+      <ListItem selected={isSelected} secondary={secondary} onClick={onClick}>
+        {defaultIcon && selectedIcon && isSelected ? selectedIcon : defaultIcon}
+        {secondary ? label : <LabelWrapper>{label}</LabelWrapper>}
+      </ListItem>
+      {children && isSelected && <SubNavList>{children}</SubNavList>}
+    </Fragment>
+  );
+};
 
 NavItem.propTypes = {
   /**

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -69,7 +69,8 @@ Array [
   cursor: pointer;
   color: #9DA7B1;
   fill: #9DA7B1;
-  margin: 0px 16px;
+  margin: 0px 24px;
+  padding: 4px 0px;
 }
 
 .circuit-0:hover {

--- a/src/components/Sidebar/components/SubNavList/SubNavList.js
+++ b/src/components/Sidebar/components/SubNavList/SubNavList.js
@@ -9,7 +9,7 @@ const SUB_NAV_ITEM_HEIGHT = 32;
 /* eslint-disable max-len */
 const baseStyles = ({ theme }) => css`
   label: sub-nav-list;
-  margin: -${theme.spacings.byte} 0 ${theme.spacings.byte} ${theme.spacings.peta};
+  margin: -${theme.spacings.byte} 0 ${theme.spacings.byte} ${theme.spacings.tera};
   list-style: none;
   height: auto;
   position: relative;

--- a/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
+++ b/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SubNavList styles should render with default styles when there is a selected child 1`] = `
 .circuit-0 {
-  margin: -8px 0 8px 40px;
+  margin: -8px 0 8px 32px;
   list-style: none;
   height: auto;
   position: relative;
@@ -46,7 +46,7 @@ exports[`SubNavList styles should render with default styles when there is a sel
 
 exports[`SubNavList styles should render with default styles when there is no selected child 1`] = `
 .circuit-0 {
-  margin: -8px 0 8px 40px;
+  margin: -8px 0 8px 32px;
   list-style: none;
   height: auto;
   position: relative;
@@ -76,7 +76,7 @@ exports[`SubNavList styles should render with default styles when there is no se
 
 exports[`SubNavList styles should render without children 1`] = `
 .circuit-0 {
-  margin: -8px 0 8px 40px;
+  margin: -8px 0 8px 32px;
   list-style: none;
   height: auto;
   position: relative;


### PR DESCRIPTION
### Changes
* Decrease some spacings to match new design constraints for the Sidebar second navigation level;
* Make `NavItem` icon appear selected when a `NavItem` has any `selected` child.