### PR TITLE
refactor(components): Use new props to pass styles to the Input

### DIFF
--- a/src/components/CreditCardDetails/components/CardNumberInput/CardNumberInput.js
+++ b/src/components/CreditCardDetails/components/CardNumberInput/CardNumberInput.js
@@ -15,11 +15,15 @@
 
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { css, ClassNames } from '@emotion/core';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { withTheme } from 'emotion-theming';
 import { hideVisually } from 'polished';
 
+import {
+  deprecatedPropType,
+  themePropType
+} from '../../../../util/shared-prop-types';
 import { flow, toPairs, map, keys } from '../../../../util/fp';
 import MaskedInput from '../../../MaskedInput';
 import Label from '../../../Label';
@@ -82,23 +86,15 @@ const AccessibleCardSchemeInfo = styled('div')`
   ${hideVisually()};
 `;
 
-const inputLongStyles = ({
-  theme,
-  acceptedCardSchemes,
-  className,
-  stringCss
-}) =>
-  shouldRenderSchemesUnderInput(acceptedCardSchemes)
-    ? stringCss`
-        label: card-number-input__input--long;
-        ${theme.mq.untilKilo} {
-          margin-bottom: ${theme.spacings.tera};
-          margin-bottom: calc(${theme.spacings.tera} + ${theme.spacings.bit});
-        }
-
-        ${className};
-      `
-    : className;
+const inputLongStyles = ({ theme, acceptedCardSchemes }) =>
+  shouldRenderSchemesUnderInput(acceptedCardSchemes) &&
+  css`
+    label: card-number-input__input--long;
+    ${theme.mq.untilKilo} {
+      margin-bottom: ${theme.spacings.tera};
+      margin-bottom: calc(${theme.spacings.tera} + ${theme.spacings.bit});
+    }
+  `;
 
 const schemeIconWrapperStyles = ({ theme }) => css`
   label: card-number-input__scheme-icon-wrapper;
@@ -134,10 +130,8 @@ const CardNumberInput = ({
   acceptedCardSchemes,
   detectedCardScheme,
   value,
-  className,
   id,
   label,
-  // eslint-disable-next-line
   theme,
   supportedSchemesLabel,
   detectedSchemeLabel,
@@ -151,53 +145,47 @@ const CardNumberInput = ({
     `${detectedSchemeLabel}: ${detectedCardScheme}`;
 
   return (
-    <ClassNames>
-      {({ css: stringCss }) => (
-        <Fragment>
-          <AccessibleCardSchemeInfo>
-            {supportedSchemesText}
-          </AccessibleCardSchemeInfo>
-          <AccessibleCardSchemeInfo aria-live="polite">
-            {detectedSchemesText}
-          </AccessibleCardSchemeInfo>
-          <Label htmlFor={id}>{label}</Label>
-          <MaskedInput
-            value={value}
-            type="tel"
-            id={id}
-            autoComplete="cc-number"
-            placeholder="•••• •••• •••• ••••"
-            wrapperClassName={inputLongStyles({
-              stringCss,
-              theme,
-              acceptedCardSchemes,
-              className
-            })}
-            guide={false}
-            mask={CARD_NUMBER_MASK}
-            {...props}
-          >
-            <SchemeList {...{ acceptedCardSchemes }} aria-hidden="true">
-              {flow(
-                toPairs,
-                map(([cardScheme, IconComponent]) => (
-                  <SchemeIconWrapper
-                    disabled={isDisabledSchemeIcon(
-                      value,
-                      detectedCardScheme,
-                      cardScheme
-                    )}
-                    key={cardScheme}
-                  >
-                    <IconComponent />
-                  </SchemeIconWrapper>
-                ))
-              )(acceptedCardSchemes)}
-            </SchemeList>
-          </MaskedInput>
-        </Fragment>
-      )}
-    </ClassNames>
+    <Fragment>
+      <AccessibleCardSchemeInfo>
+        {supportedSchemesText}
+      </AccessibleCardSchemeInfo>
+      <AccessibleCardSchemeInfo aria-live="polite">
+        {detectedSchemesText}
+      </AccessibleCardSchemeInfo>
+      <Label htmlFor={id}>{label}</Label>
+      <MaskedInput
+        value={value}
+        type="tel"
+        id={id}
+        autoComplete="cc-number"
+        placeholder="•••• •••• •••• ••••"
+        wrapperStyles={inputLongStyles({
+          theme,
+          acceptedCardSchemes
+        })}
+        guide={false}
+        mask={CARD_NUMBER_MASK}
+        {...props}
+      >
+        <SchemeList {...{ acceptedCardSchemes }} aria-hidden="true">
+          {flow(
+            toPairs,
+            map(([cardScheme, IconComponent]) => (
+              <SchemeIconWrapper
+                disabled={isDisabledSchemeIcon(
+                  value,
+                  detectedCardScheme,
+                  cardScheme
+                )}
+                key={cardScheme}
+              >
+                <IconComponent />
+              </SchemeIconWrapper>
+            ))
+          )(acceptedCardSchemes)}
+        </SchemeList>
+      </MaskedInput>
+    </Fragment>
   );
 };
 
@@ -233,9 +221,17 @@ CardNumberInput.propTypes = {
    */
   detectedSchemeLabel: PropTypes.string,
   /**
+   * @deprecated
    * Override styles for the Input component.
    */
-  className: PropTypes.string
+  className: deprecatedPropType(
+    PropTypes.string,
+    [
+      'Emotion 10 uses style objects instead of classnames.',
+      `Use Emotion's "css" prop instead.`
+    ].join(' ')
+  ),
+  theme: themePropType
 };
 
 CardNumberInput.defaultProps = {

--- a/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
+++ b/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
@@ -614,7 +614,7 @@ Array [
 }
 
 <div
-    class="circuit-20 circuit-21"
+    class=" circuit-20 circuit-21"
   >
     <input
       aria-invalid="false"

--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/SimpleCurrencyInput.js
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/SimpleCurrencyInput.js
@@ -17,7 +17,7 @@
 
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { css, ClassNames, jsx } from '@emotion/core';
+import { css, jsx } from '@emotion/core';
 import { withTheme } from 'emotion-theming';
 
 import { themePropType } from '../../../../util/shared-prop-types';
@@ -60,22 +60,22 @@ const CurrencyIcon = styled('span')`
   ${iconInvalidStyles};
 `;
 
-const inputStyles = stringCss => stringCss`
+const inputBaseStyles = () => css`
   label: currency-input__input;
   text-align: right;
 `;
 
-const inputPrependStyles = ({ theme, symbol = '', prependSymbol, stringCss }) =>
+const inputPrependStyles = ({ theme, symbol = '', prependSymbol }) =>
   prependSymbol &&
-  stringCss`
+  css`
     label: currency-input__input--prepend-symbol;
     padding-left: ${theme.spacings.exa};
     padding-left: calc(${theme.spacings.giga} + ${symbol.length}ch);
   `;
 
-const inputAppendStyles = ({ theme, symbol = '', prependSymbol, stringCss }) =>
+const inputAppendStyles = ({ theme, symbol = '', prependSymbol }) =>
   !prependSymbol &&
-  stringCss`
+  css`
     label: currency-input__input--prepend-symbol;
     padding-right: ${theme.spacings.exa};
     padding-right: calc(${theme.spacings.giga} + ${symbol.length}ch);
@@ -94,62 +94,52 @@ const SimpleCurrencyInput = ({
   numberMask,
   ...props
 }) => (
-  <ClassNames>
-    {({ css: stringCss, cx }) => {
-      const inputClassName = cx(
-        inputStyles(stringCss),
-        inputPrependStyles({
-          theme,
-          symbol,
-          stringCss,
-          prependSymbol
-        }),
-        inputAppendStyles({
-          theme,
-          symbol,
-          stringCss,
-          prependSymbol
-        })
-      );
-
-      return (
-        <MaskedInput
-          inputClassName={inputClassName}
-          renderPrefix={({ className }) =>
-            prependSymbol && (
-              <CurrencyIcon
-                {...{ hasWarning, invalid, disabled }}
-                css={css`
-                  ${iconOverrideWidthStyles({ symbol })};
-                `}
-                className={className}
-                symbol={symbol}
-              >
-                {symbol}
-              </CurrencyIcon>
-            )
-          }
-          renderSuffix={({ className }) =>
-            !prependSymbol && (
-              <CurrencyIcon
-                {...{ hasWarning, invalid, disabled }}
-                css={css`
-                  ${iconOverrideWidthStyles({ symbol })};
-                `}
-                className={className}
-                symbol={symbol}
-              >
-                {symbol}
-              </CurrencyIcon>
-            )
-          }
-          type="text"
-          mask={numberMask}
-          {...{ ...props, hasWarning, invalid, disabled }}
-        />
-      );
-    }}
-  </ClassNames>
+  <MaskedInput
+    inputStyles={css([
+      inputBaseStyles(),
+      inputPrependStyles({
+        theme,
+        symbol,
+        prependSymbol
+      }),
+      inputAppendStyles({
+        theme,
+        symbol,
+        prependSymbol
+      })
+    ])}
+    renderPrefix={({ className }) =>
+      prependSymbol && (
+        <CurrencyIcon
+          {...{ hasWarning, invalid, disabled }}
+          css={css`
+            ${iconOverrideWidthStyles({ symbol })};
+          `}
+          className={className}
+          symbol={symbol}
+        >
+          {symbol}
+        </CurrencyIcon>
+      )
+    }
+    renderSuffix={({ className }) =>
+      !prependSymbol && (
+        <CurrencyIcon
+          {...{ hasWarning, invalid, disabled }}
+          css={css`
+            ${iconOverrideWidthStyles({ symbol })};
+          `}
+          className={className}
+          symbol={symbol}
+        >
+          {symbol}
+        </CurrencyIcon>
+      )
+    }
+    type="text"
+    mask={numberMask}
+    {...{ ...props, hasWarning, invalid, disabled }}
+  />
 );
 
 SimpleCurrencyInput.propTypes = {

--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
@@ -76,7 +76,7 @@ exports[`SimpleCurrencyInput should adjust input padding and postfix width to ma
 >
   <input
     aria-invalid="false"
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
     placeholder="123,45"
     type="text"
   />
@@ -168,7 +168,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over error styles 1`] = 
 >
   <input
     aria-invalid="true"
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
     disabled=""
     type="text"
   />
@@ -303,7 +303,7 @@ exports[`SimpleCurrencyInput should prioritize disabled over warning styles 1`] 
 >
   <input
     aria-invalid="true"
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -388,7 +388,7 @@ exports[`SimpleCurrencyInput should render with default styles 1`] = `
 >
   <input
     aria-invalid="false"
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -499,7 +499,7 @@ exports[`SimpleCurrencyInput should render with error styles 1`] = `
 >
   <input
     aria-invalid="true"
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -610,7 +610,7 @@ exports[`SimpleCurrencyInput should render with warning styles 1`] = `
 >
   <input
     aria-invalid="false"
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -702,7 +702,7 @@ exports[`SimpleCurrencyInput should support rendering symbols on the left 1`] = 
   </span>
   <input
     aria-invalid="false"
-    class="circuit-2 circuit-3"
+    class=" circuit-2 circuit-3"
     placeholder="123.45"
     type="text"
   />


### PR DESCRIPTION
## Purpose

Passing class names to the `Input` component was deprecated in #445. All Circuit UI components should use the new style props.

## Approach and changes

- Switch to the new style props in the `SimpleCurrencyInput` and `CardNumberInput` components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
