### PR TITLE
fix(utils): Check custom prop types correctly

### DIFF
--- a/src/util/shared-prop-types.js
+++ b/src/util/shared-prop-types.js
@@ -34,7 +34,7 @@ export const deprecatedPropType = (propType, explanation = '') => (
   }
 
   return PropTypes.checkPropTypes(
-    { propName: propType },
+    { [propName]: propType },
     props,
     propName,
     componentName
@@ -63,7 +63,7 @@ export const eitherOrPropType = (
   /* eslint-enable max-len */
 
   return PropTypes.checkPropTypes(
-    { propName: propType },
+    { [propName]: propType },
     props,
     propName,
     componentName


### PR DESCRIPTION
## Purpose

@voronianski noticed that custom prop type checks didn't specify the prop name correctly.

## Approach and changes

- Fix typos

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
