### PR TITLE
feat(components): Add a validation hint to the Checkbox

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -45,7 +45,7 @@ const labelBaseStyles = ({ theme }) => css`
     top: ${theme.spacings.kilo};
     left: 0;
     transform: translateY(-50%);
-    transition: border 0.05s ease-in;
+    transition: border 0.05s ease-in, background-color 0.05s ease-in;
   }
 
   svg {
@@ -69,6 +69,7 @@ const labelInvalidStyles = ({ theme, invalid }) =>
     label: checkbox--error;
     &:not(:focus)::before {
       border-color: ${theme.colors.r500};
+      background-color: ${theme.colors.r100};
     }
 
     &:not(:focus) svg {

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -23,6 +23,7 @@ import { ReactComponent as CheckedIcon } from './checked-icon.svg';
 import { disableVisually } from '../../styles/style-helpers';
 import { childrenPropType } from '../../util/shared-prop-types';
 import { uniqueId } from '../../util/id';
+import Tooltip from '../Tooltip';
 
 const labelBaseStyles = ({ theme }) => css`
   label: checkbox__label;
@@ -119,6 +120,11 @@ const checkboxWrapperBaseStyles = ({ theme }) => css`
   }
 `;
 
+const tooltipBaseStyles = ({ theme }) => css`
+  label: checkbox__tooltip;
+  left: -${theme.spacings.kilo};
+`;
+
 const CheckboxInput = styled('input')`
   ${inputStyles};
 `;
@@ -133,18 +139,34 @@ const CheckboxWrapper = styled('div')`
   ${checkboxWrapperBaseStyles};
 `;
 
+const CheckboxTooltip = styled(Tooltip)`
+  ${tooltipBaseStyles};
+`;
+
 /**
  * Checkbox component for forms.
  */
-const Checkbox = ({ children, id: customId, className, ...props }) => {
+const Checkbox = ({
+  children,
+  id: customId,
+  disabled,
+  validationHint,
+  className,
+  ...props
+}) => {
   const id = customId || uniqueId('checkbox_');
   return (
     <CheckboxWrapper className={className}>
-      <CheckboxInput {...props} id={id} type="checkbox" />
-      <CheckboxLabel {...props} htmlFor={id}>
+      <CheckboxInput {...props} id={id} type="checkbox" disabled={disabled} />
+      <CheckboxLabel {...props} htmlFor={id} disabled={disabled}>
         {children}
         <CheckedIcon aria-hidden="true" />
       </CheckboxLabel>
+      {!disabled && validationHint && (
+        <CheckboxTooltip position={Tooltip.TOP} align={Tooltip.RIGHT}>
+          {validationHint}
+        </CheckboxTooltip>
+      )}
     </CheckboxWrapper>
   );
 };
@@ -184,6 +206,10 @@ Checkbox.propTypes = {
    * attribute to the <input> element.
    */
   disabled: PropTypes.bool,
+  /**
+   * Warning or error message, displayed in a tooltip.
+   */
+  validationHint: PropTypes.string,
   /**
    * Override styles for the Checkbox component.
    */

--- a/src/components/Checkbox/Checkbox.spec.js
+++ b/src/components/Checkbox/Checkbox.spec.js
@@ -44,6 +44,16 @@ describe('Checkbox', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with a tooltip when passed a validation hint', () => {
+    const actual = create(
+      <Checkbox
+        validationHint="This field is required."
+        {...{ name, onChange }}
+      />
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Accessibility tests.
    */

--- a/src/components/Checkbox/Checkbox.story.js
+++ b/src/components/Checkbox/Checkbox.story.js
@@ -17,6 +17,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
+import { text } from '@storybook/addon-knobs';
 import { withState } from 'recompose';
 import { GROUPS } from '../../../.storybook/hierarchySeparators';
 
@@ -69,9 +70,10 @@ storiesOf(`${GROUPS.FORMS}|Checkbox`, module)
               onChange(e);
             }}
             checked={isChecked}
+            validationHint={text('Validation hint', 'Something is wrong.')}
             invalid
           >
-            Error
+            {text('Label', 'Error')}
           </Checkbox>
         )}
       </State>
@@ -81,7 +83,7 @@ storiesOf(`${GROUPS.FORMS}|Checkbox`, module)
     'Disabled Checkbox',
     withInfo()(() => (
       <Checkbox value="checkbox" name="checkbox" disabled>
-        Disabled
+        {text('Label', 'Disabled')}
       </Checkbox>
     ))
   )

--- a/src/components/Checkbox/Checkbox.story.js
+++ b/src/components/Checkbox/Checkbox.story.js
@@ -70,8 +70,8 @@ storiesOf(`${GROUPS.FORMS}|Checkbox`, module)
               onChange(e);
             }}
             checked={isChecked}
-            validationHint={text('Validation hint', 'Something is wrong.')}
-            invalid
+            validationHint={text('Validation hint', 'This field is required.')}
+            invalid={!isChecked}
           >
             {text('Label', 'Error')}
           </Checkbox>

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -59,8 +59,8 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  -webkit-transition: border 0.05s ease-in;
-  transition: border 0.05s ease-in;
+  -webkit-transition: border 0.05s ease-in,background-color 0.05s ease-in;
+  transition: border 0.05s ease-in,background-color 0.05s ease-in;
 }
 
 .circuit-2 svg {
@@ -216,8 +216,8 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  -webkit-transition: border 0.05s ease-in;
-  transition: border 0.05s ease-in;
+  -webkit-transition: border 0.05s ease-in,background-color 0.05s ease-in;
+  transition: border 0.05s ease-in,background-color 0.05s ease-in;
 }
 
 .circuit-2 svg {
@@ -327,8 +327,8 @@ exports[`Checkbox should render with default styles 1`] = `
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  -webkit-transition: border 0.05s ease-in;
-  transition: border 0.05s ease-in;
+  -webkit-transition: border 0.05s ease-in,background-color 0.05s ease-in;
+  transition: border 0.05s ease-in,background-color 0.05s ease-in;
 }
 
 .circuit-2 svg {
@@ -441,8 +441,8 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  -webkit-transition: border 0.05s ease-in;
-  transition: border 0.05s ease-in;
+  -webkit-transition: border 0.05s ease-in,background-color 0.05s ease-in;
+  transition: border 0.05s ease-in,background-color 0.05s ease-in;
 }
 
 .circuit-2 svg {
@@ -567,8 +567,8 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  -webkit-transition: border 0.05s ease-in;
-  transition: border 0.05s ease-in;
+  -webkit-transition: border 0.05s ease-in,background-color 0.05s ease-in;
+  transition: border 0.05s ease-in,background-color 0.05s ease-in;
 }
 
 .circuit-2 svg {
@@ -592,6 +592,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 
 .circuit-2:not(:focus)::before {
   border-color: #DB4D4D;
+  background-color: #F4CBCB;
 }
 
 .circuit-2:not(:focus) svg {

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -1,5 +1,162 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Checkbox should render with a tooltip when passed a validation hint 1`] = `
+.circuit-6:last-of-type {
+  margin-bottom: 16px;
+}
+
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-0:focus + label::before {
+  border-width: 2px;
+  border-color: #3388FF;
+}
+
+.circuit-0:checked + label > svg {
+  -webkit-transform: translateY(-50%) scale(1,1);
+  -ms-transform: translateY(-50%) scale(1,1);
+  transform: translateY(-50%) scale(1,1);
+  opacity: 1;
+}
+
+.circuit-0:checked + label::before {
+  border-color: #3388FF;
+}
+
+.circuit-2 {
+  color: #5C656F;
+  display: inline-block;
+  padding-left: 24px;
+  position: relative;
+}
+
+.circuit-2::before {
+  height: 16px;
+  width: 16px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px 0 rgba(102,113,123,0.12);
+  background-color: #FFFFFF;
+  border: 1px solid #9DA7B1;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 0.05s ease-in;
+  transition: border 0.05s ease-in;
+}
+
+.circuit-2 svg {
+  height: 10px;
+  width: 10px;
+  box-sizing: border-box;
+  fill: #3388FF;
+  display: block;
+  left: 3px;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  -webkit-transform: translateY(-50%) scale(0,0);
+  -ms-transform: translateY(-50%) scale(0,0);
+  transform: translateY(-50%) scale(0,0);
+  -webkit-transition: -webkit-transform 0.05s ease-in,opacity 0.05s ease-in;
+  -webkit-transition: transform 0.05s ease-in,opacity 0.05s ease-in;
+  transition: transform 0.05s ease-in,opacity 0.05s ease-in;
+}
+
+.circuit-4 {
+  display: inline-block;
+  width: 100%;
+  max-width: 280px;
+  min-width: 120px;
+  background-color: #212933;
+  color: #FFFFFF;
+  border-radius: 4px;
+  padding: 8px 12px;
+  position: absolute;
+  z-index: 31;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  font-size: 13px;
+  line-height: 20px;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+  left: 50%;
+  left: calc(50% - (16px + 4px));
+  bottom: 100%;
+  bottom: calc(100% + 12px);
+  left: -12px;
+}
+
+.circuit-4::after {
+  display: block;
+  content: '';
+  width: 0;
+  height: 0;
+  position: absolute;
+  border: 8px solid transparent;
+}
+
+.circuit-4::after {
+  left: 12px;
+}
+
+.circuit-4::after {
+  top: 100%;
+  border-top-color: #212933;
+}
+
+<div
+  className=" circuit-6 circuit-7"
+>
+  <input
+    checked={false}
+    className="circuit-0 circuit-1"
+    disabled={false}
+    id="checkbox_5"
+    name="name"
+    onChange={[MockFunction]}
+    type="checkbox"
+    value=""
+  />
+  <label
+    checked={false}
+    className="circuit-2 circuit-3"
+    disabled={false}
+    htmlFor="checkbox_5"
+    name="name"
+    onChange={[MockFunction]}
+    value=""
+  >
+    <div>
+      checked-icon.svg
+    </div>
+  </label>
+  <div
+    className="circuit-4 circuit-5"
+  >
+    This field is required.
+  </div>
+</div>
+`;
+
 exports[`Checkbox should render with checked styles when passed the checked prop 1`] = `
 .circuit-4:last-of-type {
   margin-bottom: 16px;


### PR DESCRIPTION
Addresses #450.

## Purpose

Display a validation hint on a Checkbox component, e.g. when the field is required.

## Approach and changes

We decided to point the validation hint at the checkbox itself since that's where we want the user to click. In addition, we added a light red background to the invalid state so the checkbox stands out more.

_With validation hint:_
![Captura de tela 2019-07-26 11 05 27](https://user-images.githubusercontent.com/11017722/61940298-6a4e1200-af95-11e9-8eb0-60ee3dcc8c6e.png)


## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
