### PR TITLE
Replace innerRef usage with ref

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -217,7 +217,7 @@ class Popover extends Component {
         {({ ref }) => (
           <ReferenceWrapper
             referenceWrapperStyles={referenceWrapperStyles}
-            innerRef={this.receiveButtonRef}
+            ref={this.receiveButtonRef}
             onClick={this.handleReferenceClick}
           >
             <div ref={ref}>{renderReference()}</div>
@@ -240,7 +240,7 @@ class Popover extends Component {
           isOpen && (
             <PopoverWrapper
               style={style}
-              innerRef={this.receivePopoverRef}
+              ref={this.receivePopoverRef}
               zIndex={zIndex}
             >
               <div ref={ref}>

--- a/src/components/SideNav/components/Modal/Modal.js
+++ b/src/components/SideNav/components/Modal/Modal.js
@@ -298,7 +298,7 @@ class Modal extends React.Component {
         onRendered={this.handleRendered}
       >
         <ModalContent
-          innerRef={ref => {
+          ref={ref => {
             this.modalRef = ref;
           }}
           hidden={exited}


### PR DESCRIPTION
Emotion 10 introduced `ref`, and a nice development error about `innerRef` being deprecated in the next version.

![image](https://user-images.githubusercontent.com/2780941/59550298-41376c00-8f69-11e9-917f-45c86db24389.png)


~~Still need to figure it out how to make it work with our AutoComplete input (It's using downshift)~~