### PR TITLE
feat: Add hover state and change selected styles for Selector component

### DIFF
--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -17,23 +17,37 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import withAriaSelected from '../../util/withAriaSelected';
+import { shadowSingle } from '../../styles/style-helpers';
 
 const baseStyles = ({ theme }) => css`
   label: selector;
   cursor: pointer;
-  padding: ${theme.spacings.mega};
-  border-radius: ${theme.borderRadius.mega};
+  padding: ${theme.spacings.giga};
+  border-radius: ${theme.borderRadius.giga};
   border: 1px solid ${theme.colors.n300};
-  background-color: 1px solid ${theme.colors.n100};
+  background-color: ${theme.colors.white};
   margin-bottom: ${theme.spacings.mega};
+  fill: ${theme.colors.n400};
 `;
+
+const hoverStyles = ({ selected, theme }) =>
+  !selected &&
+  css`
+    label: selector--hover;
+    & :hover {
+      background-color: ${theme.colors.n100};
+    }
+  `;
 
 const selectedStyles = ({ selected, theme }) =>
   selected &&
   css`
     label: selector--selected;
     border: ${theme.borderWidth.mega} solid ${theme.colors.p500};
-    background-color: ${theme.colors.white};
+    background-color: ${theme.colors.b100};
+    color: ${theme.colors.p500};
+    fill: ${theme.colors.p500};
+    ${shadowSingle({ theme })};
   `;
 
 const disabledStyles = ({ disabled, theme }) =>
@@ -48,7 +62,12 @@ const disabledStyles = ({ disabled, theme }) =>
  * A selector allows users to choose between several mutually-exlusive choices,
  * accompanied by descriptions, possibly with tabular data.
  */
-const Selector = styled('div')(baseStyles, selectedStyles, disabledStyles);
+const Selector = styled.div(
+  baseStyles,
+  hoverStyles,
+  selectedStyles,
+  disabledStyles
+);
 
 Selector.propTypes = {
   /**

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -34,7 +34,8 @@ const hoverStyles = ({ selected, theme }) =>
   !selected &&
   css`
     label: selector--hover;
-    & :hover {
+    &:hover {
+      border: ${theme.borderWidth.mega} solid ${theme.colors.n300};
       background-color: ${theme.colors.n100};
     }
   `;

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -24,7 +24,7 @@ const baseStyles = ({ theme }) => css`
   cursor: pointer;
   padding: ${theme.spacings.giga};
   border-radius: ${theme.borderRadius.giga};
-  border: 1px solid ${theme.colors.n300};
+  border: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
   background-color: ${theme.colors.white};
   margin-bottom: ${theme.spacings.mega};
   fill: ${theme.colors.n400};
@@ -45,8 +45,6 @@ const selectedStyles = ({ selected, theme }) =>
     label: selector--selected;
     border: ${theme.borderWidth.mega} solid ${theme.colors.p500};
     background-color: ${theme.colors.b100};
-    color: ${theme.colors.p500};
-    fill: ${theme.colors.p500};
     ${shadowSingle({ theme })};
   `;
 

--- a/src/components/Selector/Selector.spec.js
+++ b/src/components/Selector/Selector.spec.js
@@ -19,15 +19,15 @@ import Selector from '.';
 
 describe('Selector', () => {
   it('should render a default selector appropriately', () => {
-    const component = <Selector />;
-    expect(component).toMatchSnapshot();
+    const actual = mount(<Selector />);
+    expect(actual).toMatchSnapshot();
   });
   it('should render a disabled selector appropriately', () => {
-    const component = <Selector disabled />;
-    expect(component).toMatchSnapshot();
+    const actual = mount(<Selector disabled />);
+    expect(actual).toMatchSnapshot();
   });
   it('should render a selected selector appropriately', () => {
-    const component = <Selector selected />;
-    expect(component).toMatchSnapshot();
+    const actual = mount(<Selector selected />);
+    expect(actual).toMatchSnapshot();
   });
 });

--- a/src/components/Selector/__snapshots__/Selector.spec.js.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.js.snap
@@ -1,15 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Selector should render a default selector appropriately 1`] = `<withProps(Styled(div)) />`;
+exports[`Selector should render a default selector appropriately 1`] = `
+.circuit-0 {
+  cursor: pointer;
+  padding: 24px;
+  border-radius: 5px;
+  border: 1px solid #D8DDE1;
+  background-color: #FFFFFF;
+  margin-bottom: 16px;
+}
+
+.circuit-0:hover {
+  background-color: #FAFBFC;
+}
+
+<withProps(Styled(div))>
+  <Styled(div)
+    disabled={false}
+    selected={false}
+  >
+    <div
+      className="circuit-0 circuit-1"
+      disabled={false}
+      selected={false}
+    />
+  </Styled(div)>
+</withProps(Styled(div))>
+`;
 
 exports[`Selector should render a disabled selector appropriately 1`] = `
+.circuit-0 {
+  cursor: pointer;
+  padding: 24px;
+  border-radius: 5px;
+  border: 1px solid #D8DDE1;
+  background-color: #FFFFFF;
+  margin-bottom: 16px;
+  color: #9DA7B1;
+  cursor: default;
+}
+
+.circuit-0:hover {
+  background-color: #FAFBFC;
+}
+
 <withProps(Styled(div))
   disabled={true}
-/>
+>
+  <Styled(div)
+    disabled={true}
+    selected={false}
+  >
+    <div
+      className="circuit-0 circuit-1"
+      disabled={true}
+      selected={false}
+    />
+  </Styled(div)>
+</withProps(Styled(div))>
 `;
 
 exports[`Selector should render a selected selector appropriately 1`] = `
+.circuit-0 {
+  cursor: pointer;
+  padding: 24px;
+  border-radius: 5px;
+  border: 1px solid #D8DDE1;
+  background-color: #FFFFFF;
+  margin-bottom: 16px;
+  border: 2px solid #3388FF;
+  background-color: #EDF4FC;
+  color: #3388FF;
+  fill: #3388FF;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
 <withProps(Styled(div))
   selected={true}
-/>
+>
+  <Styled(div)
+    aria-selected={true}
+    disabled={false}
+    selected={true}
+  >
+    <div
+      aria-selected={true}
+      className="circuit-0 circuit-1"
+      disabled={false}
+      selected={true}
+    />
+  </Styled(div)>
+</withProps(Styled(div))>
 `;

--- a/src/components/Selector/__snapshots__/Selector.spec.js.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.js.snap
@@ -70,8 +70,6 @@ exports[`Selector should render a selected selector appropriately 1`] = `
   margin-bottom: 16px;
   border: 2px solid #3388FF;
   background-color: #EDF4FC;
-  color: #3388FF;
-  fill: #3388FF;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 

--- a/src/components/Selector/__snapshots__/Selector.spec.js.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.js.snap
@@ -11,6 +11,7 @@ exports[`Selector should render a default selector appropriately 1`] = `
 }
 
 .circuit-0:hover {
+  border: 2px solid #D8DDE1;
   background-color: #FAFBFC;
 }
 
@@ -41,6 +42,7 @@ exports[`Selector should render a disabled selector appropriately 1`] = `
 }
 
 .circuit-0:hover {
+  border: 2px solid #D8DDE1;
   background-color: #FAFBFC;
 }
 


### PR DESCRIPTION
### Purpose
We changed the component visuals to ensure two main usability improvements:
* Ensure the component discoverability as a clickable selector with the added hover state on the desktop
* Better differentiate the states, increasing the perception of what's active/selected with the new selected state (stronger action/primary color and shadow)

For now, the text color on the selected state will remain an implementation detail for each domain. We truly believe that is better for the user to use the whole content as a primary color and recommend doing so. However, we still need to adapt some usage of the selector in some domains before forcing that change globally.

### Changes
* Increase `padding` and `border-radius` for the `Selector` component;
* Add a `hover` state;
* Change `background-color` for `selected` state.
* Fix snapshot tests to get style snapshots;

#### Before
![image](https://user-images.githubusercontent.com/15806312/60370605-6c8c7300-99cd-11e9-9630-2fc8f14e1b9b.png)

![image](https://user-images.githubusercontent.com/15806312/60368102-57f8ac80-99c6-11e9-9a0a-891335841d67.png)


#### After
![Selector-Improved](https://user-images.githubusercontent.com/15806312/60370529-3b13a780-99cd-11e9-9f06-25782dd6dd80.gif)
