### PR TITLE
fix: Aggregator styles and open state

### DIFF
--- a/src/components/Sidebar/components/Aggregator/Aggregator.js
+++ b/src/components/Sidebar/components/Aggregator/Aggregator.js
@@ -26,7 +26,7 @@ import { childrenPropType } from '../../../../util/shared-prop-types';
 const baseStyles = ({ theme }) => css`
   label: nav-aggregator;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: flex-start;
   height: auto;
   margin: ${theme.spacings.mega};
@@ -56,9 +56,14 @@ const selectedStyles = ({ theme, selected }) =>
 const AggregatorContainer = styled.div(baseStyles, hoverStyles, selectedStyles);
 
 class Aggregator extends Component {
-  state = {
-    open: false
-  };
+  state = { open: false };
+
+  static getDerivedStateFromProps(props) {
+    if (hasSelectedChild(props.children)) {
+      return { open: true };
+    }
+    return null;
+  }
 
   componentDidUpdate(prevProps, prevState) {
     const { children } = this.props;
@@ -94,7 +99,9 @@ class Aggregator extends Component {
           selected={hasSelectedChild(children)}
           onClick={this.toggleAggregator}
         >
-          {defaultIcon && selectedIcon && open ? selectedIcon : defaultIcon}
+          {defaultIcon && selectedIcon && hasSelectedChild(children)
+            ? selectedIcon
+            : defaultIcon}
           <NavLabel>{label}</NavLabel>
         </AggregatorContainer>
         {children && <SubNavList visible={open}>{children}</SubNavList>}

--- a/src/components/Sidebar/components/Aggregator/Aggregator.spec.js
+++ b/src/components/Sidebar/components/Aggregator/Aggregator.spec.js
@@ -26,7 +26,7 @@ const props = {
 
 class MockedNavigation extends Component {
   state = {
-    selected: 0
+    selected: 1
   };
 
   render() {
@@ -110,7 +110,7 @@ describe('Aggregator', () => {
       expect(actual.state().open).toBe(true);
     });
 
-    it('should close the aggregator when clicking again on the aggregator', async () => {
+    it('should not toggle when clicking again on the aggregator with a selected child', async () => {
       const actual = mount(
         <Aggregator {...props}>
           <div selected data-testid="child">
@@ -128,7 +128,7 @@ describe('Aggregator', () => {
       actual.find("[className*='nav-aggregator']").simulate('click');
 
       expect(props.onClick).toHaveBeenCalled();
-      expect(actual.state().open).toBe(false);
+      expect(actual.state().open).toBe(true);
     });
 
     it('should close when there are no selected children', async () => {

--- a/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.js.snap
+++ b/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.js.snap
@@ -6,9 +6,9 @@ exports[`Aggregator styles should render and match snapshot when open 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -92,7 +92,7 @@ exports[`Aggregator styles should render and match snapshot when open 1`] = `
       className="circuit-2 circuit-3"
       onClick={[Function]}
     >
-      selected-icon
+      default-icon
       <Styled(div)>
         <div
           className="circuit-0 circuit-1"
@@ -131,9 +131,9 @@ exports[`Aggregator styles should render with default styles 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;


### PR DESCRIPTION
### Changes
* When opening the navigation item in a new tab, the `Aggregator` remains open;
* Change `flex-direction` for `Aggregator` so it renders icons properly;
* Only show `selected` styles if the `Aggregator` has a selected child.