### PR TITLE
feat(components): Add vertical scroll to table

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -148,7 +148,7 @@ class Table extends Component {
   };
 
   componentDidMount() {
-    if (this.props.scrollable) {
+    if (this.props.scrollable && this.props.rowHeaders) {
       this.addVerticalScroll();
     }
   }

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -76,8 +76,9 @@ const containerStyles = ({ theme, rowHeaders }) =>
     }
   `;
 
-const scrollableStyles = ({ scrollable, height }) =>
+const scrollableStyles = ({ scrollable, height, rowHeaders }) =>
   scrollable &&
+  !rowHeaders &&
   css`
     height: ${height || '100%'};
     overflow-y: auto;
@@ -152,13 +153,20 @@ class Table extends Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    if (!prevProps.scrollable && this.props.scrollable) {
+  componentDidUpdate({ scrollable, rowHeaders }) {
+    const shouldAddScroll =
+      (!scrollable && this.props.scrollable) ||
+      (rowHeaders && !this.props.rowHeaders);
+
+    const shouldRemoveScroll =
+      (scrollable && !this.props.scrollable) ||
+      (!rowHeaders && this.props.rowHeaders);
+
+    if (shouldAddScroll) {
       this.addVerticalScroll();
     }
 
-    if (prevProps.scrollable && !this.props.scrollable) {
-      this.setState({ tableBodyHeight: null });
+    if (shouldRemoveScroll) {
       this.removeVerticalScroll();
     }
   }
@@ -187,13 +195,7 @@ class Table extends Component {
   };
 
   calculateTableBodyHeight = () => {
-    const HEADER_HEIGHT = 41;
-    const CONDENSED_HEADER_HEIGHT = 37;
-
-    const tableBodyHeight = `${this.tableContainer.offsetHeight -
-      (this.props.condensed ? CONDENSED_HEADER_HEIGHT : HEADER_HEIGHT)}px`;
-
-    this.setState({ tableBodyHeight });
+    this.setState({ tableBodyHeight: `${this.tableContainer.offsetHeight}px` });
   };
 
   onSortEnter = i => this.setState({ sortHover: i });
@@ -266,7 +268,7 @@ class Table extends Component {
           rowHeaders={rowHeaders}
           scrollable={scrollable}
           height={tableBodyHeight}
-          onScroll={scrollable && this.handleScroll}
+          onScroll={scrollable ? this.handleScroll : null}
         >
           <StyledTable
             rowHeaders={rowHeaders}

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -114,9 +114,19 @@ const ShadowContainer = styled.div`
  * The position: relative; container is necessary because ShadowContainer
  * is a position: absolute; element
  */
-const TableContainer = styled.div`
+
+const tableContainerBaseStyles = () => css`
   position: relative;
-  height: 100%;
+`;
+const tableContainerScrollableStyles = ({ scrollable }) =>
+  scrollable &&
+  css`
+    height: 100%;
+  `;
+
+const TableContainer = styled.div`
+  ${tableContainerBaseStyles};
+  ${tableContainerScrollableStyles};
 `;
 
 /**
@@ -211,7 +221,7 @@ class Table extends Component {
     const { sortDirection, sortHover, sortedRow, tableBodyHeight } = this.state;
 
     return (
-      <TableContainer ref={this.setTableRef}>
+      <TableContainer ref={this.setTableRef} scrollable={scrollable}>
         <ShadowContainer noShadow={noShadow}>
           <ScrollContainer
             rowHeaders={rowHeaders}
@@ -224,6 +234,7 @@ class Table extends Component {
             >
               <TableHead
                 condensed={condensed}
+                scrollable={scrollable}
                 sortDirection={sortDirection}
                 sortedRow={sortedRow}
                 onSortBy={this.onSortBy}
@@ -234,6 +245,7 @@ class Table extends Component {
               />
               <TableBody
                 condensed={condensed}
+                scrollable={scrollable}
                 rows={this.getSortedRows()}
                 rowHeaders={rowHeaders}
                 sortHover={sortHover}

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -32,6 +32,65 @@ import {
 import { ASCENDING } from './constants';
 import { shadowSingle } from '../../styles/style-helpers';
 
+/**
+ * Table container styles.
+ * The position: relative; container is necessary because ShadowContainer
+ * is a position: absolute; element
+ */
+const tableContainerBaseStyles = () => css`
+  label: table-container;
+  position: relative;
+`;
+const tableContainerScrollableStyles = ({ scrollable, rowHeaders }) =>
+  scrollable &&
+  !rowHeaders &&
+  css`
+    height: 100%;
+  `;
+
+const noShadowStyles = ({ noShadow }) =>
+  noShadow &&
+  css`
+    label: table-container--no-shadow;
+    box-shadow: none;
+  `;
+
+const TableContainer = styled.div`
+  ${tableContainerBaseStyles};
+  ${shadowSingle};
+  ${noShadowStyles};
+  ${tableContainerScrollableStyles};
+`;
+
+/**
+ * Scroll container styles.
+ */
+const containerStyles = ({ theme, rowHeaders }) =>
+  rowHeaders &&
+  css`
+    label: table-container;
+    border-radius: ${theme.borderRadius.mega};
+    ${theme.mq.untilMega} {
+      margin-left: 145px;
+      overflow-x: auto;
+    }
+  `;
+
+const scrollableStyles = ({ scrollable, height }) =>
+  scrollable &&
+  css`
+    height: ${height || '100%'};
+    overflow-y: auto;
+  `;
+
+const ScrollContainer = styled.div`
+  ${containerStyles};
+  ${scrollableStyles};
+`;
+
+/**
+ * Table styles.
+ */
 const baseStyles = ({ theme }) => css`
   label: table;
   background-color: ${theme.colors.white};
@@ -73,59 +132,6 @@ const StyledTable = styled.table`
   ${baseStyles};
   ${responsiveStyles};
   ${borderCollapsedStyles};
-`;
-
-const containerStyles = ({ theme, rowHeaders }) =>
-  rowHeaders &&
-  css`
-    label: table-container;
-    border-radius: ${theme.borderRadius.mega};
-    ${theme.mq.untilMega} {
-      margin-left: 145px;
-      overflow-x: auto;
-    }
-  `;
-
-const scrollableStyles = ({ scrollable, height }) =>
-  scrollable &&
-  css`
-    height: ${height || '100%'};
-    overflow-y: auto;
-  `;
-
-const ScrollContainer = styled.div`
-  ${containerStyles};
-  ${scrollableStyles};
-`;
-
-/**
- * The position: relative; container is necessary because ShadowContainer
- * is a position: absolute; element
- */
-
-const tableContainerBaseStyles = () => css`
-  label: table-container;
-  position: relative;
-`;
-const tableContainerScrollableStyles = ({ scrollable, rowHeaders }) =>
-  scrollable &&
-  !rowHeaders &&
-  css`
-    height: 100%;
-  `;
-
-const noShadowStyles = ({ noShadow }) =>
-  noShadow &&
-  css`
-    label: table-container--no-shadow;
-    box-shadow: none;
-  `;
-
-const TableContainer = styled.div`
-  ${tableContainerBaseStyles};
-  ${shadowSingle};
-  ${noShadowStyles};
-  ${tableContainerScrollableStyles};
 `;
 
 /**
@@ -227,10 +233,6 @@ class Table extends Component {
     return [...rows].sort(sortFn(i), rows);
   };
 
-  setHeadRef = thead => {
-    this.tableHead = thead;
-  };
-
   handleScroll = e => {
     this.setState({ scrollTop: e.target.scrollTop });
   };
@@ -261,17 +263,16 @@ class Table extends Component {
         noShadow={noShadow}
       >
         <ScrollContainer
-          onScroll={scrollable && this.handleScroll}
           rowHeaders={rowHeaders}
           scrollable={scrollable}
           height={tableBodyHeight}
+          onScroll={scrollable && this.handleScroll}
         >
           <StyledTable
             rowHeaders={rowHeaders}
             borderCollapsed={borderCollapsed}
           >
             <TableHead
-              ref={this.setHeadRef}
               top={scrollTop}
               condensed={condensed}
               scrollable={scrollable}

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -19,7 +19,7 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { jsx, css } from '@emotion/core';
-import { throttle } from 'lodash/fp';
+import { isNil, throttle } from 'lodash/fp';
 
 import TableHead from './components/TableHead';
 import TableBody from './components/TableBody';
@@ -148,7 +148,7 @@ class Table extends Component {
   };
 
   componentDidMount() {
-    if (this.props.scrollable && this.props.rowHeaders) {
+    if (this.props.scrollable && !this.props.rowHeaders) {
       this.addVerticalScroll();
     }
   }
@@ -195,7 +195,11 @@ class Table extends Component {
   };
 
   calculateTableBodyHeight = () => {
-    this.setState({ tableBodyHeight: `${this.tableContainer.offsetHeight}px` });
+    this.setState({
+      tableBodyHeight: isNil(this.tableContainer)
+        ? null
+        : `${this.tableContainer.offsetHeight}px`
+    });
   };
 
   onSortEnter = i => this.setState({ sortHover: i });

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -118,8 +118,9 @@ const ShadowContainer = styled.div`
 const tableContainerBaseStyles = () => css`
   position: relative;
 `;
-const tableContainerScrollableStyles = ({ scrollable }) =>
+const tableContainerScrollableStyles = ({ scrollable, rowHeaders }) =>
   scrollable &&
+  !rowHeaders &&
   css`
     height: 100%;
   `;
@@ -137,7 +138,8 @@ class Table extends Component {
     sortedRow: null,
     sortHover: null,
     sortDirection: null,
-    tableBodyHeight: null
+    tableBodyHeight: null,
+    scrollTop: null
   };
 
   componentDidMount() {
@@ -208,6 +210,14 @@ class Table extends Component {
     return [...rows].sort(sortFn(i), rows);
   };
 
+  setHeadRef = thead => {
+    this.tableHead = thead;
+  };
+
+  handleScroll = e => {
+    this.setState({ scrollTop: e.target.scrollTop });
+  };
+
   render() {
     const {
       rowHeaders,
@@ -218,12 +228,23 @@ class Table extends Component {
       scrollable,
       onRowClick
     } = this.props;
-    const { sortDirection, sortHover, sortedRow, tableBodyHeight } = this.state;
+    const {
+      sortDirection,
+      sortHover,
+      sortedRow,
+      tableBodyHeight,
+      scrollTop
+    } = this.state;
 
     return (
-      <TableContainer ref={this.setTableRef} scrollable={scrollable}>
+      <TableContainer
+        ref={this.setTableRef}
+        scrollable={scrollable}
+        rowHeaders={rowHeaders}
+      >
         <ShadowContainer noShadow={noShadow}>
           <ScrollContainer
+            onScroll={scrollable && this.handleScroll}
             rowHeaders={rowHeaders}
             scrollable={scrollable}
             height={tableBodyHeight}
@@ -233,8 +254,11 @@ class Table extends Component {
               borderCollapsed={borderCollapsed}
             >
               <TableHead
+                ref={this.setHeadRef}
+                top={scrollTop}
                 condensed={condensed}
                 scrollable={scrollable}
+                scrollTop={scrollTop}
                 sortDirection={sortDirection}
                 sortedRow={sortedRow}
                 onSortBy={this.onSortBy}

--- a/src/components/Table/Table.spec.js
+++ b/src/components/Table/Table.spec.js
@@ -54,6 +54,18 @@ describe('Table', () => {
       const actual = create(<Table headers={headers} rows={items} condensed />);
       expect(actual).toMatchSnapshot();
     });
+
+    it('should render a scrollable table', () => {
+      const actual = create(
+        <Table headers={headers} rows={items} scrollable rowHeaders={false} />
+      );
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should not render a scrollable table if the rowHeaders prop is true', () => {
+      const actual = create(<Table headers={headers} rows={items} />);
+      expect(actual).toMatchSnapshot();
+    });
   });
 
   describe('Accessibility tests', () => {

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -57,18 +57,6 @@ const rows = [
     { children: '14/01/2017', sortByValue: 2 },
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
-  ],
-  [
-    'Dolor sit amet, consectetur adipiscing',
-    { children: '14/01/2017', sortByValue: 2 },
-    '-',
-    { children: 'Disabled', align: TableCell.RIGHT }
-  ],
-  [
-    'Dolor sit amet, consectetur adipiscing',
-    { children: '14/01/2017', sortByValue: 2 },
-    '-',
-    { children: 'Disabled', align: TableCell.RIGHT }
   ]
 ];
 
@@ -77,12 +65,12 @@ storiesOf(`${GROUPS.COMPONENTS}|Table`, module)
   .add(
     'Table',
     withInfo()(() => (
-      <div style={{ width: '98vw', height: 200 }}>
+      <div style={{ width: '98vw', height: 150 }}>
         <Table
           headers={headers}
           rows={rows}
           rowHeaders={boolean('Mobile rows', true)}
-          condensed={boolean('Condensed', true)}
+          condensed={boolean('Condensed', false)}
           scrollable={boolean('Scrollable', false)}
           noShadow={boolean('Without Shadow', false)}
           onRowClick={action('onRowClick')}

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -83,7 +83,7 @@ storiesOf(`${GROUPS.COMPONENTS}|Table`, module)
           rows={rows}
           rowHeaders={boolean('Mobile rows', true)}
           condensed={boolean('Condensed', true)}
-          scrollable={boolean('Scrollable', true)}
+          scrollable={boolean('Scrollable', false)}
           noShadow={boolean('Without Shadow', false)}
           onRowClick={action('onRowClick')}
           borderCollapsed={boolean('Border collapsed', false)}

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -65,12 +65,13 @@ storiesOf(`${GROUPS.COMPONENTS}|Table`, module)
   .add(
     'Table',
     withInfo()(() => (
-      <div style={{ width: '98vw' }}>
+      <div style={{ width: '98vw', height: 100 }}>
         <Table
           headers={headers}
           rows={rows}
           rowHeaders={boolean('Mobile rows', false)}
-          condensed={boolean('Condensed', false)}
+          condensed={boolean('Condensed', true)}
+          scrollable={boolean('Scrollable', true)}
           noShadow={boolean('Without Shadow', false)}
           onRowClick={action('onRowClick')}
           borderCollapsed={boolean('Border collapsed', false)}

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -57,6 +57,18 @@ const rows = [
     { children: '14/01/2017', sortByValue: 2 },
     '-',
     { children: 'Disabled', align: TableCell.RIGHT }
+  ],
+  [
+    'Dolor sit amet, consectetur adipiscing',
+    { children: '14/01/2017', sortByValue: 2 },
+    '-',
+    { children: 'Disabled', align: TableCell.RIGHT }
+  ],
+  [
+    'Dolor sit amet, consectetur adipiscing',
+    { children: '14/01/2017', sortByValue: 2 },
+    '-',
+    { children: 'Disabled', align: TableCell.RIGHT }
   ]
 ];
 
@@ -65,13 +77,13 @@ storiesOf(`${GROUPS.COMPONENTS}|Table`, module)
   .add(
     'Table',
     withInfo()(() => (
-      <div style={{ width: '98vw', height: 100 }}>
+      <div style={{ width: '98vw', height: 200 }}>
         <Table
           headers={headers}
           rows={rows}
-          rowHeaders={boolean('Mobile rows', false)}
+          rowHeaders={boolean('Mobile rows', true)}
           condensed={boolean('Condensed', true)}
-          scrollable={boolean('Scrollable', true)}
+          scrollable={boolean('Scrollable', false)}
           noShadow={boolean('Without Shadow', false)}
           onRowClick={action('onRowClick')}
           borderCollapsed={boolean('Border collapsed', false)}

--- a/src/components/Table/Table.story.js
+++ b/src/components/Table/Table.story.js
@@ -83,7 +83,7 @@ storiesOf(`${GROUPS.COMPONENTS}|Table`, module)
           rows={rows}
           rowHeaders={boolean('Mobile rows', true)}
           condensed={boolean('Condensed', true)}
-          scrollable={boolean('Scrollable', false)}
+          scrollable={boolean('Scrollable', true)}
           noShadow={boolean('Without Shadow', false)}
           onRowClick={action('onRowClick')}
           borderCollapsed={boolean('Border collapsed', false)}

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table Style tests should render a collapsed table 1`] = `
-.circuit-49 {
+.circuit-51 {
   position: relative;
 }
 
-.circuit-47 {
+.circuit-49 {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-45 {
+.circuit-47 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-45 {
+  .circuit-47 {
     margin-left: 145px;
     overflow-x: auto;
   }
@@ -147,7 +147,7 @@ tbody .circuit-11:last-child td {
   vertical-align: middle;
 }
 
-.circuit-13 {
+.circuit-15 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -158,33 +158,12 @@ tbody .circuit-11:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-13 {
+  .circuit-15 {
     left: 0;
     top: auto;
     position: absolute;
     width: 145px;
     white-space: unset;
-  }
-}
-
-.circuit-15 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-  display: none;
-}
-
-@media (max-width:767px) {
-  .circuit-15 {
-    display: table-cell;
-    min-width: 145px;
-    white-space: unset;
-    width: 145px;
   }
 }
 
@@ -197,9 +176,30 @@ tbody .circuit-11:last-child td {
   transition: background-color 200ms ease-in-out;
   vertical-align: middle;
   white-space: nowrap;
+  display: none;
 }
 
-.circuit-43 {
+@media (max-width:767px) {
+  .circuit-17 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-19 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.circuit-45 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
@@ -207,12 +207,12 @@ tbody .circuit-11:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-43 {
+  .circuit-45 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-43:after {
+  .circuit-45:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -224,18 +224,22 @@ tbody .circuit-11:last-child td {
 }
 
 <div
-  className="circuit-49"
+  className="circuit-51 circuit-52"
 >
   <div
-    className="circuit-47 circuit-48"
+    className="circuit-49 circuit-50"
   >
     <div
-      className="circuit-45 circuit-46"
+      className="circuit-47 circuit-48"
+      height={null}
+      onScroll={false}
     >
       <table
-        className="circuit-43 circuit-44"
+        className="circuit-45 circuit-46"
       >
-        <thead>
+        <thead
+          className="circuit-13 circuit-14"
+        >
           <tr
             className="circuit-11 circuit-12"
           >
@@ -296,25 +300,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -325,25 +329,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -354,25 +358,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -385,38 +389,38 @@ tbody .circuit-11:last-child td {
 `;
 
 exports[`Table Style tests should render a condensed table 1`] = `
-.circuit-49 {
+.circuit-51 {
   position: relative;
 }
 
-.circuit-47 {
+.circuit-49 {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-45 {
+.circuit-47 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-45 {
+  .circuit-47 {
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-43 {
+.circuit-45 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-43 {
+  .circuit-45 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-43:after {
+  .circuit-45:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -455,6 +459,11 @@ tbody .circuit-11:last-child td {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  vertical-align: middle;
+  font-size: 13px;
+  line-height: 20px;
+  padding: 12px 16px;
+  padding: 8px 16px;
 }
 
 @media (max-width:767px) {
@@ -474,47 +483,6 @@ tbody .circuit-11:last-child td {
 
 .circuit-3:hover > button {
   opacity: 1;
-}
-
-.circuit-13 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  white-space: nowrap;
-}
-
-@media (max-width:767px) {
-  .circuit-13 {
-    left: 0;
-    top: auto;
-    position: absolute;
-    width: 145px;
-    white-space: unset;
-  }
-}
-
-.circuit-15 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-  display: none;
-}
-
-@media (max-width:767px) {
-  .circuit-15 {
-    display: table-cell;
-    min-width: 145px;
-    white-space: unset;
-    width: 145px;
-  }
 }
 
 .circuit-1 {
@@ -566,6 +534,9 @@ tbody .circuit-11:last-child td {
   transition: background-color 200ms ease-in-out;
   vertical-align: middle;
   white-space: nowrap;
+  padding: 12px 16px;
+  font-size: 13px;
+  line-height: 20px;
   display: none;
   font-size: 13px;
   font-weight: 700;
@@ -573,6 +544,7 @@ tbody .circuit-11:last-child td {
   padding: 12px 16px;
   font-size: 13px;
   line-height: 20px;
+  padding: 8px 16px;
 }
 
 @media (max-width:767px) {
@@ -598,9 +570,34 @@ tbody .circuit-11:last-child td {
   padding: 8px 24px;
   vertical-align: middle;
   vertical-align: middle;
-  padding: 8px 16px;
   font-size: 13px;
   line-height: 20px;
+  padding: 12px 16px;
+  padding: 8px 16px;
+}
+
+.circuit-15 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  vertical-align: middle;
+  font-size: 13px;
+  line-height: 20px;
+  padding: 12px 16px;
+}
+
+@media (max-width:767px) {
+  .circuit-15 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
 }
 
 .circuit-17 {
@@ -615,21 +612,52 @@ tbody .circuit-11:last-child td {
   padding: 12px 16px;
   font-size: 13px;
   line-height: 20px;
+  display: none;
+  padding: 12px 16px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+@media (max-width:767px) {
+  .circuit-17 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-19 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  padding: 12px 16px;
+  font-size: 13px;
+  line-height: 20px;
 }
 
 <div
-  className="circuit-49"
+  className="circuit-51 circuit-52"
 >
   <div
-    className="circuit-47 circuit-48"
+    className="circuit-49 circuit-50"
   >
     <div
-      className="circuit-45 circuit-46"
+      className="circuit-47 circuit-48"
+      height={null}
+      onScroll={false}
     >
       <table
-        className="circuit-43 circuit-44"
+        className="circuit-45 circuit-46"
       >
-        <thead>
+        <thead
+          className="circuit-13 circuit-14"
+        >
           <tr
             className="circuit-11 circuit-12"
           >
@@ -690,25 +718,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -719,25 +747,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -748,25 +776,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -779,38 +807,38 @@ tbody .circuit-11:last-child td {
 `;
 
 exports[`Table Style tests should render with default styles 1`] = `
-.circuit-49 {
+.circuit-51 {
   position: relative;
 }
 
-.circuit-47 {
+.circuit-49 {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-45 {
+.circuit-47 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-45 {
+  .circuit-47 {
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-43 {
+.circuit-45 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-43 {
+  .circuit-45 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-43:after {
+  .circuit-45:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -948,7 +976,7 @@ tbody .circuit-11:last-child td {
   vertical-align: middle;
 }
 
-.circuit-13 {
+.circuit-15 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -959,33 +987,12 @@ tbody .circuit-11:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-13 {
+  .circuit-15 {
     left: 0;
     top: auto;
     position: absolute;
     width: 145px;
     white-space: unset;
-  }
-}
-
-.circuit-15 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-  display: none;
-}
-
-@media (max-width:767px) {
-  .circuit-15 {
-    display: table-cell;
-    min-width: 145px;
-    white-space: unset;
-    width: 145px;
   }
 }
 
@@ -998,21 +1005,46 @@ tbody .circuit-11:last-child td {
   transition: background-color 200ms ease-in-out;
   vertical-align: middle;
   white-space: nowrap;
+  display: none;
+}
+
+@media (max-width:767px) {
+  .circuit-17 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-19 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 <div
-  className="circuit-49"
+  className="circuit-51 circuit-52"
 >
   <div
-    className="circuit-47 circuit-48"
+    className="circuit-49 circuit-50"
   >
     <div
-      className="circuit-45 circuit-46"
+      className="circuit-47 circuit-48"
+      height={null}
+      onScroll={false}
     >
       <table
-        className="circuit-43 circuit-44"
+        className="circuit-45 circuit-46"
       >
-        <thead>
+        <thead
+          className="circuit-13 circuit-14"
+        >
           <tr
             className="circuit-11 circuit-12"
           >
@@ -1073,25 +1105,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -1102,25 +1134,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -1131,25 +1163,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -1162,38 +1194,38 @@ tbody .circuit-11:last-child td {
 `;
 
 exports[`Table Style tests should render with rowHeader styles 1`] = `
-.circuit-49 {
+.circuit-51 {
   position: relative;
 }
 
-.circuit-47 {
+.circuit-49 {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-45 {
+.circuit-47 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-45 {
+  .circuit-47 {
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-43 {
+.circuit-45 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-43 {
+  .circuit-45 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-43:after {
+  .circuit-45:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -1331,7 +1363,7 @@ tbody .circuit-11:last-child td {
   vertical-align: middle;
 }
 
-.circuit-13 {
+.circuit-15 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1342,33 +1374,12 @@ tbody .circuit-11:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-13 {
+  .circuit-15 {
     left: 0;
     top: auto;
     position: absolute;
     width: 145px;
     white-space: unset;
-  }
-}
-
-.circuit-15 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-  display: none;
-}
-
-@media (max-width:767px) {
-  .circuit-15 {
-    display: table-cell;
-    min-width: 145px;
-    white-space: unset;
-    width: 145px;
   }
 }
 
@@ -1381,21 +1392,46 @@ tbody .circuit-11:last-child td {
   transition: background-color 200ms ease-in-out;
   vertical-align: middle;
   white-space: nowrap;
+  display: none;
+}
+
+@media (max-width:767px) {
+  .circuit-17 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-19 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 <div
-  className="circuit-49"
+  className="circuit-51 circuit-52"
 >
   <div
-    className="circuit-47 circuit-48"
+    className="circuit-49 circuit-50"
   >
     <div
-      className="circuit-45 circuit-46"
+      className="circuit-47 circuit-48"
+      height={null}
+      onScroll={false}
     >
       <table
-        className="circuit-43 circuit-44"
+        className="circuit-45 circuit-46"
       >
-        <thead>
+        <thead
+          className="circuit-13 circuit-14"
+        >
           <tr
             className="circuit-11 circuit-12"
           >
@@ -1456,25 +1492,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -1485,25 +1521,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -1514,25 +1550,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -1545,34 +1581,34 @@ tbody .circuit-11:last-child td {
 `;
 
 exports[`Table Style tests should render without the table shadow 1`] = `
-.circuit-49 {
+.circuit-51 {
   position: relative;
 }
 
-.circuit-45 {
+.circuit-47 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-45 {
+  .circuit-47 {
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-43 {
+.circuit-45 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-43 {
+  .circuit-45 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-43:after {
+  .circuit-45:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -1710,7 +1746,7 @@ tbody .circuit-11:last-child td {
   vertical-align: middle;
 }
 
-.circuit-13 {
+.circuit-15 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1721,33 +1757,12 @@ tbody .circuit-11:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-13 {
+  .circuit-15 {
     left: 0;
     top: auto;
     position: absolute;
     width: 145px;
     white-space: unset;
-  }
-}
-
-.circuit-15 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-  display: none;
-}
-
-@media (max-width:767px) {
-  .circuit-15 {
-    display: table-cell;
-    min-width: 145px;
-    white-space: unset;
-    width: 145px;
   }
 }
 
@@ -1760,26 +1775,51 @@ tbody .circuit-11:last-child td {
   transition: background-color 200ms ease-in-out;
   vertical-align: middle;
   white-space: nowrap;
+  display: none;
 }
 
-.circuit-47 {
+@media (max-width:767px) {
+  .circuit-17 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-19 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.circuit-49 {
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   box-shadow: none;
 }
 
 <div
-  className="circuit-49"
+  className="circuit-51 circuit-52"
 >
   <div
-    className="circuit-47 circuit-48"
+    className="circuit-49 circuit-50"
   >
     <div
-      className="circuit-45 circuit-46"
+      className="circuit-47 circuit-48"
+      height={null}
+      onScroll={false}
     >
       <table
-        className="circuit-43 circuit-44"
+        className="circuit-45 circuit-46"
       >
-        <thead>
+        <thead
+          className="circuit-13 circuit-14"
+        >
           <tr
             className="circuit-11 circuit-12"
           >
@@ -1840,25 +1880,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -1869,25 +1909,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>
@@ -1898,25 +1938,25 @@ tbody .circuit-11:last-child td {
           >
             <th
               aria-sort={null}
-              className="circuit-13 circuit-4"
+              className="circuit-15 circuit-4"
               scope="row"
             >
               1
             </th>
             <td
               aria-hidden="true"
-              className="circuit-15 circuit-6"
+              className="circuit-17 circuit-6"
               role="presentation"
             >
               1
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               2
             </td>
             <td
-              className="circuit-17 circuit-6"
+              className="circuit-19 circuit-6"
             >
               3
             </td>

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`Table Style tests should not render a scrollable table if the rowHeaders prop is true 1`] = `
 .circuit-49 {
   position: relative;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
@@ -12,6 +13,7 @@ exports[`Table Style tests should not render a scrollable table if the rowHeader
 
 @media (max-width:767px) {
   .circuit-47 {
+    height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
@@ -224,7 +226,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height="unset"
+    height={null}
     onScroll={null}
   >
     <table
@@ -383,6 +385,7 @@ tbody .circuit-11:last-child td {
 exports[`Table Style tests should render a collapsed table 1`] = `
 .circuit-49 {
   position: relative;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
@@ -392,6 +395,7 @@ exports[`Table Style tests should render a collapsed table 1`] = `
 
 @media (max-width:767px) {
   .circuit-47 {
+    height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
@@ -605,7 +609,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height="unset"
+    height={null}
     onScroll={null}
   >
     <table
@@ -764,6 +768,7 @@ tbody .circuit-11:last-child td {
 exports[`Table Style tests should render a condensed table 1`] = `
 .circuit-49 {
   position: relative;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
@@ -773,6 +778,7 @@ exports[`Table Style tests should render a condensed table 1`] = `
 
 @media (max-width:767px) {
   .circuit-47 {
+    height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
@@ -1016,7 +1022,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height="unset"
+    height={null}
     onScroll={null}
   >
     <table
@@ -1250,10 +1256,17 @@ tbody .circuit-9:last-child td {
 .circuit-41 {
   position: relative;
   height: 100%;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
+@media (max-width:767px) {
+  .circuit-41 {
+    height: 100%;
+  }
 }
 
 .circuit-39 {
-  height: unset;
+  height: 100%;
   overflow-y: auto;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
@@ -1268,6 +1281,14 @@ tbody .circuit-9:last-child td {
   -webkit-transform: translateY(px);
   -ms-transform: translateY(px);
   transform: translateY(px);
+}
+
+@media (max-width:767px) {
+  .circuit-11 {
+    -webkit-transform: translateY(nullpx);
+    -ms-transform: translateY(nullpx);
+    transform: translateY(nullpx);
+  }
 }
 
 .circuit-3 {
@@ -1305,7 +1326,7 @@ tbody .circuit-9:last-child td {
 >
   <div
     className="circuit-39 circuit-40"
-    height="unset"
+    height={null}
     onScroll={[Function]}
   >
     <table
@@ -1430,6 +1451,7 @@ tbody .circuit-9:last-child td {
 exports[`Table Style tests should render with default styles 1`] = `
 .circuit-49 {
   position: relative;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
@@ -1439,6 +1461,7 @@ exports[`Table Style tests should render with default styles 1`] = `
 
 @media (max-width:767px) {
   .circuit-47 {
+    height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
@@ -1651,7 +1674,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height="unset"
+    height={null}
     onScroll={null}
   >
     <table
@@ -1810,6 +1833,7 @@ tbody .circuit-11:last-child td {
 exports[`Table Style tests should render with rowHeader styles 1`] = `
 .circuit-49 {
   position: relative;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
@@ -1819,6 +1843,7 @@ exports[`Table Style tests should render with rowHeader styles 1`] = `
 
 @media (max-width:767px) {
   .circuit-47 {
+    height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
@@ -2031,7 +2056,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height="unset"
+    height={null}
     onScroll={null}
   >
     <table
@@ -2188,8 +2213,17 @@ tbody .circuit-11:last-child td {
 `;
 
 exports[`Table Style tests should render without the table shadow 1`] = `
-.circuit-49 {
-  position: relative;
+.circuit-47 {
+  border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
+@media (max-width:767px) {
+  .circuit-47 {
+    height: unset;
+    margin-left: 145px;
+    overflow-x: auto;
+  }
 }
 
 .circuit-45 {
@@ -2394,17 +2428,10 @@ tbody .circuit-11:last-child td {
   white-space: nowrap;
 }
 
-.circuit-47 {
-  border-radius: 4px;
+.circuit-49 {
+  position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   box-shadow: none;
-}
-
-@media (max-width:767px) {
-  .circuit-47 {
-    margin-left: 145px;
-    overflow-x: auto;
-  }
 }
 
 <div
@@ -2412,7 +2439,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height="unset"
+    height={null}
     onScroll={null}
   >
     <table

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -3,11 +3,11 @@
 exports[`Table Style tests should not render a scrollable table if the rowHeaders prop is true 1`] = `
 .circuit-49 {
   position: relative;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
   border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 @media (max-width:767px) {
@@ -224,7 +224,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height={null}
+    height="unset"
     onScroll={null}
   >
     <table
@@ -383,11 +383,11 @@ tbody .circuit-11:last-child td {
 exports[`Table Style tests should render a collapsed table 1`] = `
 .circuit-49 {
   position: relative;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
   border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 @media (max-width:767px) {
@@ -605,7 +605,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height={null}
+    height="unset"
     onScroll={null}
   >
     <table
@@ -764,11 +764,11 @@ tbody .circuit-11:last-child td {
 exports[`Table Style tests should render a condensed table 1`] = `
 .circuit-49 {
   position: relative;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
   border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 @media (max-width:767px) {
@@ -1016,7 +1016,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height={null}
+    height="unset"
     onScroll={null}
   >
     <table
@@ -1249,13 +1249,13 @@ tbody .circuit-9:last-child td {
 
 .circuit-41 {
   position: relative;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   height: 100%;
 }
 
 .circuit-39 {
-  height: 100%;
+  height: unset;
   overflow-y: auto;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-37 {
@@ -1305,7 +1305,7 @@ tbody .circuit-9:last-child td {
 >
   <div
     className="circuit-39 circuit-40"
-    height={null}
+    height="unset"
     onScroll={[Function]}
   >
     <table
@@ -1430,11 +1430,11 @@ tbody .circuit-9:last-child td {
 exports[`Table Style tests should render with default styles 1`] = `
 .circuit-49 {
   position: relative;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
   border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 @media (max-width:767px) {
@@ -1651,7 +1651,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height={null}
+    height="unset"
     onScroll={null}
   >
     <table
@@ -1810,11 +1810,11 @@ tbody .circuit-11:last-child td {
 exports[`Table Style tests should render with rowHeader styles 1`] = `
 .circuit-49 {
   position: relative;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 .circuit-47 {
   border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 @media (max-width:767px) {
@@ -2031,7 +2031,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height={null}
+    height="unset"
     onScroll={null}
   >
     <table
@@ -2188,15 +2188,8 @@ tbody .circuit-11:last-child td {
 `;
 
 exports[`Table Style tests should render without the table shadow 1`] = `
-.circuit-47 {
-  border-radius: 4px;
-}
-
-@media (max-width:767px) {
-  .circuit-47 {
-    margin-left: 145px;
-    overflow-x: auto;
-  }
+.circuit-49 {
+  position: relative;
 }
 
 .circuit-45 {
@@ -2401,10 +2394,17 @@ tbody .circuit-11:last-child td {
   white-space: nowrap;
 }
 
-.circuit-49 {
-  position: relative;
+.circuit-47 {
+  border-radius: 4px;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   box-shadow: none;
+}
+
+@media (max-width:767px) {
+  .circuit-47 {
+    margin-left: 145px;
+    overflow-x: auto;
+  }
 }
 
 <div
@@ -2412,7 +2412,7 @@ tbody .circuit-11:last-child td {
 >
   <div
     className="circuit-47 circuit-48"
-    height={null}
+    height="unset"
     onScroll={null}
   >
     <table

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -1,11 +1,388 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Table Style tests should render a collapsed table 1`] = `
-.circuit-51 {
+exports[`Table Style tests should not render a scrollable table if the rowHeaders prop is true 1`] = `
+.circuit-49 {
   position: relative;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
+.circuit-47 {
+  border-radius: 4px;
+}
+
+@media (max-width:767px) {
+  .circuit-47 {
+    margin-left: 145px;
+    overflow-x: auto;
+  }
+}
+
+.circuit-45 {
+  background-color: #FFFFFF;
+  border-collapse: separate;
+  width: 100%;
+}
+
+@media (max-width:767px) {
+  .circuit-45 {
+    margin-left: -145px;
+    width: calc(100% + 145px);
+  }
+
+  .circuit-45:after {
+    content: '';
+    background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
+    height: 100%;
+    left: 145px;
+    position: absolute;
+    top: 0;
+    width: 6px;
+  }
+}
+
+.circuit-11 {
+  vertical-align: middle;
+}
+
+tbody .circuit-11:last-child th,
+tbody .circuit-11:last-child td {
+  border-bottom: none;
+}
+
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media (max-width:767px) {
+  .circuit-3 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  overflow: initial;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 10px;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+  width: 5px;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-5 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+}
+
+@media (max-width:767px) {
+  .circuit-5 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-7 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+}
+
+.circuit-15 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+}
+
+@media (max-width:767px) {
+  .circuit-15 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-17 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+}
+
+@media (max-width:767px) {
+  .circuit-17 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-19 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+<div
+  className="circuit-49 circuit-50"
+>
+  <div
+    className="circuit-47 circuit-48"
+    height={null}
+    onScroll={null}
+  >
+    <table
+      className="circuit-45 circuit-46"
+    >
+      <thead
+        className="circuit-13 circuit-14"
+      >
+        <tr
+          className="circuit-11 circuit-12"
+        >
+          <th
+            aria-sort="none"
+            className="circuit-3 circuit-4"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            scope="col"
+          >
+            <button
+              className="circuit-0 circuit-1 circuit-2"
+              type="button"
+            >
+              <div>
+                arrow.svg
+              </div>
+              <div>
+                arrow.svg
+              </div>
+            </button>
+            Foo
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-5 circuit-6"
+            role="presentation"
+          >
+            Foo
+          </td>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
+            onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
+          >
+            Bar
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
+            onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
+          >
+            Baz
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Table Style tests should render a collapsed table 1`] = `
 .circuit-49 {
+  position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
@@ -224,176 +601,169 @@ tbody .circuit-11:last-child td {
 }
 
 <div
-  className="circuit-51 circuit-52"
+  className="circuit-49 circuit-50"
 >
   <div
-    className="circuit-49 circuit-50"
+    className="circuit-47 circuit-48"
+    height={null}
+    onScroll={null}
   >
-    <div
-      className="circuit-47 circuit-48"
-      height={null}
-      onScroll={false}
+    <table
+      className="circuit-45 circuit-46"
     >
-      <table
-        className="circuit-45 circuit-46"
+      <thead
+        className="circuit-13 circuit-14"
       >
-        <thead
-          className="circuit-13 circuit-14"
+        <tr
+          className="circuit-11 circuit-12"
         >
-          <tr
-            className="circuit-11 circuit-12"
+          <th
+            aria-sort="none"
+            className="circuit-3 circuit-4"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            scope="col"
           >
-            <th
-              aria-sort="none"
-              className="circuit-3 circuit-4"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              scope="col"
+            <button
+              className="circuit-0 circuit-1 circuit-2"
+              type="button"
             >
-              <button
-                className="circuit-0 circuit-1 circuit-2"
-                type="button"
-              >
-                <div>
-                  arrow.svg
-                </div>
-                <div>
-                  arrow.svg
-                </div>
-              </button>
-              Foo
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-5 circuit-6"
-              role="presentation"
-            >
-              Foo
-            </td>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Bar
-            </th>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Baz
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            className="circuit-11 circuit-12"
+              <div>
+                arrow.svg
+              </div>
+              <div>
+                arrow.svg
+              </div>
+            </button>
+            Foo
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-5 circuit-6"
+            role="presentation"
+          >
+            Foo
+          </td>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
+            Bar
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
-            onClick={null}
+            Baz
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
 
 exports[`Table Style tests should render a condensed table 1`] = `
-.circuit-51 {
-  position: relative;
-}
-
 .circuit-49 {
+  position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
@@ -642,176 +1012,424 @@ tbody .circuit-11:last-child td {
 }
 
 <div
-  className="circuit-51 circuit-52"
+  className="circuit-49 circuit-50"
 >
   <div
-    className="circuit-49 circuit-50"
+    className="circuit-47 circuit-48"
+    height={null}
+    onScroll={null}
   >
-    <div
-      className="circuit-47 circuit-48"
-      height={null}
-      onScroll={false}
+    <table
+      className="circuit-45 circuit-46"
     >
-      <table
-        className="circuit-45 circuit-46"
+      <thead
+        className="circuit-13 circuit-14"
       >
-        <thead
-          className="circuit-13 circuit-14"
+        <tr
+          className="circuit-11 circuit-12"
         >
-          <tr
-            className="circuit-11 circuit-12"
+          <th
+            aria-sort="none"
+            className="circuit-3 circuit-4"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            scope="col"
           >
-            <th
-              aria-sort="none"
-              className="circuit-3 circuit-4"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              scope="col"
+            <button
+              className="circuit-0 circuit-1 circuit-2"
+              type="button"
             >
-              <button
-                className="circuit-0 circuit-1 circuit-2"
-                type="button"
-              >
-                <div>
-                  arrow.svg
-                </div>
-                <div>
-                  arrow.svg
-                </div>
-              </button>
-              Foo
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-5 circuit-6"
-              role="presentation"
-            >
-              Foo
-            </td>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Bar
-            </th>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Baz
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            className="circuit-11 circuit-12"
+              <div>
+                arrow.svg
+              </div>
+              <div>
+                arrow.svg
+              </div>
+            </button>
+            Foo
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-5 circuit-6"
+            role="presentation"
+          >
+            Foo
+          </td>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
+            Bar
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
+            Baz
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Table Style tests should render a scrollable table 1`] = `
+.circuit-9 {
+  vertical-align: middle;
+}
+
+tbody .circuit-9:last-child th,
+tbody .circuit-9:last-child td {
+  border-bottom: none;
+}
+
+.circuit-1 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  overflow: initial;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 10px;
+  left: 12px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+  width: 5px;
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  outline: none;
+}
+
+.circuit-1 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-5 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+}
+
+.circuit-13 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.circuit-41 {
+  position: relative;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+  height: 100%;
+}
+
+.circuit-39 {
+  height: 100%;
+  overflow-y: auto;
+}
+
+.circuit-37 {
+  background-color: #FFFFFF;
+  border-collapse: separate;
+  width: 100%;
+}
+
+.circuit-11 {
+  -webkit-transform: translateY(px);
+  -ms-transform: translateY(px);
+  transform: translateY(px);
+}
+
+.circuit-3 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-3:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-3:hover > button {
+  opacity: 1;
+}
+
+<div
+  className="circuit-41 circuit-42"
+>
+  <div
+    className="circuit-39 circuit-40"
+    height={null}
+    onScroll={[Function]}
+  >
+    <table
+      className="circuit-37 circuit-38"
+    >
+      <thead
+        className="circuit-11 circuit-12"
+      >
+        <tr
+          className="circuit-9 circuit-10"
+        >
+          <th
+            aria-sort="none"
+            className="circuit-3 circuit-4"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            scope="col"
+          >
+            <button
+              className="circuit-0 circuit-1 circuit-2"
+              type="button"
             >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
+              <div>
+                arrow.svg
+              </div>
+              <div>
+                arrow.svg
+              </div>
+            </button>
+            Foo
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-5 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            Bar
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-5 circuit-4"
+            onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
+          >
+            Baz
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="circuit-9 circuit-10"
+          onClick={null}
+        >
+          <td
+            className="circuit-13 circuit-14"
+          >
+            1
+          </td>
+          <td
+            className="circuit-13 circuit-14"
+          >
+            2
+          </td>
+          <td
+            className="circuit-13 circuit-14"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-9 circuit-10"
+          onClick={null}
+        >
+          <td
+            className="circuit-13 circuit-14"
+          >
+            1
+          </td>
+          <td
+            className="circuit-13 circuit-14"
+          >
+            2
+          </td>
+          <td
+            className="circuit-13 circuit-14"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-9 circuit-10"
+          onClick={null}
+        >
+          <td
+            className="circuit-13 circuit-14"
+          >
+            1
+          </td>
+          <td
+            className="circuit-13 circuit-14"
+          >
+            2
+          </td>
+          <td
+            className="circuit-13 circuit-14"
+          >
+            3
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
 
 exports[`Table Style tests should render with default styles 1`] = `
-.circuit-51 {
-  position: relative;
-}
-
 .circuit-49 {
+  position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
@@ -1029,176 +1647,169 @@ tbody .circuit-11:last-child td {
 }
 
 <div
-  className="circuit-51 circuit-52"
+  className="circuit-49 circuit-50"
 >
   <div
-    className="circuit-49 circuit-50"
+    className="circuit-47 circuit-48"
+    height={null}
+    onScroll={null}
   >
-    <div
-      className="circuit-47 circuit-48"
-      height={null}
-      onScroll={false}
+    <table
+      className="circuit-45 circuit-46"
     >
-      <table
-        className="circuit-45 circuit-46"
+      <thead
+        className="circuit-13 circuit-14"
       >
-        <thead
-          className="circuit-13 circuit-14"
+        <tr
+          className="circuit-11 circuit-12"
         >
-          <tr
-            className="circuit-11 circuit-12"
+          <th
+            aria-sort="none"
+            className="circuit-3 circuit-4"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            scope="col"
           >
-            <th
-              aria-sort="none"
-              className="circuit-3 circuit-4"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              scope="col"
+            <button
+              className="circuit-0 circuit-1 circuit-2"
+              type="button"
             >
-              <button
-                className="circuit-0 circuit-1 circuit-2"
-                type="button"
-              >
-                <div>
-                  arrow.svg
-                </div>
-                <div>
-                  arrow.svg
-                </div>
-              </button>
-              Foo
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-5 circuit-6"
-              role="presentation"
-            >
-              Foo
-            </td>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Bar
-            </th>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Baz
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            className="circuit-11 circuit-12"
+              <div>
+                arrow.svg
+              </div>
+              <div>
+                arrow.svg
+              </div>
+            </button>
+            Foo
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-5 circuit-6"
+            role="presentation"
+          >
+            Foo
+          </td>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
+            Bar
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
-            onClick={null}
+            Baz
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
 
 exports[`Table Style tests should render with rowHeader styles 1`] = `
-.circuit-51 {
-  position: relative;
-}
-
 .circuit-49 {
+  position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
@@ -1416,175 +2027,167 @@ tbody .circuit-11:last-child td {
 }
 
 <div
-  className="circuit-51 circuit-52"
+  className="circuit-49 circuit-50"
 >
   <div
-    className="circuit-49 circuit-50"
+    className="circuit-47 circuit-48"
+    height={null}
+    onScroll={null}
   >
-    <div
-      className="circuit-47 circuit-48"
-      height={null}
-      onScroll={false}
+    <table
+      className="circuit-45 circuit-46"
     >
-      <table
-        className="circuit-45 circuit-46"
+      <thead
+        className="circuit-13 circuit-14"
       >
-        <thead
-          className="circuit-13 circuit-14"
+        <tr
+          className="circuit-11 circuit-12"
         >
-          <tr
-            className="circuit-11 circuit-12"
+          <th
+            aria-sort="none"
+            className="circuit-3 circuit-4"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            scope="col"
           >
-            <th
-              aria-sort="none"
-              className="circuit-3 circuit-4"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              scope="col"
+            <button
+              className="circuit-0 circuit-1 circuit-2"
+              type="button"
             >
-              <button
-                className="circuit-0 circuit-1 circuit-2"
-                type="button"
-              >
-                <div>
-                  arrow.svg
-                </div>
-                <div>
-                  arrow.svg
-                </div>
-              </button>
-              Foo
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-5 circuit-6"
-              role="presentation"
-            >
-              Foo
-            </td>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Bar
-            </th>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Baz
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            className="circuit-11 circuit-12"
+              <div>
+                arrow.svg
+              </div>
+              <div>
+                arrow.svg
+              </div>
+            </button>
+            Foo
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-5 circuit-6"
+            role="presentation"
+          >
+            Foo
+          </td>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
+            Bar
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
-            onClick={null}
+            Baz
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
 
 exports[`Table Style tests should render without the table shadow 1`] = `
-.circuit-51 {
-  position: relative;
-}
-
 .circuit-47 {
   border-radius: 4px;
 }
@@ -1799,171 +2402,168 @@ tbody .circuit-11:last-child td {
 }
 
 .circuit-49 {
+  position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   box-shadow: none;
 }
 
 <div
-  className="circuit-51 circuit-52"
+  className="circuit-49 circuit-50"
 >
   <div
-    className="circuit-49 circuit-50"
+    className="circuit-47 circuit-48"
+    height={null}
+    onScroll={null}
   >
-    <div
-      className="circuit-47 circuit-48"
-      height={null}
-      onScroll={false}
+    <table
+      className="circuit-45 circuit-46"
     >
-      <table
-        className="circuit-45 circuit-46"
+      <thead
+        className="circuit-13 circuit-14"
       >
-        <thead
-          className="circuit-13 circuit-14"
+        <tr
+          className="circuit-11 circuit-12"
         >
-          <tr
-            className="circuit-11 circuit-12"
+          <th
+            aria-sort="none"
+            className="circuit-3 circuit-4"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            scope="col"
           >
-            <th
-              aria-sort="none"
-              className="circuit-3 circuit-4"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              scope="col"
+            <button
+              className="circuit-0 circuit-1 circuit-2"
+              type="button"
             >
-              <button
-                className="circuit-0 circuit-1 circuit-2"
-                type="button"
-              >
-                <div>
-                  arrow.svg
-                </div>
-                <div>
-                  arrow.svg
-                </div>
-              </button>
-              Foo
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-5 circuit-6"
-              role="presentation"
-            >
-              Foo
-            </td>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Bar
-            </th>
-            <th
-              aria-sort={null}
-              className="circuit-7 circuit-4"
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
-              scope="col"
-            >
-              Baz
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            className="circuit-11 circuit-12"
+              <div>
+                arrow.svg
+              </div>
+              <div>
+                arrow.svg
+              </div>
+            </button>
+            Foo
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-5 circuit-6"
+            role="presentation"
+          >
+            Foo
+          </td>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
+            Bar
+          </th>
+          <th
+            aria-sort={null}
+            className="circuit-7 circuit-4"
             onClick={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            scope="col"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-          <tr
-            className="circuit-11 circuit-12"
-            onClick={null}
+            Baz
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
           >
-            <th
-              aria-sort={null}
-              className="circuit-15 circuit-4"
-              scope="row"
-            >
-              1
-            </th>
-            <td
-              aria-hidden="true"
-              className="circuit-17 circuit-6"
-              role="presentation"
-            >
-              1
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              2
-            </td>
-            <td
-              className="circuit-19 circuit-6"
-            >
-              3
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          className="circuit-11 circuit-12"
+          onClick={null}
+        >
+          <th
+            aria-sort={null}
+            className="circuit-15 circuit-4"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            aria-hidden="true"
+            className="circuit-17 circuit-6"
+            role="presentation"
+          >
+            1
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            2
+          </td>
+          <td
+            className="circuit-19 circuit-6"
+          >
+            3
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;

--- a/src/components/Table/components/TableBody/index.js
+++ b/src/components/Table/components/TableBody/index.js
@@ -51,7 +51,11 @@ const TableBody = ({ rows, condensed, rowHeaders, sortHover, onRowClick }) => (
                   isHovered={sortHover === cellIndex}
                   {...mapCellProps(cell)}
                 />
-                <TableCell role="presentation" aria-hidden="true">
+                <TableCell
+                  role="presentation"
+                  condensed={condensed}
+                  aria-hidden="true"
+                >
                   {getCellChildren(cell)}
                 </TableCell>
               </Fragment>

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -68,15 +68,29 @@ const condensedStyles = ({ condensed, theme }) =>
     ${theme.typography.text.kilo};
   `;
 
+const condensedPresentationStyles = ({ role, header, condensed, theme }) =>
+  condensed &&
+  role === PRESENTATION &&
+  css`
+    label: table-cell-presentation--condensed;
+    padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+    ${theme.typography.text.kilo};
+    ${header &&
+      css`
+        padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+      `}
+  `;
+
 /**
  * TableCell component for the Table. You shouldn't import this component
  * directly, the Table handles it
  */
 const TableCell = styled.td`
   ${baseStyles};
+  ${condensedStyles};
   ${presentationStyles};
   ${hoverStyles};
-  ${condensedStyles};
+  ${condensedPresentationStyles};
 `;
 
 TableCell.LEFT = directions.LEFT;

--- a/src/components/Table/components/TableCell/index.js
+++ b/src/components/Table/components/TableCell/index.js
@@ -77,7 +77,7 @@ const condensedPresentationStyles = ({ role, header, condensed, theme }) =>
     ${theme.typography.text.kilo};
     ${header &&
       css`
-        padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+        padding: ${theme.spacings.byte} ${theme.spacings.mega};
       `}
   `;
 

--- a/src/components/Table/components/TableHead/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableHead/__snapshots__/index.spec.js.snap
@@ -94,7 +94,9 @@ tbody .circuit-9:last-child td {
   vertical-align: middle;
 }
 
-<thead>
+<thead
+  className="circuit-11 circuit-12"
+>
   <tr
     className="circuit-9 circuit-10"
   >
@@ -237,7 +239,9 @@ tbody .circuit-9:last-child td {
   vertical-align: middle;
 }
 
-<thead>
+<thead
+  className="circuit-11 circuit-12"
+>
   <tr
     className="circuit-9 circuit-10"
   >

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -25,9 +25,9 @@ import TableCell from '../TableCell';
 import { mapCellProps, getCellChildren, RowPropType } from '../../utils';
 import { ASCENDING, DESCENDING, TH_KEY_PREFIX } from '../../constants';
 
-const fixedStyles = ({ scrollable, top }) =>
+const fixedStyles = ({ scrollable, top, rowHeaders }) =>
   scrollable &&
-  top &&
+  !rowHeaders &&
   css`
     transform: translateY(${top}px);
   `;
@@ -48,7 +48,7 @@ const TableHead = ({
   onSortEnter,
   onSortLeave
 }) => (
-  <Thead scrollable={scrollable} top={top}>
+  <Thead scrollable={scrollable} top={top} rowHeaders={rowHeaders}>
     {!!headers.length && (
       <TableRow header>
         {headers.map((header, i) => {

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -27,6 +27,7 @@ const TableHead = ({
   headers,
   rowHeaders,
   condensed,
+  scrollable,
   onSortBy,
   sortDirection,
   sortedRow,
@@ -43,6 +44,7 @@ const TableHead = ({
               <TableHeader
                 {...cellProps}
                 condensed={condensed}
+                scrollable={scrollable}
                 fixed={rowHeaders && i === 0}
                 // eslint-disable-next-line react/prop-types
                 onClick={cellProps.sortable ? () => onSortBy(i) : null}
@@ -62,6 +64,7 @@ const TableHead = ({
               {rowHeaders && i === 0 && (
                 <TableCell
                   condensed={condensed}
+                  scrollable={scrollable}
                   role="presentation"
                   aria-hidden="true"
                   header
@@ -91,10 +94,15 @@ TableHead.propTypes = {
    */
   rowHeaders: PropTypes.bool,
   /**
-   * @private Adds condensed styles the table according to the table props.
+   * @private Adds condensed styles the table head according to the table props.
    * Handled internally.
    */
   condensed: PropTypes.bool,
+  /**
+   * @private Adds scrollable styles the table head according to the table props.
+   * Handled internally.
+   */
+  scrollable: PropTypes.bool,
   /**
    * @private sortBy handler
    */

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -29,6 +29,7 @@ const fixedStyles = ({ scrollable, top, rowHeaders }) =>
   scrollable &&
   !rowHeaders &&
   css`
+    label: table-head--fixed;
     transform: translateY(${top}px);
   `;
 

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -25,12 +25,14 @@ import TableCell from '../TableCell';
 import { mapCellProps, getCellChildren, RowPropType } from '../../utils';
 import { ASCENDING, DESCENDING, TH_KEY_PREFIX } from '../../constants';
 
-const fixedStyles = ({ scrollable, top, rowHeaders }) =>
+const fixedStyles = ({ scrollable, top, rowHeaders, theme }) =>
   scrollable &&
-  !rowHeaders &&
   css`
     label: table-head--fixed;
     transform: translateY(${top}px);
+    ${theme.mq.untilMega} {
+      transform: ${rowHeaders ? 'unset' : `translateY(${top}px)`};
+    }
   `;
 
 const Thead = styled.thead`

--- a/src/components/Table/components/TableHead/index.js
+++ b/src/components/Table/components/TableHead/index.js
@@ -16,6 +16,8 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash/fp';
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 
 import TableRow from '../TableRow';
 import TableHeader from '../TableHeader';
@@ -23,18 +25,30 @@ import TableCell from '../TableCell';
 import { mapCellProps, getCellChildren, RowPropType } from '../../utils';
 import { ASCENDING, DESCENDING, TH_KEY_PREFIX } from '../../constants';
 
+const fixedStyles = ({ scrollable, top }) =>
+  scrollable &&
+  top &&
+  css`
+    transform: translateY(${top}px);
+  `;
+
+const Thead = styled.thead`
+  ${fixedStyles}
+`;
+
 const TableHead = ({
   headers,
   rowHeaders,
   condensed,
   scrollable,
+  top,
   onSortBy,
   sortDirection,
   sortedRow,
   onSortEnter,
   onSortLeave
 }) => (
-  <thead>
+  <Thead scrollable={scrollable} top={top}>
     {!!headers.length && (
       <TableRow header>
         {headers.map((header, i) => {
@@ -63,11 +77,11 @@ const TableHead = ({
               />
               {rowHeaders && i === 0 && (
                 <TableCell
+                  header
                   condensed={condensed}
                   scrollable={scrollable}
                   role="presentation"
                   aria-hidden="true"
-                  header
                 >
                   {getCellChildren(header)}
                 </TableCell>
@@ -77,7 +91,7 @@ const TableHead = ({
         })}
       </TableRow>
     )}
-  </thead>
+  </Thead>
 );
 
 /**
@@ -103,6 +117,11 @@ TableHead.propTypes = {
    * Handled internally.
    */
   scrollable: PropTypes.bool,
+  /**
+   * @private The value used to make the thead fixed while scrolling.
+   * Handled internally.
+   */
+  top: PropTypes.number,
   /**
    * @private sortBy handler
    */

--- a/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/index.spec.js.snap
@@ -15,9 +15,10 @@ exports[`TableHeader Style tests should render with condensed styles 1`] = `
   padding: 8px 24px;
   vertical-align: middle;
   vertical-align: middle;
-  padding: 8px 16px;
   font-size: 13px;
   line-height: 20px;
+  padding: 12px 16px;
+  padding: 8px 16px;
 }
 
 <th

--- a/src/components/Table/components/TableHeader/index.js
+++ b/src/components/Table/components/TableHeader/index.js
@@ -95,14 +95,21 @@ const sortableActiveStyles = ({ sortable, isSorted }) =>
     }
   `;
 
-const condensedStyles = ({ condensed, theme, fixed }) =>
+const condensedStyles = ({ condensed, theme }) =>
   condensed &&
-  !fixed &&
   css`
     label: table-header--condensed;
     vertical-align: middle;
-    padding: ${theme.spacings.byte} ${theme.spacings.mega};
     ${theme.typography.text.kilo};
+    padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+  `;
+
+const condensedColStyles = ({ condensed, scope, theme }) =>
+  condensed &&
+  scope === COL &&
+  css`
+    label: table-header-condensed--col;
+    padding: ${theme.spacings.byte} ${theme.spacings.mega};
   `;
 
 const StyledHeader = styled.th`
@@ -113,6 +120,7 @@ const StyledHeader = styled.th`
   ${sortableStyles};
   ${sortableActiveStyles};
   ${condensedStyles};
+  ${condensedColStyles};
 `;
 
 /**


### PR DESCRIPTION
Addresses https://sumupteam.atlassian.net/browse/PMNTSS-14

## Purpose

The purpose is to add a vertical scroll to the Table which is needed mainly for the condensed version.

![final-table](https://user-images.githubusercontent.com/4214288/62613608-754c5f00-b912-11e9-8953-7ea245ab04f1.gif)

## Approach and changes

I've added the prop `scrollable` to the Table which controls the appearance of the vertical scroll. Basically the height of the table body is set to be equal to the height of the container the component lives in. The top of the `TableHead` is calculated when scrolling, so the table header stays fixed. 

NOTE: The `scrollable` prop doesn't work when the `rowHeaders` prop is true. This is done on purpose because `rowHeaders` is usually meant to work on mobile devices where it's better to scroll the whole page instead of scrolling the inner content of the component. I've discussed it with our product designer and we came to the conclusion we could just keep the current behaviour for now. 

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
