### PR TITLE
fix: Remove default props for deprecated props in Input

### DIFF
--- a/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
+++ b/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
@@ -64,7 +64,7 @@ exports[`AutoCompleteInput should render with default styles 1`] = `
   className="circuit-4 circuit-5"
 >
   <div
-    className=" circuit-2 circuit-3"
+    className="circuit-2 circuit-3"
     disabled={false}
   >
     <div>
@@ -76,7 +76,7 @@ exports[`AutoCompleteInput should render with default styles 1`] = `
       aria-expanded={false}
       aria-invalid={false}
       autoComplete="off"
-      className=" circuit-0 circuit-1"
+      className="circuit-0 circuit-1"
       disabled={false}
       id="downshift-0-input"
       onBlur={[Function]}

--- a/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
+++ b/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
@@ -64,7 +64,7 @@ exports[`AutoCompleteTags should render with default styles 1`] = `
   className="circuit-4 circuit-5"
 >
   <div
-    className=" circuit-2 circuit-3"
+    className="circuit-2 circuit-3"
     disabled={false}
   >
     <div>
@@ -76,7 +76,7 @@ exports[`AutoCompleteTags should render with default styles 1`] = `
       aria-expanded={false}
       aria-invalid={false}
       autoComplete="off"
-      className=" circuit-0 circuit-1"
+      className="circuit-0 circuit-1"
       disabled={false}
       id="downshift-0-input"
       onBlur={[Function]}

--- a/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
+++ b/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
@@ -175,12 +175,12 @@ Array [
 }
 
 <div
-    class=" circuit-14 circuit-15"
+    class="circuit-14 circuit-15"
   >
     <input
       aria-invalid="false"
       autocomplete="cc-number"
-      class=" circuit-0 circuit-1"
+      class="circuit-0 circuit-1"
       id="cui-cc-card-number"
       name="creditCardInput"
       placeholder="•••• •••• •••• ••••"
@@ -388,12 +388,12 @@ Array [
 }
 
 <div
-    class=" circuit-14 circuit-15"
+    class="circuit-14 circuit-15"
   >
     <input
       aria-invalid="false"
       autocomplete="cc-number"
-      class=" circuit-0 circuit-1"
+      class="circuit-0 circuit-1"
       id="cui-cc-card-number"
       name="creditCardInput"
       placeholder="•••• •••• •••• ••••"
@@ -614,12 +614,12 @@ Array [
 }
 
 <div
-    class=" circuit-20 circuit-21"
+    class="circuit-20 circuit-21"
   >
     <input
       aria-invalid="false"
       autocomplete="cc-number"
-      class=" circuit-0 circuit-1"
+      class="circuit-0 circuit-1"
       id="cui-cc-card-number"
       name="creditCardInput"
       placeholder="•••• •••• •••• ••••"

--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
@@ -72,11 +72,11 @@ exports[`SimpleCurrencyInput should adjust input padding and postfix width to ma
 }
 
 <div
-  class=" circuit-4 circuit-5"
+  class="circuit-4 circuit-5"
 >
   <input
     aria-invalid="false"
-    class=" circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     placeholder="123,45"
     type="text"
   />
@@ -163,12 +163,12 @@ exports[`SimpleCurrencyInput should prioritize disabled over error styles 1`] = 
 }
 
 <div
-  class=" circuit-4 circuit-5"
+  class="circuit-4 circuit-5"
   disabled=""
 >
   <input
     aria-invalid="true"
-    class=" circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     disabled=""
     type="text"
   />
@@ -299,11 +299,11 @@ exports[`SimpleCurrencyInput should prioritize disabled over warning styles 1`] 
 }
 
 <div
-  class=" circuit-4 circuit-5"
+  class="circuit-4 circuit-5"
 >
   <input
     aria-invalid="true"
-    class=" circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -384,11 +384,11 @@ exports[`SimpleCurrencyInput should render with default styles 1`] = `
 }
 
 <div
-  class=" circuit-4 circuit-5"
+  class="circuit-4 circuit-5"
 >
   <input
     aria-invalid="false"
-    class=" circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -495,11 +495,11 @@ exports[`SimpleCurrencyInput should render with error styles 1`] = `
 }
 
 <div
-  class=" circuit-4 circuit-5"
+  class="circuit-4 circuit-5"
 >
   <input
     aria-invalid="true"
-    class=" circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -606,11 +606,11 @@ exports[`SimpleCurrencyInput should render with warning styles 1`] = `
 }
 
 <div
-  class=" circuit-4 circuit-5"
+  class="circuit-4 circuit-5"
 >
   <input
     aria-invalid="false"
-    class=" circuit-0 circuit-1"
+    class="circuit-0 circuit-1"
     type="text"
   />
   <span
@@ -693,7 +693,7 @@ exports[`SimpleCurrencyInput should support rendering symbols on the left 1`] = 
 }
 
 <div
-  class=" circuit-4 circuit-5"
+  class="circuit-4 circuit-5"
 >
   <span
     class="circuit-0 circuit-1"
@@ -702,7 +702,7 @@ exports[`SimpleCurrencyInput should support rendering symbols on the left 1`] = 
   </span>
   <input
     aria-invalid="false"
-    class=" circuit-2 circuit-3"
+    class="circuit-2 circuit-3"
     placeholder="123.45"
     type="text"
   />

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -461,9 +461,7 @@ Input.defaultProps = {
   inline: false,
   noMargin: false,
   deepRef: undefined,
-  textAlign: Input.LEFT,
-  inputClassName: '',
-  wrapperClassName: ''
+  textAlign: Input.LEFT
 };
 
 /**

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -58,12 +58,12 @@ exports[`Input should prioritize disabled over error styles 1`] = `
 }
 
 <div
-  className=" circuit-2 circuit-3"
+  className="circuit-2 circuit-3"
   disabled={true}
 >
   <input
     aria-invalid={true}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={true}
     required={false}
   />
@@ -179,12 +179,12 @@ exports[`Input should prioritize disabled over warning styles 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={true}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -290,12 +290,12 @@ exports[`Input should prioritize error over optional styles 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={true}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -418,12 +418,12 @@ exports[`Input should render with a Tooltip when passed the validationHint prop 
 }
 
 <div
-  className=" circuit-6 circuit-7"
+  className="circuit-6 circuit-7"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -507,7 +507,7 @@ exports[`Input should render with a prefix when passed the prefix prop 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <div
@@ -520,7 +520,7 @@ exports[`Input should render with a prefix when passed the prefix prop 1`] = `
   />
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -585,12 +585,12 @@ exports[`Input should render with a suffix when passed the suffix prop 1`] = `
 }
 
 <div
-  className=" circuit-2 circuit-3"
+  className="circuit-2 circuit-3"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -675,12 +675,12 @@ exports[`Input should render with custom styles 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -758,12 +758,12 @@ exports[`Input should render with default styles 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -831,12 +831,12 @@ exports[`Input should render with disabled styles when passed the disabled prop 
 }
 
 <div
-  className=" circuit-2 circuit-3"
+  className="circuit-2 circuit-3"
   disabled={true}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={true}
     required={false}
   />
@@ -913,12 +913,12 @@ exports[`Input should render with inline styles when passed the inline prop 1`] 
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1017,12 +1017,12 @@ exports[`Input should render with invalid styles when passed the invalid prop 1`
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={true}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1105,12 +1105,12 @@ exports[`Input should render with no margin styles when passed the noMargin prop
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1191,12 +1191,12 @@ exports[`Input should render with optional styles when passed the optional prop 
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1275,12 +1275,12 @@ exports[`Input should render with right aligned text 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1358,12 +1358,12 @@ exports[`Input should render with valid styles when passed the showValid prop 1`
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1466,12 +1466,12 @@ exports[`Input should render with warning styles when passed the hasWarning prop
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
@@ -59,7 +59,7 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
 }
 
 <div
-  className=" circuit-2 circuit-3"
+  className="circuit-2 circuit-3"
   disabled={true}
 >
   <div>
@@ -67,7 +67,7 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
   </div>
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={true}
     required={false}
     type="search"
@@ -144,7 +144,7 @@ exports[`SearchInput should render with default styles 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <div>
@@ -152,7 +152,7 @@ exports[`SearchInput should render with default styles 1`] = `
   </div>
   <input
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
     type="search"

--- a/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
@@ -60,12 +60,12 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
 }
 
 <div
-  className=" circuit-2 circuit-3"
+  className="circuit-2 circuit-3"
   disabled={true}
 >
   <textarea
     aria-invalid={true}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={true}
     required={false}
   />
@@ -183,12 +183,12 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={true}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -296,12 +296,12 @@ exports[`TextArea should prioritize error over optional styles 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={true}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -426,12 +426,12 @@ exports[`TextArea should render with a Tooltip when passed the validationHint pr
 }
 
 <div
-  className=" circuit-6 circuit-7"
+  className="circuit-6 circuit-7"
   disabled={false}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -516,12 +516,12 @@ exports[`TextArea should render with a prefix when passed the prefix prop 1`] = 
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     prefix={[Function]}
     required={false}
@@ -602,12 +602,12 @@ exports[`TextArea should render with a suffix when passed the suffix prop 1`] = 
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
     suffix={[Function]}
@@ -688,12 +688,12 @@ exports[`TextArea should render with default styles 1`] = `
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -763,12 +763,12 @@ exports[`TextArea should render with disabled styled when passed the disabled pr
 }
 
 <div
-  className=" circuit-2 circuit-3"
+  className="circuit-2 circuit-3"
   disabled={true}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={true}
     required={false}
   />
@@ -847,12 +847,12 @@ exports[`TextArea should render with inline styles when passed the inline prop 1
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -953,12 +953,12 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={true}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1043,12 +1043,12 @@ exports[`TextArea should render with no margin styles when passed the noMargin p
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1131,12 +1131,12 @@ exports[`TextArea should render with optional styles when passed the optional pr
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1216,12 +1216,12 @@ exports[`TextArea should render with valid styles when passed the showValid prop
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />
@@ -1326,12 +1326,12 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
 }
 
 <div
-  className=" circuit-4 circuit-5"
+  className="circuit-4 circuit-5"
   disabled={false}
 >
   <textarea
     aria-invalid={false}
-    className=" circuit-0 circuit-1"
+    className="circuit-0 circuit-1"
     disabled={false}
     required={false}
   />

--- a/src/util/deprecate.js
+++ b/src/util/deprecate.js
@@ -19,8 +19,7 @@ const warned = {};
 
 export default function deprecate(explanation = '') {
   if (__DEV__) {
-    const { stack } = new Error();
-    const message = `DEPRECATION: ${explanation}\n ${stack}`;
+    const message = `DEPRECATION: ${explanation}`;
 
     if (!warned[message]) {
       warning(false, message);


### PR DESCRIPTION
## Purpose

The class name props are deprecated. Providing a default prop will always trigger the deprecation warning and might confuse users. Since the current default prop is just an empty string, it's redundant and can be safely removed.

## Approach and changes

- Remove default props for class names from Input component.
- Remove the stack trace from deprecation warnings. The stack traces tend to be 20+ lines long and pollute the console.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
