### PR TITLE
fix(components): add missing font-styles to table fixed row headers

### DIFF
--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -114,6 +114,8 @@ tbody .circuit-11:last-child td {
   vertical-align: middle;
   white-space: nowrap;
   display: none;
+  font-size: 13px;
+  font-weight: 700;
   padding: 8px 24px;
 }
 
@@ -511,6 +513,8 @@ tbody .circuit-11:last-child td {
   vertical-align: middle;
   white-space: nowrap;
   display: none;
+  font-size: 13px;
+  font-weight: 700;
   padding: 8px 24px;
 }
 
@@ -884,6 +888,8 @@ tbody .circuit-11:last-child td {
   vertical-align: middle;
   white-space: nowrap;
   display: none;
+  font-size: 13px;
+  font-weight: 700;
   padding: 8px 24px;
 }
 
@@ -1253,6 +1259,8 @@ tbody .circuit-11:last-child td {
   vertical-align: middle;
   white-space: nowrap;
   display: none;
+  font-size: 13px;
+  font-weight: 700;
   padding: 8px 24px;
 }
 

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -38,7 +38,12 @@ const presentationStyles = ({ theme, role, header }) =>
     label: table-cell--presentation;
     display: none;
 
-    ${header && `padding: ${theme.spacings.byte} ${theme.spacings.giga}`};
+    ${header &&
+      css`
+        font-size: ${theme.typography.text.kilo.fontSize};
+        font-weight: ${theme.fontWeight.bold};
+        padding: ${theme.spacings.byte} ${theme.spacings.giga};
+      `}
 
     ${theme.mq.untilMega} {
       display: table-cell;


### PR DESCRIPTION
`font-size` styles weren't being applied to hidden rows, causing larger texts to create a line-break.

Both texts are `Product Name`, the difference is the hidden fixed row had a larger `font-size`.

![image](https://user-images.githubusercontent.com/2780941/61048696-ddc32180-a3e2-11e9-9ea7-aa3065363981.png)
