### PR TITLE
feat(components): add prop forwarding support to TableRows

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -194,10 +194,15 @@ Table.propTypes = {
    */
   headers: PropTypes.arrayOf(RowPropType),
   /**
-   * An array of rows with an array of cells for the table. The Cell can be a
+   * (An array of rows or object with children) containing an array of cells for the table. The Cell can be a
    * string or an object with options described on TableCell component
    */
-  rows: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
+  rows: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.shape({ cells: PropTypes.arrayOf(RowPropType) }),
+      PropTypes.arrayOf(RowPropType)
+    ])
+  ),
   /**
    * Enables/disables sticky columns on mobile
    */

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -33,12 +33,19 @@ const headers = [
 ];
 
 const rows = [
-  [
-    'Lorem ipsum dolor',
-    { children: '12/01/2017', sortByValue: 0 },
-    '-',
-    { children: 'Disabled', align: TableCell.RIGHT }
-  ],
+  {
+    cells: [
+      'Lorem ipsum dolor',
+      {
+        children: '12/01/2017',
+        sortByValue: 0,
+        'data-selector': 'item-1-cell-date-12/01/2017'
+      },
+      '-',
+      { children: 'Disabled', align: TableCell.RIGHT }
+    ],
+    'data-selector': 'item-1'
+  },
   [
     'Ipsum dolor sit amet',
     { children: '13/01/2017', sortByValue: 1 },

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -19,7 +19,12 @@ import PropTypes from 'prop-types';
 import TableRow from '../TableRow';
 import TableHeader from '../TableHeader';
 import TableCell from '../TableCell';
-import { mapProps, getChildren, RowPropType } from '../../utils';
+import {
+  mapRowProps,
+  mapCellProps,
+  getCellChildren,
+  RowPropType
+} from '../../utils';
 import { TR_KEY_PREFIX, TD_KEY_PREFIX } from '../../constants';
 
 const getRowKey = index => `${TR_KEY_PREFIX}-${index}`;
@@ -28,37 +33,38 @@ const getCellKey = (rowIndex, cellIndex) =>
 
 const TableBody = ({ rows, rowHeaders, sortHover, onRowClick }) => (
   <tbody>
-    {rows.map((row, rowIndex) => (
-      // eslint-disable-next-line react/no-array-index-key
-      <TableRow
-        key={getRowKey(rowIndex)}
-        onClick={onRowClick && (() => onRowClick(rowIndex))}
-      >
-        {row.map((cell, cellIndex) =>
-          rowHeaders && cellIndex === 0 ? (
-            // eslint-disable-next-line react/no-array-index-key
-            <Fragment key={getCellKey(rowIndex, cellIndex)}>
-              <TableHeader
-                fixed
-                scope={TableHeader.ROW}
+    {rows.map((row, rowIndex) => {
+      const { cells, ...props } = mapRowProps(row);
+      return (
+        <TableRow
+          key={getRowKey(rowIndex)}
+          onClick={onRowClick && (() => onRowClick(rowIndex))}
+          {...props}
+        >
+          {cells.map((cell, cellIndex) =>
+            rowHeaders && cellIndex === 0 ? (
+              <Fragment key={getCellKey(rowIndex, cellIndex)}>
+                <TableHeader
+                  fixed
+                  scope={TableHeader.ROW}
+                  isHovered={sortHover === cellIndex}
+                  {...mapCellProps(cell)}
+                />
+                <TableCell role="presentation" aria-hidden="true">
+                  {getCellChildren(cell)}
+                </TableCell>
+              </Fragment>
+            ) : (
+              <TableCell
+                key={getCellKey(rowIndex, cellIndex)}
                 isHovered={sortHover === cellIndex}
-                {...mapProps(cell)}
+                {...mapCellProps(cell)}
               />
-              <TableCell role="presentation" aria-hidden="true">
-                {getChildren(cell)}
-              </TableCell>
-            </Fragment>
-          ) : (
-            <TableCell
-              // eslint-disable-next-line react/no-array-index-key
-              key={getCellKey(rowIndex, cellIndex)}
-              isHovered={sortHover === cellIndex}
-              {...mapProps(cell)}
-            />
-          )
-        )}
-      </TableRow>
-    ))}
+            )
+          )}
+        </TableRow>
+      );
+    })}
   </tbody>
 );
 
@@ -67,10 +73,15 @@ const TableBody = ({ rows, rowHeaders, sortHover, onRowClick }) => (
  */
 TableBody.propTypes = {
   /**
-   * An array of rows with cells for the table. The Cell can be a string
+   *(An array of rows or object with children) containing cells for the table. The Cell can be a string
    * or an object with options described on TableHeader component
    */
-  rows: PropTypes.arrayOf(PropTypes.arrayOf(RowPropType)),
+  rows: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.shape({ cells: PropTypes.arrayOf(RowPropType) }),
+      PropTypes.arrayOf(RowPropType)
+    ])
+  ),
   /**
    * Enables/disables sticky columns on mobile
    */

--- a/src/components/Table/components/TableBody/index.spec.js
+++ b/src/components/Table/components/TableBody/index.spec.js
@@ -112,6 +112,30 @@ describe('TableBody', () => {
     });
   });
 
+  describe('Row prop forwarding', () => {
+    describe('when additional props are provided with rows', () => {
+      it('should attach those props to the row', () => {
+        const selector = 'row-1-selector';
+        const rows = [{ cells: ['Foo', 'Bar'], 'data-selector': selector }];
+        const wrapper = mount(<TableBody rows={rows} />);
+
+        expect(wrapper.find(`tr[data-selector="${selector}"]`)).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('Cell prop forwarding', () => {
+    describe('when additional props are provided with cells', () => {
+      it('should attach those props to the cell', () => {
+        const selector = 'cell-1-selector';
+        const rows = [[{ children: 'Foo', 'data-selector': selector }, 'Bar']];
+        const wrapper = mount(<TableBody rows={rows} />);
+
+        expect(wrapper.find(`td[data-selector="${selector}"]`)).toHaveLength(1);
+      });
+    });
+  });
+
   describe('Accessibility tests', () => {
     it('should meet accessibility guidelines', async () => {
       const wrapper = renderToHtml(<TableBody rowHeader rows={fixtureRows} />);

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -20,7 +20,7 @@ import { noop } from 'lodash/fp';
 import TableRow from '../TableRow';
 import TableHeader from '../TableHeader';
 import TableCell from '../TableCell';
-import { mapProps, getChildren, RowPropType } from '../../utils';
+import { mapCellProps, getCellChildren, RowPropType } from '../../utils';
 import { ASCENDING, DESCENDING, TH_KEY_PREFIX } from '../../constants';
 
 const TableHead = ({
@@ -36,9 +36,8 @@ const TableHead = ({
     {!!headers.length && (
       <TableRow header>
         {headers.map((header, i) => {
-          const props = mapProps(header);
+          const props = mapCellProps(header);
           return (
-            // eslint-disable-next-line react/no-array-index-key
             <Fragment key={`${TH_KEY_PREFIX}-${i}`}>
               <TableHeader
                 {...props}
@@ -56,7 +55,7 @@ const TableHead = ({
               />
               {rowHeaders && i === 0 && (
                 <TableCell role="presentation" aria-hidden="true" header>
-                  {getChildren(header)}
+                  {getCellChildren(header)}
                 </TableCell>
               )}
             </Fragment>

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -14,19 +14,21 @@
  */
 
 import PropTypes from 'prop-types';
-import { isString, isNumber, curry } from 'lodash/fp';
+import { isString, isNumber, isArray, curry } from 'lodash/fp';
 import { ASCENDING, DESCENDING } from './constants';
 import { childrenPropType } from '../../util/shared-prop-types';
 
-export const mapProps = props =>
+export const mapRowProps = props => (isArray(props) ? { cells: props } : props);
+
+export const mapCellProps = props =>
   isString(props) || isNumber(props) ? { children: props } : props;
 
-export const getChildren = props => mapProps(props).children;
+export const getCellChildren = props => mapCellProps(props).children;
 
 export const getSortByValue = props =>
   Object.prototype.hasOwnProperty.call(props, 'sortByValue')
     ? props.sortByValue
-    : getChildren(props);
+    : getCellChildren(props);
 
 export const getSortDirection = (isActive, currentSort) => {
   if (!currentSort || !isActive) {

--- a/src/components/Table/utils.spec.js
+++ b/src/components/Table/utils.spec.js
@@ -17,12 +17,31 @@ import * as utils from './utils';
 import { ASCENDING, DESCENDING } from './constants';
 
 describe('Table utils', () => {
-  describe('mapProps()', () => {
+  describe('mapRowProps()', () => {
+    describe('isArray', () => {
+      it('should map the array to cells key', () => {
+        const props = ['Foo'];
+        const expected = { cells: props };
+        const actual = utils.mapRowProps(props);
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    it('should forward the props object', () => {
+      const props = { cells: ['Foo'] };
+      const expected = props;
+      const actual = utils.mapRowProps(props);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+  describe('mapCellProps()', () => {
     describe('isString', () => {
       it('should map the string to children key', () => {
         const props = 'Foo';
         const expected = { children: props };
-        const actual = utils.mapProps(props);
+        const actual = utils.mapCellProps(props);
 
         expect(actual).toEqual(expected);
       });
@@ -31,18 +50,18 @@ describe('Table utils', () => {
     it('should forward the props object', () => {
       const props = { children: 'Foo' };
       const expected = props;
-      const actual = utils.mapProps(props);
+      const actual = utils.mapCellProps(props);
 
       expect(actual).toEqual(expected);
     });
   });
 
-  describe('getChildren()', () => {
+  describe('getCellChildren()', () => {
     describe('isString', () => {
       it('should return it', () => {
         const props = 'Foo';
         const expected = props;
-        const actual = utils.getChildren(props);
+        const actual = utils.getCellChildren(props);
 
         expect(actual).toBe(expected);
       });
@@ -51,7 +70,7 @@ describe('Table utils', () => {
     it('should return the children prop', () => {
       const props = { children: 'Foo' };
       const expected = 'Foo';
-      const actual = utils.getChildren(props);
+      const actual = utils.getCellChildren(props);
 
       expect(actual).toBe(expected);
     });


### PR DESCRIPTION
**Changes**
- Add any prop forwarding (`data-selector`, `css` and so on) to TableRows. Previously the only supported logic was:

```
[
  'Lorem ipsum dolor',
  {
    children: '12/01/2017',
    sortByValue: 0,
    'data-selector': 'item-1-cell-date-12/01/2017'
  },
  '-',
  { children: 'Disabled', align: TableCell.RIGHT }
],
```

Now you can also provide an object containing the `cells` prop, and any extra prop will be forwarded and rendered at the `tr` element:

```
{
    cells: [
      'Lorem ipsum dolor',
      {
        children: '12/01/2017',
        sortByValue: 0,
        'data-selector': 'item-1-cell-date-12/01/2017'
      },
      '-',
      { children: 'Disabled', align: TableCell.RIGHT }
    ],
    'data-selector': 'item-1'
  },
```

![image](https://user-images.githubusercontent.com/2780941/60426027-12b9c200-9bf4-11e9-9910-77790b08bb42.png)
