### PR TITLE
refactor(components): Move Spinner component aria attrs to default props

### DIFF
--- a/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
+++ b/src/components/LoadingButton/__snapshots__/Container.spec.js.snap
@@ -101,7 +101,7 @@ exports[`Container Container Style tests should have default styles 1`] = `
       aria-busy="true"
       aria-live="assertive"
       className="circuit-0 circuit-1 circuit-2"
-      role="alertdialog"
+      role="alert"
       size="mega"
     >
       <div>

--- a/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
+++ b/src/components/LoadingButton/components/LoadingButton/__snapshots__/index.spec.js.snap
@@ -106,7 +106,7 @@ exports[`LoadingButton Style tests should have active loading styles 1`] = `
       aria-busy="true"
       aria-live="assertive"
       className="circuit-0 circuit-1 circuit-2"
-      role="alertdialog"
+      role="alert"
       size="mega"
     >
       <div>
@@ -221,7 +221,7 @@ exports[`LoadingButton Style tests should have default styles 1`] = `
       aria-busy="true"
       aria-live="assertive"
       className="circuit-0 circuit-1 circuit-2"
-      role="alertdialog"
+      role="alert"
       size="mega"
     >
       <div>
@@ -339,7 +339,7 @@ exports[`LoadingButton Style tests should have isLoading styles 1`] = `
       aria-busy="true"
       aria-live="assertive"
       className="circuit-0 circuit-1 circuit-2"
-      role="alertdialog"
+      role="alert"
       size="mega"
     >
       <div>

--- a/src/components/LoadingButton/components/LoadingIcon/__snapshots__/index.spec.js.snap
+++ b/src/components/LoadingButton/components/LoadingIcon/__snapshots__/index.spec.js.snap
@@ -24,7 +24,7 @@ exports[`LoadingIcon Style tests should have active LoadingIcon styles 1`] = `
   aria-busy="true"
   aria-live="assertive"
   className="circuit-0 circuit-1 circuit-2"
-  role="alertdialog"
+  role="alert"
   size="kilo"
 >
   <div>
@@ -56,7 +56,7 @@ exports[`LoadingIcon Style tests should have disabled LoadingIcon styles 1`] = `
   aria-busy="true"
   aria-live="assertive"
   className="circuit-0 circuit-1 circuit-2"
-  role="alertdialog"
+  role="alert"
   size="kilo"
 >
   <div>
@@ -89,7 +89,7 @@ Array [
     aria-busy="true"
     aria-live="assertive"
     className="circuit-0 circuit-1 circuit-2"
-    role="alertdialog"
+    role="alert"
     size="kilo"
   >
     <div>
@@ -141,7 +141,7 @@ exports[`LoadingIcon Style tests should have giga LoadingIcon styles 1`] = `
   aria-busy="true"
   aria-live="assertive"
   className="circuit-0 circuit-1 circuit-2"
-  role="alertdialog"
+  role="alert"
   size="giga"
 >
   <div>
@@ -173,7 +173,7 @@ exports[`LoadingIcon Style tests should have kilo LoadingIcon styles 1`] = `
   aria-busy="true"
   aria-live="assertive"
   className="circuit-0 circuit-1 circuit-2"
-  role="alertdialog"
+  role="alert"
   size="kilo"
 >
   <div>
@@ -205,7 +205,7 @@ exports[`LoadingIcon Style tests should have mega LoadingIcon styles 1`] = `
   aria-busy="true"
   aria-live="assertive"
   className="circuit-0 circuit-1 circuit-2"
-  role="alertdialog"
+  role="alert"
   size="mega"
 >
   <div>
@@ -238,7 +238,7 @@ Array [
     aria-busy="true"
     aria-live="assertive"
     className="circuit-0 circuit-1 circuit-2"
-    role="alertdialog"
+    role="alert"
     size="kilo"
   >
     <div>

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -109,8 +109,17 @@ Spinner.defaultProps = {
   /**
    * Accessibilty attributes.
    */
-  role: 'alertdialog',
+  /**
+   * Indicates that element has been dynamically updated.
+   */
+  role: 'alert',
+  /**
+   * Tells screen reader to wait until loading is complete.
+   */
   'aria-busy': 'true',
+  /**
+   * Indicates that updates to the region have the highest priority.
+   */
   'aria-live': 'assertive'
 };
 

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -17,7 +17,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css, keyframes } from '@emotion/core';
-import { withProps } from 'recompose';
 
 import { ReactComponent as SpinnerSvg } from './icons/spinner.svg';
 
@@ -105,14 +104,17 @@ Spinner.propTypes = {
 
 Spinner.defaultProps = {
   dark: false,
-  active: true
+  active: true,
+
+  /**
+   * Accessibilty attributes.
+   */
+  role: 'alertdialog',
+  'aria-busy': 'true',
+  'aria-live': 'assertive'
 };
 
 /**
  * @component
  */
-export default withProps({
-  role: 'alertdialog',
-  'aria-busy': 'true',
-  'aria-live': 'assertive'
-})(Spinner);
+export default Spinner;

--- a/src/components/Spinner/__snapshots__/Spinner.spec.js.snap
+++ b/src/components/Spinner/__snapshots__/Spinner.spec.js.snap
@@ -16,7 +16,7 @@ exports[`Spinner should render with dark styles 1`] = `
   aria-busy="true"
   aria-live="assertive"
   className="circuit-0 circuit-1"
-  role="alertdialog"
+  role="alert"
 >
   <div>
     spinner.svg
@@ -40,7 +40,7 @@ exports[`Spinner should render with default styles 1`] = `
   aria-busy="true"
   aria-live="assertive"
   className="circuit-0 circuit-1"
-  role="alertdialog"
+  role="alert"
 >
   <div>
     spinner.svg


### PR DESCRIPTION
## Purpose

Sometimes it's necessary to remove current aria attributes from the spinner or replace it with other ones (e.g. not-disruptive spinner for lazy-loading images on the page).

## Approach and changes

Remove recompose `withProps` method and add aria attrs to `defaultProps`.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
