### PR TITLE
fix(components): allow Sidebar custom styles with a className prop

### DIFF
--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -57,9 +57,11 @@ const openStyles = ({ theme, open }) =>
 
 const Drawer = styled('div')(baseStyles, openStyles);
 
-const Sidebar = ({ children, open, closeButtonLabel, onClose }) => (
+const Sidebar = ({ children, open, closeButtonLabel, onClose, className }) => (
   <Fragment>
-    <Drawer open={open}>{children}</Drawer>
+    <Drawer open={open} className={className}>
+      {children}
+    </Drawer>
     <Backdrop visible={open} onClick={onClose} />
     <CloseButton
       visible={open}
@@ -85,7 +87,11 @@ Sidebar.propTypes = {
   /**
    * A function to handle the sidebar close
    */
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  /**
+   * A className to allow custom styles with Emotion's css prop
+   */
+  className: PropTypes.string
 };
 
 Sidebar.defaultProps = {


### PR DESCRIPTION
Solves #461

## Purpose

Allow Sidebar custom styles to make the component more flexible for various use cases.

## Approach and changes

Add a className prop to the `Sidebar` component's interface.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
