### PR TITLE
docs(docs): fix typos on Props arguments for Forms documentation

### DIFF
--- a/docs/content/components/forms.mdx
+++ b/docs/content/components/forms.mdx
@@ -264,7 +264,7 @@ possibilities and allowing only one option to be chosen.
   </Fragment>
 </Playground>
 
-<Props of={RedioButton} />
+<Props of={RadioButton} />
 
 ### When to use it
 
@@ -340,7 +340,7 @@ It is a type of input that allow mutiple lines of text.
   <TextArea value="Howdy from the text area" />
 </Playground>
 
-<Props of={Textarea} />
+<Props of={TextArea} />
 
 ### When to use it
 


### PR DESCRIPTION
## Purpose

The page was displaying some errors due to some typos

## Approach and changes

Fix typos

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
