### PR TITLE
feat(components): Add condensed styles to Table

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -154,9 +154,10 @@ class Table extends Component {
     const {
       rowHeaders,
       headers,
-      onRowClick,
       noShadow,
-      borderCollapsed
+      borderCollapsed,
+      condensed,
+      onRowClick
     } = this.props;
     const { sortDirection, sortHover, sortedRow } = this.state;
 
@@ -177,6 +178,7 @@ class Table extends Component {
               borderCollapsed={borderCollapsed}
             >
               <TableHead
+                condensed={condensed}
                 sortDirection={sortDirection}
                 sortedRow={sortedRow}
                 onSortBy={this.onSortBy}
@@ -186,6 +188,7 @@ class Table extends Component {
                 rowHeaders={rowHeaders}
               />
               <TableBody
+                condensed={condensed}
                 rows={this.getSortedRows()}
                 rowHeaders={rowHeaders}
                 sortHover={sortHover}
@@ -223,6 +226,10 @@ Table.propTypes = {
    * Removes the default box-shadow from the table.
    */
   noShadow: PropTypes.bool,
+  /**
+   * Toggles condensed styles on the Table.
+   */
+  condensed: PropTypes.bool,
   /**
    * Custom onSortBy function for the onSort handler.
    * The signature is (index, nextDirection, currentRows) and it should return

--- a/src/components/Table/Table.spec.js
+++ b/src/components/Table/Table.spec.js
@@ -49,6 +49,11 @@ describe('Table', () => {
       );
       expect(actual).toMatchSnapshot();
     });
+
+    it('should render a condensed table', () => {
+      const actual = create(<Table headers={headers} rows={items} condensed />);
+      expect(actual).toMatchSnapshot();
+    });
   });
 
   describe('Accessibility tests', () => {

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -70,7 +70,7 @@ storiesOf(`${GROUPS.COMPONENTS}|Table`, module)
           headers={headers}
           rows={rows}
           rowHeaders={boolean('Mobile rows', false)}
-          condensed={boolean('Condensed', true)}
+          condensed={boolean('Condensed', false)}
           noShadow={boolean('Without Shadow', false)}
           onRowClick={action('onRowClick')}
           borderCollapsed={boolean('Border collapsed', false)}

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -70,6 +70,7 @@ storiesOf(`${GROUPS.COMPONENTS}|Table`, module)
           headers={headers}
           rows={rows}
           rowHeaders={boolean('Mobile rows', false)}
+          condensed={boolean('Condensed', true)}
           noShadow={boolean('Without Shadow', false)}
           onRowClick={action('onRowClick')}
           borderCollapsed={boolean('Border collapsed', false)}

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -384,6 +384,400 @@ tbody .circuit-11:last-child td {
 </div>
 `;
 
+exports[`Table Style tests should render a condensed table 1`] = `
+.circuit-49 {
+  position: relative;
+}
+
+.circuit-47 {
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
+.circuit-45 {
+  border-radius: 4px;
+}
+
+@media (max-width:767px) {
+  .circuit-45 {
+    margin-left: 145px;
+    overflow-x: auto;
+  }
+}
+
+.circuit-43 {
+  background-color: #FFFFFF;
+  border-collapse: separate;
+  width: 100%;
+}
+
+@media (max-width:767px) {
+  .circuit-43 {
+    margin-left: -145px;
+    width: calc(100% + 145px);
+  }
+
+  .circuit-43:after {
+    content: '';
+    background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
+    height: 100%;
+    left: 145px;
+    position: absolute;
+    top: 0;
+    width: 6px;
+  }
+}
+
+.circuit-11 {
+  vertical-align: middle;
+}
+
+tbody .circuit-11:last-child th,
+tbody .circuit-11:last-child td {
+  border-bottom: none;
+}
+
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media (max-width:767px) {
+  .circuit-3 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+.circuit-13 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+}
+
+@media (max-width:767px) {
+  .circuit-13 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-15 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+}
+
+@media (max-width:767px) {
+  .circuit-15 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  overflow: initial;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 10px;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+  width: 5px;
+  left: 8px;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-5 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  padding: 12px 16px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+@media (max-width:767px) {
+  .circuit-5 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-7 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  vertical-align: middle;
+  padding: 8px 16px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.circuit-17 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  padding: 12px 16px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+<div
+  className="circuit-49"
+>
+  <div
+    className="circuit-47 circuit-48"
+  >
+    <div
+      className="circuit-45 circuit-46"
+    >
+      <table
+        className="circuit-43 circuit-44"
+      >
+        <thead>
+          <tr
+            className="circuit-11 circuit-12"
+          >
+            <th
+              aria-sort="none"
+              className="circuit-3 circuit-4"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              scope="col"
+            >
+              <button
+                className="circuit-0 circuit-1 circuit-2"
+                type="button"
+              >
+                <div>
+                  arrow.svg
+                </div>
+                <div>
+                  arrow.svg
+                </div>
+              </button>
+              Foo
+            </th>
+            <td
+              aria-hidden="true"
+              className="circuit-5 circuit-6"
+              role="presentation"
+            >
+              Foo
+            </td>
+            <th
+              aria-sort={null}
+              className="circuit-7 circuit-4"
+              onClick={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              scope="col"
+            >
+              Bar
+            </th>
+            <th
+              aria-sort={null}
+              className="circuit-7 circuit-4"
+              onClick={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              scope="col"
+            >
+              Baz
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            className="circuit-11 circuit-12"
+            onClick={null}
+          >
+            <th
+              aria-sort={null}
+              className="circuit-13 circuit-4"
+              scope="row"
+            >
+              1
+            </th>
+            <td
+              aria-hidden="true"
+              className="circuit-15 circuit-6"
+              role="presentation"
+            >
+              1
+            </td>
+            <td
+              className="circuit-17 circuit-6"
+            >
+              2
+            </td>
+            <td
+              className="circuit-17 circuit-6"
+            >
+              3
+            </td>
+          </tr>
+          <tr
+            className="circuit-11 circuit-12"
+            onClick={null}
+          >
+            <th
+              aria-sort={null}
+              className="circuit-13 circuit-4"
+              scope="row"
+            >
+              1
+            </th>
+            <td
+              aria-hidden="true"
+              className="circuit-15 circuit-6"
+              role="presentation"
+            >
+              1
+            </td>
+            <td
+              className="circuit-17 circuit-6"
+            >
+              2
+            </td>
+            <td
+              className="circuit-17 circuit-6"
+            >
+              3
+            </td>
+          </tr>
+          <tr
+            className="circuit-11 circuit-12"
+            onClick={null}
+          >
+            <th
+              aria-sort={null}
+              className="circuit-13 circuit-4"
+              scope="row"
+            >
+              1
+            </th>
+            <td
+              aria-hidden="true"
+              className="circuit-15 circuit-6"
+              role="presentation"
+            >
+              1
+            </td>
+            <td
+              className="circuit-17 circuit-6"
+            >
+              2
+            </td>
+            <td
+              className="circuit-17 circuit-6"
+            >
+              3
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Table Style tests should render with default styles 1`] = `
 .circuit-49 {
   position: relative;

--- a/src/components/Table/components/SortArrow/index.js
+++ b/src/components/Table/components/SortArrow/index.js
@@ -52,7 +52,7 @@ const DownArrow = styled(ArrowIcon)`
 `;
 
 /**
- * [PRIVATE] Arrow component for TableHeader sorting
+ * @private Arrow component for TableHeader sorting
  */
 const SortArrow = ({ direction, condensed }) => (
   <StyledWrapper condensed={condensed}>

--- a/src/components/Table/components/SortArrow/index.js
+++ b/src/components/Table/components/SortArrow/index.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
@@ -35,8 +35,15 @@ const baseStyles = ({ theme }) => css`
   width: 5px;
 `;
 
+const condensedStyles = ({ condensed, theme }) =>
+  condensed &&
+  css`
+    left: ${theme.spacings.byte};
+  `;
+
 const StyledWrapper = styled(SvgButton)`
   ${baseStyles};
+  ${condensedStyles};
 `;
 
 const DownArrow = styled(ArrowIcon)`
@@ -47,21 +54,21 @@ const DownArrow = styled(ArrowIcon)`
 /**
  * [PRIVATE] Arrow component for TableHeader sorting
  */
-const SortArrow = ({ direction }) => (
-  <StyledWrapper>
-    <Fragment>
-      {direction !== DESCENDING && <ArrowIcon />}
-      {direction !== ASCENDING && <DownArrow />}
-    </Fragment>
+const SortArrow = ({ direction, condensed }) => (
+  <StyledWrapper condensed={condensed}>
+    {direction !== DESCENDING && <ArrowIcon />}
+    {direction !== ASCENDING && <DownArrow />}
   </StyledWrapper>
 );
 
 SortArrow.propTypes = {
-  direction: PropTypes.oneOf([ASCENDING, DESCENDING])
+  direction: PropTypes.oneOf([ASCENDING, DESCENDING]),
+  condensed: PropTypes.bool
 };
 
 SortArrow.defaultProps = {
-  direction: null
+  direction: null,
+  condensed: false
 };
 
 export default SortArrow;

--- a/src/components/Table/components/SortArrow/index.js
+++ b/src/components/Table/components/SortArrow/index.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
@@ -56,8 +56,10 @@ const DownArrow = styled(ArrowIcon)`
  */
 const SortArrow = ({ direction, condensed }) => (
   <StyledWrapper condensed={condensed}>
-    {direction !== DESCENDING && <ArrowIcon />}
-    {direction !== ASCENDING && <DownArrow />}
+    <Fragment>
+      {direction !== DESCENDING && <ArrowIcon />}
+      {direction !== ASCENDING && <DownArrow />}
+    </Fragment>
   </StyledWrapper>
 );
 

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -71,7 +71,7 @@ const TableBody = ({ rows, condensed, rowHeaders, sortHover, onRowClick }) => (
 );
 
 /**
- * [PRIVATE] TableHead for the Table component. The Table handles rendering it
+ * @private TableHead for the Table component. The Table handles rendering it
  */
 TableBody.propTypes = {
   /**
@@ -89,12 +89,12 @@ TableBody.propTypes = {
    */
   rowHeaders: PropTypes.bool,
   /**
-   * [PRIVATE] The current hovered sort cell index
+   * @private The current hovered sort cell index
    * Handled internally
    */
   sortHover: PropTypes.number,
   /**
-   * [PRIVATE] Adds condensed styles to the table.
+   * @private Adds condensed styles to the table.
    * Handled internally
    */
   condensed: PropTypes.bool,

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -31,7 +31,7 @@ const getRowKey = index => `${TR_KEY_PREFIX}-${index}`;
 const getCellKey = (rowIndex, cellIndex) =>
   `${TD_KEY_PREFIX}-${rowIndex}-${cellIndex}`;
 
-const TableBody = ({ rows, rowHeaders, sortHover, onRowClick }) => (
+const TableBody = ({ rows, condensed, rowHeaders, sortHover, onRowClick }) => (
   <tbody>
     {rows.map((row, rowIndex) => {
       const { cells, ...props } = mapRowProps(row);
@@ -46,6 +46,7 @@ const TableBody = ({ rows, rowHeaders, sortHover, onRowClick }) => (
               <Fragment key={getCellKey(rowIndex, cellIndex)}>
                 <TableHeader
                   fixed
+                  condensed={condensed}
                   scope={TableHeader.ROW}
                   isHovered={sortHover === cellIndex}
                   {...mapCellProps(cell)}
@@ -57,6 +58,7 @@ const TableBody = ({ rows, rowHeaders, sortHover, onRowClick }) => (
             ) : (
               <TableCell
                 key={getCellKey(rowIndex, cellIndex)}
+                condensed={condensed}
                 isHovered={sortHover === cellIndex}
                 {...mapCellProps(cell)}
               />
@@ -91,6 +93,11 @@ TableBody.propTypes = {
    * Handled internally
    */
   sortHover: PropTypes.number,
+  /**
+   * [PRIVATE] Adds condensed styles to the table.
+   * Handled internally
+   */
+  condensed: PropTypes.bool,
   /**
    * onClick handler
    */

--- a/src/components/Table/components/TableCell/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableCell/__snapshots__/index.spec.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TableCell Style tests should render with condensed styles 1`] = `
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  padding: 12px 16px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+<td
+  className="circuit-0 circuit-1"
+>
+  Foo
+</td>
+`;
+
 exports[`TableCell Style tests should render with default styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -89,12 +89,12 @@ TableCell.propTypes = {
    */
   align: PropTypes.oneOf([TableCell.LEFT, TableCell.RIGHT, TableCell.CENTER]),
   /**
-   * [PRIVATE] Add heading styles to placeholder Cell.
+   * @private Add heading styles to placeholder Cell.
    * Handled internally
    */
   header: PropTypes.bool,
   /**
-   * [PRIVATE] Adds active style to the Cell if it is currently hovered by
+   * @private Adds active style to the Cell if it is currently hovered by
    * sort.
    * Handled internally
    */

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -60,6 +60,13 @@ const hoverStyles = ({ theme, isHovered }) =>
     background-color: ${theme.colors.n100};
   `;
 
+const condensedStyles = ({ condensed, theme }) =>
+  condensed &&
+  css`
+    padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+    ${theme.typography.text.kilo};
+  `;
+
 /**
  * TableCell component for the Table. You shouldn't import this component
  * directly, the Table handles it
@@ -68,6 +75,7 @@ const TableCell = styled.td`
   ${baseStyles};
   ${presentationStyles};
   ${hoverStyles};
+  ${condensedStyles};
 `;
 
 TableCell.LEFT = directions.LEFT;

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -63,6 +63,7 @@ const hoverStyles = ({ theme, isHovered }) =>
 const condensedStyles = ({ condensed, theme }) =>
   condensed &&
   css`
+    label: table-cell--condensed;
     padding: ${theme.spacings.kilo} ${theme.spacings.mega};
     ${theme.typography.text.kilo};
   `;

--- a/src/components/Table/components/TableCell/index.spec.js
+++ b/src/components/Table/components/TableCell/index.spec.js
@@ -35,6 +35,11 @@ describe('TableCell', () => {
       const actual = create(<TableCell header>{children}</TableCell>);
       expect(actual).toMatchSnapshot();
     });
+
+    it('should render with condensed styles', () => {
+      const actual = create(<TableCell condensed>{children}</TableCell>);
+      expect(actual).toMatchSnapshot();
+    });
   });
 
   describe('Accessibility tests', () => {

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -78,7 +78,7 @@ const TableHead = ({
 );
 
 /**
- * [PRIVATE] TableHead for the Table component. The Table handlers rendering it
+ * @private TableHead for the Table component. The Table handlers rendering it
  */
 TableHead.propTypes = {
   /**
@@ -91,28 +91,28 @@ TableHead.propTypes = {
    */
   rowHeaders: PropTypes.bool,
   /**
-   * [PRIVATE] Adds condensed styles the table according to the table props.
+   * @private Adds condensed styles the table according to the table props.
    * Handled internally.
    */
   condensed: PropTypes.bool,
   /**
-   * [PRIVATE] sortBy handler
+   * @private sortBy handler
    */
   onSortBy: PropTypes.func,
   /**
-   * [PRIVATE] The current sortDirection
+   * @private The current sortDirection
    */
   sortDirection: PropTypes.oneOf([ASCENDING, DESCENDING]),
   /**
-   * [PRIVATE] The current sorted row index
+   * @private The current sorted row index
    */
   sortedRow: PropTypes.number,
   /**
-   * [PRIVATE] sortEnter handler
+   * @private sortEnter handler
    */
   onSortEnter: PropTypes.func,
   /**
-   * [PRIVATE] sortLeave handler
+   * @private sortLeave handler
    */
   onSortLeave: PropTypes.func
 };

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -26,6 +26,7 @@ import { ASCENDING, DESCENDING, TH_KEY_PREFIX } from '../../constants';
 const TableHead = ({
   headers,
   rowHeaders,
+  condensed,
   onSortBy,
   sortDirection,
   sortedRow,
@@ -36,25 +37,35 @@ const TableHead = ({
     {!!headers.length && (
       <TableRow header>
         {headers.map((header, i) => {
-          const props = mapCellProps(header);
+          const cellProps = mapCellProps(header);
           return (
             <Fragment key={`${TH_KEY_PREFIX}-${i}`}>
               <TableHeader
-                {...props}
+                {...cellProps}
+                condensed={condensed}
                 fixed={rowHeaders && i === 0}
                 // eslint-disable-next-line react/prop-types
-                onClick={props.sortable ? () => onSortBy(i) : null}
+                onClick={cellProps.sortable ? () => onSortBy(i) : null}
                 onMouseEnter={
-                  props.sortable ? onSortEnter && (() => onSortEnter(i)) : null
+                  cellProps.sortable
+                    ? onSortEnter && (() => onSortEnter(i))
+                    : null
                 }
                 onMouseLeave={
-                  props.sortable ? onSortLeave && (() => onSortLeave(i)) : null
+                  cellProps.sortable
+                    ? onSortLeave && (() => onSortLeave(i))
+                    : null
                 }
                 sortDirection={sortedRow === i ? sortDirection : null}
                 isSorted={sortedRow === i}
               />
               {rowHeaders && i === 0 && (
-                <TableCell role="presentation" aria-hidden="true" header>
+                <TableCell
+                  condensed={condensed}
+                  role="presentation"
+                  aria-hidden="true"
+                  header
+                >
                   {getCellChildren(header)}
                 </TableCell>
               )}
@@ -79,6 +90,11 @@ TableHead.propTypes = {
    * Enables/disables sticky columns on mobile
    */
   rowHeaders: PropTypes.bool,
+  /**
+   * [PRIVATE] Adds condensed styles the table according to the table props.
+   * Handled internally.
+   */
+  condensed: PropTypes.bool,
   /**
    * [PRIVATE] sortBy handler
    */

--- a/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TableHeader Style tests should render with condensed styles 1`] = `
+.circuit-0 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  vertical-align: middle;
+  padding: 8px 16px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+<th
+  aria-sort={null}
+  className="circuit-0 circuit-1"
+  scope="col"
+>
+  Foo
+</th>
+`;
+
 exports[`TableHeader Style tests should render with default styles 1`] = `
 .circuit-0 {
   background-color: #FFFFFF;

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -95,9 +95,11 @@ const sortableActiveStyles = ({ sortable, isSorted }) =>
     }
   `;
 
-const condensedStyles = ({ condensed, theme }) =>
+const condensedStyles = ({ condensed, theme, fixed }) =>
   condensed &&
+  !fixed &&
   css`
+    label: table-header--condensed;
     vertical-align: middle;
     padding: ${theme.spacings.byte} ${theme.spacings.mega};
     ${theme.typography.text.kilo};

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -153,17 +153,17 @@ TableHeader.propTypes = {
     TableHeader.CENTER
   ]),
   /**
-   * [PRIVATE] Adds ROL or COL styles based on the provided Scope.
+   * @private Adds ROL or COL styles based on the provided Scope.
    * Handled internally
    */
   scope: PropTypes.oneOf([TableHeader.COL, TableHeader.ROW]),
   /**
-   * [PRIVATE] Adds sticky style to the Header based on rowHeader definition.
+   * @private Adds sticky style to the Header based on rowHeader definition.
    * Handled internally
    */
   fixed: PropTypes.bool,
   /**
-   * [PRIVATE] Adds condensed style to the Header based on the table props.
+   * @private Adds condensed style to the Header based on the table props.
    * Handled internally
    */
   condensed: PropTypes.bool,
@@ -172,7 +172,7 @@ TableHeader.propTypes = {
    */
   sortable: PropTypes.bool,
   /**
-   * [PRIVATE] Adds active style to the Header if it is currently hovered by
+   * @private Adds active style to the Header if it is currently hovered by
    * sort.
    * Handled internally
    */
@@ -180,7 +180,7 @@ TableHeader.propTypes = {
   children: childrenPropType,
   sortDirection: PropTypes.oneOf([ASCENDING, DESCENDING]),
   /**
-   * [PRIVATE] Adds sorted style to the Header if it is currently sorted
+   * @private Adds sorted style to the Header if it is currently sorted
    * Handled internally
    */
   isSorted: PropTypes.bool

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -95,6 +95,14 @@ const sortableActiveStyles = ({ sortable, isSorted }) =>
     }
   `;
 
+const condensedStyles = ({ condensed, theme }) =>
+  condensed &&
+  css`
+    vertical-align: middle;
+    padding: ${theme.spacings.byte} ${theme.spacings.mega};
+    ${theme.typography.text.kilo};
+  `;
+
 const StyledHeader = styled.th`
   ${baseStyles};
   ${hoveredStyles};
@@ -102,19 +110,27 @@ const StyledHeader = styled.th`
   ${colStyles};
   ${sortableStyles};
   ${sortableActiveStyles};
+  ${condensedStyles};
 `;
 
 /**
  * TableHeader component for the Table. You shouldn't import this component
  * directly, the Table handles it
  */
-const TableHeader = ({ sortable, children, sortDirection, ...rest }) => (
+const TableHeader = ({
+  sortable,
+  children,
+  sortDirection,
+  condensed,
+  ...rest
+}) => (
   <StyledHeader
     sortable={sortable}
+    condensed={condensed}
     aria-sort={getAriaSort(sortable, sortDirection)}
     {...rest}
   >
-    {sortable && <SortArrow direction={sortDirection} />}
+    {sortable && <SortArrow condensed={condensed} direction={sortDirection} />}
     {children}
   </StyledHeader>
 );
@@ -144,6 +160,11 @@ TableHeader.propTypes = {
    * Handled internally
    */
   fixed: PropTypes.bool,
+  /**
+   * [PRIVATE] Adds condensed style to the Header based on the table props.
+   * Handled internally
+   */
+  condensed: PropTypes.bool,
   /**
    * Defines whether or not the Header is sortable
    */

--- a/src/components/Table/components/TableHeader/index.spec.js
+++ b/src/components/Table/components/TableHeader/index.spec.js
@@ -44,6 +44,11 @@ describe('TableHeader', () => {
       expect(actual).toMatchSnapshot();
     });
 
+    it('should render with condensed styles', () => {
+      const actual = create(<TableHeader condensed>{children}</TableHeader>);
+      expect(actual).toMatchSnapshot();
+    });
+
     describe('sortable + sorted', () => {
       it('should render with sortable + sorted ascending styles', () => {
         const actual = create(


### PR DESCRIPTION
Addresses https://sumupteam.atlassian.net/browse/PMNTSS-14

## Purpose

This PR adds condensed styles to the Table component. Check out the design below: 

<img width="405" alt="Screenshot 2019-08-01 at 15 14 56" src="https://user-images.githubusercontent.com/4214288/62292879-041f2e80-b470-11e9-8d18-b9996410fd40.png">

## Approach and changes

I've added the `condensed` property which enables the new styles in the Table and tweaked the `TableHeader` and `TableCell` components to meet the design requirements. The next step would be to make the table body scrollable but I've decided to make this in a separate PR so reviewing is easier :))

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
