### PR TITLE
fix(components): Use flexible children prop type for SvgButton

### DIFF
--- a/src/components/SvgButton/SvgButton.js
+++ b/src/components/SvgButton/SvgButton.js
@@ -13,11 +13,12 @@
  * limitations under the License.
  */
 
-import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { size } from 'polished';
 import { withProps } from 'recompose';
+
+import { childrenPropType } from '../../util/shared-prop-types';
 
 const baseStyles = ({ theme }) => css`
   label: svg-button;
@@ -48,7 +49,7 @@ const SvgButton = styled('button')`
 `;
 
 SvgButton.propTypes = {
-  children: PropTypes.element.isRequired
+  children: childrenPropType
 };
 
 /**


### PR DESCRIPTION
## Purpose

The `<SvgButton />` expects a single element as child, however, the `<CloseButton />` in the `<ModalHeader />` has an array of children. This causes the following warning:

```
Warning: Failed prop type: Invalid prop `children` of type `array` supplied to `Styled(button)`, expected a single ReactElement.
          in Styled(button) (created by withProps(Styled(button)))
          in withProps(Styled(button)) (created by Context.Consumer)
          in Styled(withProps(Styled(button))) (created by CloseButton)
          in CloseButton (created by CardHeader)
          in header (created by Context.Consumer)
          in Styled(header) (created by CardHeader)
          in CardHeader (created by ModalHeader)
          in ModalHeader (created by Context.Consumer)
          in WithTheme(ModalHeader)
          in div (created by Context.Consumer)
          in Styled(div) (created by ModalWrapper)
          in ModalWrapper (created by Context.Consumer)
          in WithTheme(ModalWrapper) (created by WrapperComponent)
          in RootFinder (created by WrapperComponent)
          in ThemeProvider (created by WrapperComponent)
          in WrapperComponent
```

## Approach and changes

- Use the more lenient shared children prop type for `<SvgButton />`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
