### PR TITLE
Fix SimpleCurrencyInput styles

### DIFF
--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/SimpleCurrencyInput.js
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/SimpleCurrencyInput.js
@@ -45,7 +45,7 @@ const CurrencyIcon = styled('span')`
   ${iconInvalidStyles};
 `;
 
-const inputStyles = css`
+const inputStyles = stringCss => stringCss`
   label: currency-input__input;
   text-align: right;
 `;
@@ -82,7 +82,7 @@ const SimpleCurrencyInput = ({
   <ClassNames>
     {({ css: stringCss, cx }) => {
       const inputClassName = cx(
-        inputStyles,
+        inputStyles(stringCss),
         inputPrependStyles({
           theme,
           symbol,

--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
@@ -23,6 +23,7 @@ exports[`SimpleCurrencyInput should adjust input padding and postfix width to ma
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
+  text-align: right;
   padding-right: 48px;
   padding-right: calc(24px + 3ch);
 }
@@ -75,7 +76,7 @@ exports[`SimpleCurrencyInput should adjust input padding and postfix width to ma
 >
   <input
     aria-invalid="false"
-    class="name styles map circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     placeholder="123,45"
     type="text"
   />
@@ -113,6 +114,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over error styles 1`] = 
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
+  text-align: right;
   padding-right: 48px;
   padding-right: calc(24px + 0ch);
 }
@@ -166,7 +168,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over error styles 1`] = 
 >
   <input
     aria-invalid="true"
-    class="name styles map circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     disabled=""
     type="text"
   />
@@ -200,6 +202,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over warning styles 1`] 
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
+  text-align: right;
   padding-right: 48px;
   padding-right: calc(24px + 0ch);
 }
@@ -300,7 +303,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over warning styles 1`] 
 >
   <input
     aria-invalid="true"
-    class="name styles map circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -332,6 +335,7 @@ exports[`SimpleCurrencyInput should render with default styles 1`] = `
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
+  text-align: right;
   padding-right: 48px;
   padding-right: calc(24px + 1ch);
 }
@@ -384,7 +388,7 @@ exports[`SimpleCurrencyInput should render with default styles 1`] = `
 >
   <input
     aria-invalid="false"
-    class="name styles map circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -418,6 +422,7 @@ exports[`SimpleCurrencyInput should render with error styles 1`] = `
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
+  text-align: right;
   padding-right: 48px;
   padding-right: calc(24px + 1ch);
 }
@@ -494,7 +499,7 @@ exports[`SimpleCurrencyInput should render with error styles 1`] = `
 >
   <input
     aria-invalid="true"
-    class="name styles map circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -528,6 +533,7 @@ exports[`SimpleCurrencyInput should render with warning styles 1`] = `
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
+  text-align: right;
   padding-right: 48px;
   padding-right: calc(24px + 1ch);
 }
@@ -604,7 +610,7 @@ exports[`SimpleCurrencyInput should render with warning styles 1`] = `
 >
   <input
     aria-invalid="false"
-    class="name styles map circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -651,6 +657,7 @@ exports[`SimpleCurrencyInput should support rendering symbols on the left 1`] = 
   line-height: 24px;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
+  text-align: right;
   padding-left: 48px;
   padding-left: calc(24px + 1ch);
 }
@@ -695,7 +702,7 @@ exports[`SimpleCurrencyInput should support rendering symbols on the left 1`] = 
   </span>
   <input
     aria-invalid="false"
-    class="name styles map circuit-2 circuit-3"
+    class="circuit-2 circuit-3"
     placeholder="123.45"
     type="text"
   />


### PR DESCRIPTION
With the emotion migration, we didn't properly update the `inputStyles` for the SimpleCurrencyInput, it was looking like this:

<img width="281" alt="Screenshot 2019-06-15 at 11 57 00" src="https://user-images.githubusercontent.com/2780941/59549994-d8022980-8f65-11e9-8277-c19b0b7ce70a.png">
