### PR TITLE
Replace className usage with css object for legacy SideNav

### DIFF
--- a/src/components/SideNav/SideNav.js
+++ b/src/components/SideNav/SideNav.js
@@ -86,7 +86,7 @@ const SideNav = props => {
       open={mode !== MODE.HIDDEN}
       variant={variant}
       anchor="left"
-      CardProps={{ className: drawerContentStyles }}
+      CardProps={{ additionalStyles: drawerContentStyles }}
     >
       <div
         css={css`

--- a/src/components/SideNav/components/Drawer/Drawer.js
+++ b/src/components/SideNav/components/Drawer/Drawer.js
@@ -64,6 +64,7 @@ const DrawerContainer = styled.div`
   ${anchorRightStyles};
   ${anchorTopStyles};
   ${anchorBottomStyles};
+  ${({ additionalStyles }) => additionalStyles}
 `;
 
 const Docked = styled.div`
@@ -201,7 +202,9 @@ Drawer.propTypes = {
   /**
    * Properties applied to the [`Paper`](/api/paper) element.
    */
-  CardProps: PropTypes.shape(Card.propTypes),
+  CardProps: PropTypes.shape({
+    additionalStyles: PropTypes.object
+  }),
   /**
    * Properties applied to the [`Slide`](/api/slide) element.
    */


### PR DESCRIPTION
Also a leftover from the migration to Emotion 10.