### PR TITLE
chore(configs): Temporarily disable security audit in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
   include:
     # Run tests in parallel
     - stage: test
-      script: yarn check:security && yarn check:licenses
+      script: yarn check:licenses
     - script: yarn test:lint-js
     - script: yarn test:unit --runInBand
       # Upload coverage reports to Codecov


### PR DESCRIPTION
## Purpose

The security audit currently produces an error (https://github.com/IBM/audit-ci/issues/103), causing CI to wrongly fail.

## Approach and changes

- Temporarily disable security audit in CI

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
