### PR TITLE
feat: Add new navigation Aggregator and improve animations

### DIFF
--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -24,6 +24,7 @@ import NavList from './components/NavList';
 import NavItem from './components/NavItem';
 import Backdrop from './components/Backdrop';
 import CloseButton from './components/CloseButton';
+import Aggregator from './components/Aggregator';
 
 const SIDEBAR_WIDTH = 256;
 
@@ -97,5 +98,6 @@ Sidebar.Header = Header;
 Sidebar.Footer = Footer;
 Sidebar.NavList = NavList;
 Sidebar.NavItem = NavItem;
+Sidebar.Aggregator = Aggregator;
 
 export default Sidebar;

--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -52,31 +52,24 @@ class Container extends Component {
         >
           <Sidebar.Header>Header</Sidebar.Header>
           <Sidebar.NavList>
-            <Sidebar.NavItem
-              selected={Number(selected) === 10}
-              onClick={() => this.changeSelected(10)}
-              label={`Item #${10}`}
-            >
+            <Sidebar.Aggregator label={`Item #${1}`}>
               <Sidebar.NavItem
-                secondary
-                onClick={() => this.changeSelected(11)}
-                label={`Sub Item #${11}`}
-                selected={Number(selected) === 11}
+                onClick={() => this.changeSelected(4)}
+                label={`Sub Item #${1}`}
+                selected={Number(selected) === 4}
               />
               <Sidebar.NavItem
-                secondary
-                onClick={() => this.changeSelected(12)}
-                label={`Sub Item #${12}`}
-                selected={Number(selected) === 12}
+                onClick={() => this.changeSelected(5)}
+                label={`Sub Item #${2}`}
+                selected={Number(selected) === 5}
               />
               <Sidebar.NavItem
-                secondary
-                onClick={() => this.changeSelected(13)}
-                label={`Sub Item #${13}`}
-                selected={Number(selected) === 13}
+                onClick={() => this.changeSelected(6)}
+                label={`Sub Item #${3}`}
+                selected={Number(selected) === 6}
               />
-            </Sidebar.NavItem>
-            {range(1, 9).map(i => (
+            </Sidebar.Aggregator>
+            {range(2, 4).map(i => (
               <Sidebar.NavItem
                 key={i}
                 selected={i === Number(selected)}

--- a/src/components/Sidebar/components/Aggregator/Aggregator.js
+++ b/src/components/Sidebar/components/Aggregator/Aggregator.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';

--- a/src/components/Sidebar/components/Aggregator/Aggregator.js
+++ b/src/components/Sidebar/components/Aggregator/Aggregator.js
@@ -1,0 +1,125 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+import SubNavList from '../SubNavList';
+import NavLabel from '../NavLabel';
+import hasSelectedChild from '../NavItem/utils';
+import { childrenPropType } from '../../../../util/shared-prop-types';
+
+const baseStyles = ({ theme }) => css`
+  label: nav-aggregator;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  height: auto;
+  margin: ${theme.spacings.mega};
+  padding: ${theme.spacings.bit};
+  cursor: pointer;
+  color: ${theme.colors.n500};
+  fill: ${theme.colors.n500};
+`;
+
+const hoverStyles = ({ theme, selected }) =>
+  !selected &&
+  css`
+    label: nav-aggregator--hover;
+    &:hover {
+      color: ${theme.colors.n300};
+      fill: ${theme.colors.n300};
+    }
+  `;
+
+const selectedStyles = ({ theme, selected }) =>
+  selected &&
+  css`
+    label: nav-aggregator--active;
+    color: ${theme.colors.n100};
+  `;
+
+const AggregatorContainer = styled.div(baseStyles, hoverStyles, selectedStyles);
+
+class Aggregator extends Component {
+  state = {
+    open: false
+  };
+
+  componentDidUpdate(prevProps, prevState) {
+    const { children } = this.props;
+    const shouldClose =
+      (hasSelectedChild(prevProps.children) || prevState.open) &&
+      !hasSelectedChild(children);
+
+    if (shouldClose) {
+      this.closeAggregator();
+    }
+  }
+
+  closeAggregator = () => {
+    this.setState({ open: false });
+  };
+
+  toggleAggregator = () => {
+    const { onClick } = this.props;
+
+    this.setState(prevState => ({ open: !prevState.open }));
+    if (onClick) {
+      onClick();
+    }
+  };
+
+  render() {
+    const { children, label, defaultIcon, selectedIcon } = this.props;
+    const { open } = this.state;
+
+    return (
+      <Fragment>
+        <AggregatorContainer
+          selected={hasSelectedChild(children)}
+          onClick={this.toggleAggregator}
+        >
+          {defaultIcon && selectedIcon && open ? selectedIcon : defaultIcon}
+          <NavLabel>{label}</NavLabel>
+        </AggregatorContainer>
+        {children && <SubNavList visible={open}>{children}</SubNavList>}
+      </Fragment>
+    );
+  }
+}
+
+Aggregator.propTypes = {
+  /**
+   * The children component passed to the NavAggregator
+   */
+  children: childrenPropType,
+  /**
+   * The label of NavAggregator
+   */
+  label: PropTypes.string,
+  /**
+   * The icon to be shown when the NavAggregator is not selected
+   */
+  defaultIcon: PropTypes.node,
+  /**
+   * The icon to be shown when the NavAggregator is selected
+   */
+  selectedIcon: PropTypes.node,
+  /**
+   * The onClick method to handle the click event on the NavAggregator
+   */
+  onClick: PropTypes.func
+};
+
+Aggregator.defaultProps = {
+  children: null,
+  label: '',
+  defaultIcon: '',
+  selectedIcon: '',
+  onClick: null
+};
+
+/**
+ * @component
+ */
+export default Aggregator;

--- a/src/components/Sidebar/components/Aggregator/Aggregator.spec.js
+++ b/src/components/Sidebar/components/Aggregator/Aggregator.spec.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { Component, Fragment } from 'react';
 
 import Aggregator from './Aggregator';

--- a/src/components/Sidebar/components/Aggregator/Aggregator.spec.js
+++ b/src/components/Sidebar/components/Aggregator/Aggregator.spec.js
@@ -1,0 +1,145 @@
+import React, { Component, Fragment } from 'react';
+
+import Aggregator from './Aggregator';
+
+const props = {
+  label: 'Aggregator',
+  onClick: jest.fn(),
+  selectedIcon: 'selected-icon',
+  defaultIcon: 'default-icon'
+};
+
+class MockedNavigation extends Component {
+  state = {
+    selected: 0
+  };
+
+  render() {
+    const { selected } = this.state;
+    return (
+      <Fragment>
+        <Aggregator {...props}>
+          <div selected={selected === 0} data-testid="child">
+            child
+          </div>
+        </Aggregator>
+        {/* eslint-disable-next-line */}
+        <div
+          id="sibling"
+          selected={selected !== 0}
+          onClick={() => this.setState({ selected: 1 })}
+        >
+          sibling
+        </div>
+      </Fragment>
+    );
+  }
+}
+
+describe('Aggregator', () => {
+  describe('styles', () => {
+    it('should render with default styles', () => {
+      const actual = mount(
+        <Aggregator {...props}>
+          <div data-testid="child">child</div>
+        </Aggregator>
+      );
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render and match snapshot when open', async () => {
+      const actual = mount(
+        <Aggregator {...props}>
+          <div data-testid="child">child</div>
+        </Aggregator>
+      );
+
+      actual.find("[className*='nav-aggregator']").simulate('click');
+      await new Promise(resolve => setTimeout(resolve));
+      actual.update();
+
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('interactions', () => {
+    it('should show children and call onClick when clicking the aggregator', () => {
+      const actual = mount(
+        <Aggregator {...props}>
+          <div selected data-testid="child">
+            child
+          </div>
+        </Aggregator>
+      );
+
+      actual.find("[className*='nav-aggregator']").simulate('click');
+      expect(actual.state().open).toBe(true);
+      expect(props.onClick).toHaveBeenCalled();
+    });
+
+    it('should show children when clicking the aggregator and no onClick handle is passed', () => {
+      const noHandlerProps = {
+        ...props,
+        onClick: null
+      };
+
+      const actual = mount(
+        <Aggregator {...noHandlerProps}>
+          <div selected data-testid="child">
+            child
+          </div>
+        </Aggregator>
+      );
+
+      actual.find("[className*='nav-aggregator']").simulate('click');
+      expect(actual.state().open).toBe(true);
+    });
+
+    it('should close the aggregator when clicking again on the aggregator', async () => {
+      const actual = mount(
+        <Aggregator {...props}>
+          <div selected data-testid="child">
+            child
+          </div>
+        </Aggregator>
+      );
+
+      actual.find("[className*='nav-aggregator']").simulate('click');
+      expect(actual.state().open).toBe(true);
+
+      await new Promise(resolve => setTimeout(resolve));
+      actual.update();
+
+      actual.find("[className*='nav-aggregator']").simulate('click');
+
+      expect(props.onClick).toHaveBeenCalled();
+      expect(actual.state().open).toBe(false);
+    });
+
+    it('should close when there are no selected children', async () => {
+      const actual = mount(<MockedNavigation />);
+      const aggregator = actual.find('Aggregator');
+
+      actual.find("[className*='nav-aggregator']").simulate('click');
+      expect(aggregator.state().open).toBe(true);
+
+      await new Promise(resolve => setTimeout(resolve));
+      actual.update();
+
+      actual.find("[id*='sibling']").simulate('click');
+
+      await new Promise(resolve => setTimeout(resolve));
+      actual.update();
+
+      expect(aggregator.state().open).toBe(false);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<Aggregator />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.js.snap
+++ b/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.js.snap
@@ -1,0 +1,233 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Aggregator styles should render and match snapshot when open 1`] = `
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  height: auto;
+  margin: 16px;
+  padding: 4px;
+  cursor: pointer;
+  color: #9DA7B1;
+  fill: #9DA7B1;
+}
+
+.circuit-2:hover {
+  color: #D8DDE1;
+  fill: #D8DDE1;
+}
+
+.circuit-0 {
+  margin-left: 12px;
+}
+
+.circuit-4 {
+  margin: -8px 0 8px 32px;
+  list-style: none;
+  height: 0;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  height: calc(32px * );
+  position: relative;
+  opacity: 1;
+  visibility: visible;
+  -webkit-transition: height 200ms ease-in-out,opacity 200ms ease-in-out 100ms,visibility 200ms ease-in-out 100ms;
+  transition: height 200ms ease-in-out,opacity 200ms ease-in-out 100ms,visibility 200ms ease-in-out 100ms;
+}
+
+.circuit-4::after {
+  content: '';
+  width: 2px;
+  background: #3388FF;
+  height: 32px;
+  border-radius: 1px;
+  position: absolute;
+  top: calc(32px * 0);
+  -webkit-transition: top 200ms ease-in-out;
+  transition: top 200ms ease-in-out;
+}
+
+.circuit-4::before {
+  content: '';
+  width: 2px;
+  background: #5C656F;
+  height: calc(32px * );
+  position: absolute;
+  top: 0;
+  border-radius: 1px;
+}
+
+<Aggregator
+  defaultIcon="default-icon"
+  label="Aggregator"
+  onClick={
+    [MockFunction] {
+      "calls": Array [
+        Array [],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  selectedIcon="selected-icon"
+>
+  <Styled(div)
+    onClick={[Function]}
+  >
+    <div
+      className="circuit-2 circuit-3"
+      onClick={[Function]}
+    >
+      selected-icon
+      <Styled(div)>
+        <div
+          className="circuit-0 circuit-1"
+        >
+          Aggregator
+        </div>
+      </Styled(div)>
+    </div>
+  </Styled(div)>
+  <SubNavList
+    visible={true}
+  >
+    <Styled(ul)
+      selectedChildIndex={0}
+      visible={true}
+    >
+      <ul
+        className="circuit-4 circuit-5"
+      >
+        <div
+          data-testid="child"
+          secondary={true}
+          visible={true}
+        >
+          child
+        </div>
+      </ul>
+    </Styled(ul)>
+  </SubNavList>
+</Aggregator>
+`;
+
+exports[`Aggregator styles should render with default styles 1`] = `
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  height: auto;
+  margin: 16px;
+  padding: 4px;
+  cursor: pointer;
+  color: #9DA7B1;
+  fill: #9DA7B1;
+}
+
+.circuit-2:hover {
+  color: #D8DDE1;
+  fill: #D8DDE1;
+}
+
+.circuit-0 {
+  margin-left: 12px;
+}
+
+.circuit-4 {
+  margin: -8px 0 8px 32px;
+  list-style: none;
+  height: 0;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+}
+
+.circuit-4::after {
+  content: '';
+  width: 2px;
+  background: #3388FF;
+  height: 32px;
+  border-radius: 1px;
+  position: absolute;
+  top: calc(32px * 0);
+  -webkit-transition: top 200ms ease-in-out;
+  transition: top 200ms ease-in-out;
+}
+
+.circuit-4::before {
+  content: '';
+  width: 2px;
+  background: #5C656F;
+  height: calc(32px * );
+  position: absolute;
+  top: 0;
+  border-radius: 1px;
+}
+
+<Aggregator
+  defaultIcon="default-icon"
+  label="Aggregator"
+  onClick={[MockFunction]}
+  selectedIcon="selected-icon"
+>
+  <Styled(div)
+    onClick={[Function]}
+  >
+    <div
+      className="circuit-2 circuit-3"
+      onClick={[Function]}
+    >
+      default-icon
+      <Styled(div)>
+        <div
+          className="circuit-0 circuit-1"
+        >
+          Aggregator
+        </div>
+      </Styled(div)>
+    </div>
+  </Styled(div)>
+  <SubNavList
+    visible={false}
+  >
+    <Styled(ul)
+      selectedChildIndex={0}
+      visible={false}
+    >
+      <ul
+        className="circuit-4 circuit-5"
+      >
+        <div
+          data-testid="child"
+          secondary={true}
+          visible={false}
+        >
+          child
+        </div>
+      </ul>
+    </Styled(ul)>
+  </SubNavList>
+</Aggregator>
+`;

--- a/src/components/Sidebar/components/Aggregator/index.js
+++ b/src/components/Sidebar/components/Aggregator/index.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import Aggregator from './Aggregator';
 
 export default Aggregator;

--- a/src/components/Sidebar/components/Aggregator/index.js
+++ b/src/components/Sidebar/components/Aggregator/index.js
@@ -1,0 +1,3 @@
+import Aggregator from './Aggregator';
+
+export default Aggregator;

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -13,12 +13,11 @@
  * limitations under the License.
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
-import hasSelectedChild from './utils';
-import SubNavList from '../SubNavList';
+import NavLabel from '../NavLabel';
 
 const baseStyles = ({ theme }) => css`
   label: nav-item;
@@ -39,6 +38,7 @@ const secondaryStyles = ({ theme, secondary }) =>
     label: nav-item--secondary;
     margin: 0px ${theme.spacings.giga};
     padding: ${theme.spacings.bit} 0px;
+    transition: top ${theme.transitions.default};
   `;
 
 const hoverStyles = ({ theme, selected }) =>
@@ -51,7 +51,7 @@ const hoverStyles = ({ theme, selected }) =>
     }
   `;
 
-const activeStyles = ({ theme, selected }) =>
+const selectedStyles = ({ theme, selected }) =>
   selected &&
   css`
     label: nav-item--active;
@@ -59,55 +59,48 @@ const activeStyles = ({ theme, selected }) =>
     font-weight: ${theme.fontWeight.bold};
   `;
 
-const ListItem = styled('li')(
+const ListItem = styled.li(
   baseStyles,
   hoverStyles,
-  activeStyles,
+  selectedStyles,
   secondaryStyles
 );
 
-const labelWrapperStyles = ({ theme }) => css`
-  label: nav-item__label-wrapper;
-  margin-left: ${theme.spacings.kilo};
-`;
-
-const LabelWrapper = styled('div')(labelWrapperStyles);
-
 const NavItem = ({
-  children,
   label,
   secondary,
+  visible,
   defaultIcon,
   selectedIcon,
   selected,
   onClick
-}) => {
-  const isSelected = selected || hasSelectedChild(children);
-
-  return (
-    <Fragment>
-      <ListItem selected={isSelected} secondary={secondary} onClick={onClick}>
-        {defaultIcon && selectedIcon && isSelected ? selectedIcon : defaultIcon}
-        {secondary ? label : <LabelWrapper>{label}</LabelWrapper>}
-      </ListItem>
-      {children && isSelected && <SubNavList>{children}</SubNavList>}
-    </Fragment>
-  );
-};
+}) => (
+  <ListItem
+    selected={selected}
+    secondary={secondary}
+    visible={visible}
+    onClick={onClick}
+  >
+    {defaultIcon && selectedIcon && selected ? selectedIcon : defaultIcon}
+    <NavLabel secondary={secondary} visible={visible}>
+      {label}
+    </NavLabel>
+  </ListItem>
+);
 
 NavItem.propTypes = {
   /**
-   * The children component passed to the NavItem
-   */
-  children: PropTypes.node,
-  /**
-   * The children component passed to the NavItem
+   * The label of a NavItem
    */
   label: PropTypes.string,
   /**
    * If the NavItem is a secondary navigation item
    */
   secondary: PropTypes.bool,
+  /**
+   * If the NavItem is visible (it can be hidden when secondary)
+   */
+  visible: PropTypes.bool,
   /**
    * The icon to be shown when the NavItem is not selected
    */
@@ -117,7 +110,7 @@ NavItem.propTypes = {
    */
   selectedIcon: PropTypes.node,
   /**
-   * Tells if the item is selected
+   * If the item is selected
    */
   selected: PropTypes.bool,
   /**
@@ -127,9 +120,9 @@ NavItem.propTypes = {
 };
 
 NavItem.defaultProps = {
-  children: '',
   label: '',
   secondary: false,
+  visible: true,
   defaultIcon: '',
   selectedIcon: '',
   selected: false,

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NavItem styles should render with default styles and match the snapshot 1`] = `
-Array [
-  .circuit-2 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -33,24 +32,21 @@ Array [
 }
 
 <li
-    className="circuit-2 circuit-3"
-    onClick={[MockFunction]}
-    selected={false}
+  className="circuit-2 circuit-3"
+  onClick={[MockFunction]}
+  selected={false}
+>
+  
+  <div
+    className="circuit-0 circuit-1"
   >
     
-    <div
-      className="circuit-0 circuit-1"
-    >
-      
-    </div>
-  </li>,
-  "",
-]
+  </div>
+</li>
 `;
 
 exports[`NavItem styles should render with default styles and match the snapshot for a secondary NavItem 1`] = `
-Array [
-  .circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -71,28 +67,40 @@ Array [
   fill: #9DA7B1;
   margin: 0px 24px;
   padding: 4px 0px;
+  -webkit-transition: top 200ms ease-in-out;
+  transition: top 200ms ease-in-out;
 }
 
-.circuit-0:hover {
+.circuit-2:hover {
   color: #D8DDE1;
   fill: #D8DDE1;
 }
 
+.circuit-0 {
+  margin-left: 12px;
+  margin-left: 0px;
+  margin-top: -12px;
+  -webkit-transition: margin-top 300ms ease-in-out;
+  transition: margin-top 300ms ease-in-out;
+  margin-top: 0px;
+}
+
 <li
+  className="circuit-2 circuit-3"
+  onClick={[MockFunction]}
+  selected={false}
+>
+  
+  <div
     className="circuit-0 circuit-1"
-    onClick={[MockFunction]}
-    selected={false}
   >
     
-    
-  </li>,
-  "",
-]
+  </div>
+</li>
 `;
 
 exports[`NavItem styles should render with selected state styles and match the snapshot 1`] = `
-Array [
-  .circuit-0 {
+.circuit-0 {
   margin-left: 12px;
 }
 
@@ -120,17 +128,15 @@ Array [
 }
 
 <li
-    className="circuit-2 circuit-3"
-    onClick={[MockFunction]}
-    selected={true}
+  className="circuit-2 circuit-3"
+  onClick={[MockFunction]}
+  selected={true}
+>
+  
+  <div
+    className="circuit-0 circuit-1"
   >
     
-    <div
-      className="circuit-0 circuit-1"
-    >
-      
-    </div>
-  </li>,
-  "",
-]
+  </div>
+</li>
 `;

--- a/src/components/Sidebar/components/NavLabel/NavLabel.js
+++ b/src/components/Sidebar/components/NavLabel/NavLabel.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';

--- a/src/components/Sidebar/components/NavLabel/NavLabel.js
+++ b/src/components/Sidebar/components/NavLabel/NavLabel.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+const baseStyles = ({ theme }) => css`
+  label: nav-label;
+  margin-left: ${theme.spacings.kilo};
+`;
+
+const secondaryStyles = ({ theme, secondary }) =>
+  secondary &&
+  css`
+    label: nav-label--secondary;
+    margin-left: 0px;
+    margin-top: -${theme.spacings.kilo};
+    transition: margin-top ${theme.transitions.slow};
+  `;
+
+const secondaryVisibleStyles = ({ secondary, visible }) =>
+  secondary &&
+  visible &&
+  css`
+    label: nav-label--secondary--visible;
+    margin-top: 0px;
+  `;
+
+const NavLabel = styled.div(
+  baseStyles,
+  secondaryStyles,
+  secondaryVisibleStyles
+);
+
+NavLabel.propTypes = {
+  /**
+   * If the Label is secondary and smaller margin
+   */
+  secondary: PropTypes.bool,
+  /**
+   * If the Label is visible (it can be hidden when secondary)
+   */
+  visible: PropTypes.bool
+};
+
+/**
+ * @component
+ */
+export default NavLabel;

--- a/src/components/Sidebar/components/NavLabel/NavLabel.spec.js
+++ b/src/components/Sidebar/components/NavLabel/NavLabel.spec.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import NavLabel from './NavLabel';
+
+describe('NavLabel', () => {
+  describe('styles', () => {
+    it('should render with default styles', () => {
+      const actual = mount(<NavLabel>Item 01</NavLabel>);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render and match snapshot when visible', () => {
+      const actual = mount(<NavLabel visible>Item 01</NavLabel>);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render and match snapshot when secondary', () => {
+      const actual = mount(
+        <NavLabel visible secondary>
+          Item 01
+        </NavLabel>
+      );
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<NavLabel>Item 01</NavLabel>);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Sidebar/components/NavLabel/NavLabel.spec.js
+++ b/src/components/Sidebar/components/NavLabel/NavLabel.spec.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import NavLabel from './NavLabel';

--- a/src/components/Sidebar/components/NavLabel/__snapshots__/NavLabel.spec.js.snap
+++ b/src/components/Sidebar/components/NavLabel/__snapshots__/NavLabel.spec.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavLabel styles should render and match snapshot when secondary 1`] = `
+.circuit-0 {
+  margin-left: 12px;
+  margin-left: 0px;
+  margin-top: -12px;
+  -webkit-transition: margin-top 300ms ease-in-out;
+  transition: margin-top 300ms ease-in-out;
+  margin-top: 0px;
+}
+
+<Styled(div)
+  secondary={true}
+  visible={true}
+>
+  <div
+    className="circuit-0 circuit-1"
+  >
+    Item 01
+  </div>
+</Styled(div)>
+`;
+
+exports[`NavLabel styles should render and match snapshot when visible 1`] = `
+.circuit-0 {
+  margin-left: 12px;
+}
+
+<Styled(div)
+  visible={true}
+>
+  <div
+    className="circuit-0 circuit-1"
+  >
+    Item 01
+  </div>
+</Styled(div)>
+`;
+
+exports[`NavLabel styles should render with default styles 1`] = `
+.circuit-0 {
+  margin-left: 12px;
+}
+
+<Styled(div)>
+  <div
+    className="circuit-0 circuit-1"
+  >
+    Item 01
+  </div>
+</Styled(div)>
+`;

--- a/src/components/Sidebar/components/NavLabel/index.js
+++ b/src/components/Sidebar/components/NavLabel/index.js
@@ -1,0 +1,3 @@
+import NavLabel from './NavLabel';
+
+export default NavLabel;

--- a/src/components/Sidebar/components/NavLabel/index.js
+++ b/src/components/Sidebar/components/NavLabel/index.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import NavLabel from './NavLabel';
 
 export default NavLabel;

--- a/src/components/Sidebar/components/SubNavList/SubNavList.js
+++ b/src/components/Sidebar/components/SubNavList/SubNavList.js
@@ -14,9 +14,10 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
-import getSelectedChildIndex from './utils';
+import { getSelectedChildIndex, getSecondaryChild } from './utils';
 import { childrenPropType } from '../../../../util/shared-prop-types';
 
 const SUB_NAV_ITEM_HEIGHT = 32;
@@ -26,10 +27,25 @@ const baseStyles = ({ theme }) => css`
   label: sub-nav-list;
   margin: -${theme.spacings.byte} 0 ${theme.spacings.byte} ${theme.spacings.tera};
   list-style: none;
-  height: auto;
-  position: relative;
+  height: 0;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
 `;
 /* eslint-enable max-len */
+
+const visibleStyles = ({ theme, visible, children }) =>
+  visible &&
+  css`
+    label: sub-nav-list--visible;
+    height: calc(${SUB_NAV_ITEM_HEIGHT}px * ${children.length});
+    position: relative;
+    opacity: 1;
+    visibility: visible;
+    transition: height ${theme.transitions.default},
+      opacity ${theme.transitions.default} 100ms,
+      visibility ${theme.transitions.default} 100ms;
+  `;
 
 const listStyles = ({ theme, children }) =>
   children &&
@@ -65,12 +81,16 @@ const selectedItemStyles = ({ theme, selectedChildIndex }) =>
 const SubNavigationContainer = styled.ul(
   baseStyles,
   selectedItemStyles,
-  listStyles
+  listStyles,
+  visibleStyles
 );
 
-const SubNavList = ({ children }) => (
-  <SubNavigationContainer selectedChildIndex={getSelectedChildIndex(children)}>
-    {children}
+const SubNavList = ({ children, visible }) => (
+  <SubNavigationContainer
+    visible={visible}
+    selectedChildIndex={getSelectedChildIndex(children)}
+  >
+    {getSecondaryChild(children, visible)}
   </SubNavigationContainer>
 );
 
@@ -78,11 +98,16 @@ SubNavList.propTypes = {
   /**
    * The children component passed to the SubNavList
    */
-  children: childrenPropType
+  children: childrenPropType,
+  /**
+   * If the SubNavList is currently visible
+   */
+  visible: PropTypes.bool
 };
 
 SubNavList.defaultProps = {
-  children: null
+  children: null,
+  visible: false
 };
 
 /**

--- a/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
+++ b/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
@@ -4,8 +4,10 @@ exports[`SubNavList styles should render with default styles when there is a sel
 .circuit-0 {
   margin: -8px 0 8px 32px;
   list-style: none;
-  height: auto;
-  position: relative;
+  height: 0;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
 }
 
 .circuit-0::after {
@@ -33,11 +35,16 @@ exports[`SubNavList styles should render with default styles when there is a sel
 <ul
   className="circuit-0 circuit-1"
 >
-  <li>
+  <li
+    secondary={true}
+    visible={false}
+  >
     Item 1
   </li>
   <li
+    secondary={true}
     selected={true}
+    visible={false}
   >
     Item 2
   </li>
@@ -48,8 +55,10 @@ exports[`SubNavList styles should render with default styles when there is no se
 .circuit-0 {
   margin: -8px 0 8px 32px;
   list-style: none;
-  height: auto;
-  position: relative;
+  height: 0;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
 }
 
 .circuit-0::before {
@@ -65,10 +74,16 @@ exports[`SubNavList styles should render with default styles when there is no se
 <ul
   className="circuit-0 circuit-1"
 >
-  <li>
+  <li
+    secondary={true}
+    visible={false}
+  >
     Item 1
   </li>
-  <li>
+  <li
+    secondary={true}
+    visible={false}
+  >
     Item 2
   </li>
 </ul>
@@ -78,8 +93,10 @@ exports[`SubNavList styles should render without children 1`] = `
 .circuit-0 {
   margin: -8px 0 8px 32px;
   list-style: none;
-  height: auto;
-  position: relative;
+  height: 0;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
 }
 
 .circuit-0::after {

--- a/src/components/Sidebar/components/SubNavList/utils.js
+++ b/src/components/Sidebar/components/SubNavList/utils.js
@@ -19,4 +19,17 @@ import { isArray } from '../../../../util/type-check';
 const getSelectedChildIndex = children =>
   isArray(children) ? findIndex(child => child.props.selected, children) : 0;
 
-export default getSelectedChildIndex;
+const getSecondaryChild = (children, visible) => {
+  if (!children) {
+    return null;
+  }
+
+  return isArray(children)
+    ? children.map(child => ({
+        ...child,
+        props: { ...child.props, secondary: true, visible }
+      }))
+    : { ...children, props: { ...children.props, secondary: true, visible } };
+};
+
+export { getSelectedChildIndex, getSecondaryChild };

--- a/src/components/Sidebar/components/SubNavList/utils.spec.js
+++ b/src/components/Sidebar/components/SubNavList/utils.spec.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import getSelectedChildIndex from './utils';
+import { getSelectedChildIndex, getSecondaryChild } from './utils';
 
 describe('getSelectedChildIndex', () => {
   it('should return the correct index of the selected child on an array', () => {
@@ -43,5 +43,33 @@ describe('getSelectedChildIndex', () => {
     const selectedChild = getSelectedChildIndex(children);
 
     expect(selectedChild).toEqual(0);
+  });
+});
+
+describe('getSecondaryChild', () => {
+  it('return a secondary item for a single child', () => {
+    const children = { props: { secondary: false } };
+    expect(getSecondaryChild(children).props.secondary).toBe(true);
+  });
+
+  it('should return all secondary children for an array of items', () => {
+    const children = [
+      { props: { secondary: false } },
+      { props: { secondary: false } }
+    ];
+    expect(getSecondaryChild(children)[0].props.secondary).toBe(true);
+    expect(getSecondaryChild(children)[1].props.secondary).toBe(true);
+  });
+
+  it('should return null when no children is received', () => {
+    expect(getSecondaryChild(undefined)).toBe(null);
+  });
+
+  it('should return a visible secondary child when it should be visible', () => {
+    const children = { props: { secondary: false } };
+    expect(getSecondaryChild(children, true).props).toEqual({
+      secondary: true,
+      visible: true
+    });
   });
 });

--- a/src/themes/circuit.js
+++ b/src/themes/circuit.js
@@ -274,7 +274,8 @@ export const breakpoints = {
 export const mq = createMediaQueries(breakpoints);
 
 export const transitions = {
-  default: `200ms ease-in-out`
+  default: `200ms ease-in-out`,
+  slow: `300ms ease-in-out`
 };
 
 // these values need to be properly trimmed/renamed as we go.


### PR DESCRIPTION
### Purpose
Following the work on #406, this PR adds new animations to the Sidebar's second level of navigation, removes the need of the `secondary` prop on `NavItem` and removes the navigation level from `NavItem` in order to add a new `Aggregator` component, following new design changes.

![Sidebar-2nd-Level](https://user-images.githubusercontent.com/15806312/58030806-9a8cb680-7af5-11e9-9f66-c2bd1d90b093.gif)

### Changes
* Remove the need of the `secondary` prop on `NavItem`;
* Extract the `NavLabel` component to be reusable;
* Improve animations on the second level of navigation for the `Sidebar`;
* Add new `Aggregator` component on `Sidebar` to take care of the second level of navigation;
* Update `Sidebar` story.