### PR TITLE
fix(components): center align text inside Badge

### DIFF
--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -84,6 +84,7 @@ const baseStyles = ({ theme, onClick }) => css`
   font-weight: ${theme.fontWeight.bold};
   text-transform: uppercase;
   user-select: none;
+  text-align: center;
 `;
 
 const circleStyles = ({ circle }) =>

--- a/src/components/Badge/__snapshots__/Badge.spec.js.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.js.snap
@@ -15,6 +15,7 @@ exports[`Badge rendering color variations should render with danger colors 1`] =
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  text-align: center;
   background-color: #DB4D4D;
 }
 
@@ -39,6 +40,7 @@ exports[`Badge rendering color variations should render with primary colors 1`] 
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  text-align: center;
   background-color: #3388FF;
 }
 
@@ -63,6 +65,7 @@ exports[`Badge rendering color variations should render with success colors 1`] 
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  text-align: center;
   background-color: #8CC13F;
 }
 
@@ -87,6 +90,7 @@ exports[`Badge rendering color variations should render with warning colors 1`] 
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  text-align: center;
   background-color: #D8A413;
 }
 
@@ -111,6 +115,7 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  text-align: center;
   background-color: #9DA7B1;
 }
 
@@ -144,6 +149,7 @@ exports[`Badge should have the correct circle styles 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  text-align: center;
   background-color: #9DA7B1;
   display: -webkit-box;
   display: -webkit-flex;
@@ -182,6 +188,7 @@ exports[`Badge should render with default styles 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  text-align: center;
   background-color: #9DA7B1;
 }
 


### PR DESCRIPTION
## Purpose

When a badge has a longer label and wraps on multiple lines, it's currently left-aligned:

<img width="200" alt="Captura de tela 2019-09-03 16 14 06" src="https://user-images.githubusercontent.com/11017722/64209881-17ab2400-ce78-11e9-8d19-17c94e61d44d.png">

Instead, the text should be center-aligned:

<img width="188" alt="Captura de tela 2019-09-03 18 25 15" src="https://user-images.githubusercontent.com/11017722/64209927-390c1000-ce78-11e9-9436-de0a22a21c1a.png">

## Approach and changes

- Add styles to center align the text

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
