### PR TITLE
docs(docs): add sessionStorage redirect for page refresh

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -2,8 +2,9 @@
 <html lang="en">
   <head>
     <script>
-      location.pathname = '/'
+      sessionStorage.redirect = location.href;
     </script>
+    <meta http-equiv="refresh" content="0;URL='/'" />
   </head>
   <body></body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,11 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script>
+      (function() {
+        const redirect = sessionStorage.redirect;
+        delete sessionStorage.redirect;
+
+        if (redirect && redirect !== location.href) {
+          history.replaceState(null, null, redirect);
+        }
+      })();
+    </script>
     <meta charset="UTF-8" />
     <meta name="description" content="{{ description }}" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <link rel="icon" type="image/png" href="/public/images/circuit-logo.png">
+    <link rel="icon" type="image/png" href="/public/images/circuit-logo.png" />
     <style>
       @font-face {
         font-family: 'aktiv-grotesk';


### PR DESCRIPTION
This addresses the lack of the history fallback support for GH pages

## Purpose

When refreshing the docs, the user is being redirect to `/`

## Approach and changes

Add `sessionStorage.redirect` check before page loads (as a hack) to redirect the user to the specific route

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
