### PR TITLE
fix(components): Correctly pass styles from Textarea to Input

### DIFF
--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -13,12 +13,13 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import { css } from '@emotion/core';
+/** @jsx jsx */
+
+import { jsx, css } from '@emotion/core';
 
 import Input from '../Input';
 
-const inputClassName = css`
+const textAreaStyles = css`
   label: textarea;
   overflow: auto;
   resize: vertical;
@@ -28,7 +29,7 @@ const inputClassName = css`
  * TextArea component for forms.
  */
 const TextArea = props => (
-  <Input {...{ ...props, inputClassName }} element="textarea" />
+  <Input {...props} css={textAreaStyles} element="textarea" />
 );
 
 TextArea.LEFT = Input.LEFT;

--- a/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
@@ -63,7 +63,7 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
 >
   <textarea
     aria-invalid={true}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={true}
     required={false}
   />
@@ -184,7 +184,7 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
 >
   <textarea
     aria-invalid={true}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -295,7 +295,7 @@ exports[`TextArea should prioritize error over optional styles 1`] = `
 >
   <textarea
     aria-invalid={true}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -423,7 +423,7 @@ exports[`TextArea should render with a Tooltip when passed the validationHint pr
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -511,7 +511,7 @@ exports[`TextArea should render with a prefix when passed the prefix prop 1`] = 
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     prefix={[Function]}
     required={false}
@@ -595,7 +595,7 @@ exports[`TextArea should render with a suffix when passed the suffix prop 1`] = 
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
     suffix={[Function]}
@@ -679,7 +679,7 @@ exports[`TextArea should render with default styles 1`] = `
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -752,7 +752,7 @@ exports[`TextArea should render with disabled styled when passed the disabled pr
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={true}
     required={false}
   />
@@ -834,7 +834,7 @@ exports[`TextArea should render with inline styles when passed the inline prop 1
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -938,7 +938,7 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
 >
   <textarea
     aria-invalid={true}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1026,7 +1026,7 @@ exports[`TextArea should render with no margin styles when passed the noMargin p
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1112,7 +1112,7 @@ exports[`TextArea should render with optional styles when passed the optional pr
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1195,7 +1195,7 @@ exports[`TextArea should render with valid styles when passed the showValid prop
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1303,7 +1303,7 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
 >
   <textarea
     aria-invalid={false}
-    className="circuit-0 circuit-1"
+    className=" circuit-0 circuit-1"
     disabled={false}
     required={false}
   />


### PR DESCRIPTION
Emotion 10's `css` function returns a style object instead of a class name.