### PR TITLE
docs(docs): add missing BIT spacing variant

### DIFF
--- a/docs/content/components/forms.mdx
+++ b/docs/content/components/forms.mdx
@@ -264,7 +264,7 @@ possibilities and allowing only one option to be chosen.
   </Fragment>
 </Playground>
 
-<Props of={RedioButton} />
+<Props of={RadioButton} />
 
 ### When to use it
 
@@ -340,7 +340,7 @@ It is a type of input that allow mutiple lines of text.
   <TextArea value="Howdy from the text area" />
 </Playground>
 
-<Props of={Textarea} />
+<Props of={TextArea} />
 
 ### When to use it
 


### PR DESCRIPTION
Addresses #ticket-number.

## Purpose

The `bit` spacing variant is missing in our docs

## Approach and changes

Add `bit` variant

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
