### PR TITLE
test(configs): include SVG props in snapshots

### DIFF
--- a/jest.fileTransformer.js
+++ b/jest.fileTransformer.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const { basename } = require('path');
 
 module.exports = {
@@ -6,7 +21,7 @@ module.exports = {
     return `
       const React = require('react')
       module.exports = {
-        ReactComponent: () => React.createElement('div', null, '${name}')
+        ReactComponent: props => React.createElement('div', props, '${name}')
       }
     `;
   }

--- a/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
+++ b/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AutoCompleteInput should render with default styles 1`] = `
-.circuit-4 {
+.circuit-5 {
   min-width: 150px;
 }
 
-.circuit-2 {
+.circuit-3 {
   color: #212933;
   display: block;
   position: relative;
@@ -14,6 +14,16 @@ exports[`AutoCompleteInput should render with default styles 1`] = `
 }
 
 .circuit-0 {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  height: 16px;
+  width: 16px;
+  margin: 12px;
+  pointer-events: none;
+}
+
+.circuit-1 {
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -30,43 +40,45 @@ exports[`AutoCompleteInput should render with default styles 1`] = `
   padding-right: calc( 12px + 16px + 12px );
 }
 
-.circuit-0:focus,
-.circuit-0:active {
+.circuit-1:focus,
+.circuit-1:active {
   border: 1px solid #3388FF;
   outline: none;
 }
 
-.circuit-0::-webkit-input-placeholder {
+.circuit-1::-webkit-input-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0::-moz-placeholder {
+.circuit-1::-moz-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0:-ms-input-placeholder {
+.circuit-1:-ms-input-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0::placeholder {
+.circuit-1::placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-0"
+    >
       search.svg
     </div>
     <input
@@ -74,7 +86,7 @@ exports[`AutoCompleteInput should render with default styles 1`] = `
       aria-expanded="false"
       aria-invalid="false"
       autocomplete="off"
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
       id="downshift-0-input"
       role="combobox"
       type="search"

--- a/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
+++ b/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AutoCompleteTags should render with default styles 1`] = `
-.circuit-4 {
+.circuit-5 {
   min-width: 150px;
 }
 
-.circuit-2 {
+.circuit-3 {
   color: #212933;
   display: block;
   position: relative;
@@ -14,6 +14,16 @@ exports[`AutoCompleteTags should render with default styles 1`] = `
 }
 
 .circuit-0 {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  height: 16px;
+  width: 16px;
+  margin: 12px;
+  pointer-events: none;
+}
+
+.circuit-1 {
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -30,43 +40,45 @@ exports[`AutoCompleteTags should render with default styles 1`] = `
   padding-right: calc( 12px + 16px + 12px );
 }
 
-.circuit-0:focus,
-.circuit-0:active {
+.circuit-1:focus,
+.circuit-1:active {
   border: 1px solid #3388FF;
   outline: none;
 }
 
-.circuit-0::-webkit-input-placeholder {
+.circuit-1::-webkit-input-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0::-moz-placeholder {
+.circuit-1::-moz-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0:-ms-input-placeholder {
+.circuit-1:-ms-input-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0::placeholder {
+.circuit-1::placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-0"
+    >
       search.svg
     </div>
     <input
@@ -74,7 +86,7 @@ exports[`AutoCompleteTags should render with default styles 1`] = `
       aria-expanded="false"
       aria-invalid="false"
       autocomplete="off"
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
       id="downshift-0-input"
       role="combobox"
       type="search"

--- a/src/components/CardSchemes/__snapshots__/CardSchemes.spec.js.snap
+++ b/src/components/CardSchemes/__snapshots__/CardSchemes.spec.js.snap
@@ -1,276 +1,376 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CardSchemes should render with default styles 1`] = `
-.circuit-92 {
+.circuit-115 {
   display: block;
   line-height: 0;
   text-align: center;
 }
 
-.circuit-2 {
+.circuit-3 {
   box-sizing: content-box;
   display: inline-block;
   padding: 8px;
 }
 
-.circuit-0 {
+.circuit-1 {
   height: 32px;
   width: auto;
   max-width: 56px;
 }
 
+.circuit-0 {
+  width: auto;
+  max-width: 100%;
+  height: 100%;
+  display: inline-block;
+  line-height: 0;
+}
+
 <ul
-  class="circuit-92 circuit-93"
+  class="circuit-115 circuit-116"
 >
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon amex"
+        class="circuit-0"
+        role="img"
+      >
         amex.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon diners"
+        class="circuit-0"
+        role="img"
+      >
         diners.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon discover"
+        class="circuit-0"
+        role="img"
+      >
         discover.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon ec"
+        class="circuit-0"
+        role="img"
+      >
         ec.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon elo"
+        class="circuit-0"
+        role="img"
+      >
         elo.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon elv"
+        class="circuit-0"
+        role="img"
+      >
         elv.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon hiper"
+        class="circuit-0"
+        role="img"
+      >
         hiper.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon hipercard"
+        class="circuit-0"
+        role="img"
+      >
         hipercard.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon jcb"
+        class="circuit-0"
+        role="img"
+      >
         jcb.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon maestro"
+        class="circuit-0"
+        role="img"
+      >
         maestro.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon mastercard"
+        class="circuit-0"
+        role="img"
+      >
         mastercard.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon visaElectron"
+        class="circuit-0"
+        role="img"
+      >
         visa-electron.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon visa"
+        class="circuit-0"
+        role="img"
+      >
         visa.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon vpay"
+        class="circuit-0"
+        role="img"
+      >
         vpay.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon cash"
+        class="circuit-0"
+        role="img"
+      >
         cash.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon googlePay"
+        class="circuit-0"
+        role="img"
+      >
         google-pay.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon applePay"
+        class="circuit-0"
+        role="img"
+      >
         apple-pay.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon bancoEstado"
+        class="circuit-0"
+        role="img"
+      >
         banco-estado.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon dankort"
+        class="circuit-0"
+        role="img"
+      >
         dankort.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon nfc"
+        class="circuit-0"
+        role="img"
+      >
         nfc.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon unionPay"
+        class="circuit-0"
+        role="img"
+      >
         union-pay.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon redCompra"
+        class="circuit-0"
+        role="img"
+      >
         red-compra.svg
       </div>
     </div>
   </li>
   <li
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
     <div
-      class="circuit-0 circuit-1"
+      class="circuit-1 circuit-2"
     >
-      <div>
+      <div
+        aria-label="icon default"
+        class="circuit-0"
+        role="img"
+      >
         unknown.svg
       </div>
     </div>

--- a/src/components/CardSchemes/components/PaymentMethodIcon/__snapshots__/PaymentMethodIcon.spec.js.snap
+++ b/src/components/CardSchemes/components/PaymentMethodIcon/__snapshots__/PaymentMethodIcon.spec.js.snap
@@ -1,16 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PaymentMethodIcon should render with default styles 1`] = `
-.circuit-0 {
+.circuit-1 {
   height: 16px;
   width: auto;
   max-width: 56px;
 }
 
+.circuit-0 {
+  width: auto;
+  max-width: 100%;
+  height: 100%;
+  display: inline-block;
+  line-height: 0;
+}
+
 <div
-  class="circuit-0 circuit-1"
+  class="circuit-1 circuit-2"
 >
-  <div>
+  <div
+    aria-label="icon visa"
+    class="circuit-0"
+    role="img"
+  >
     visa.svg
   </div>
 </div>

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -143,7 +143,9 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
     name="name"
     value=""
   >
-    <div>
+    <div
+      aria-hidden="true"
+    >
       checked-icon.svg
     </div>
   </label>
@@ -258,7 +260,9 @@ exports[`Checkbox should render with checked styles when passed the checked prop
     name="name"
     value=""
   >
-    <div>
+    <div
+      aria-hidden="true"
+    >
       checked-icon.svg
     </div>
   </label>
@@ -367,7 +371,9 @@ exports[`Checkbox should render with default styles 1`] = `
     name="name"
     value=""
   >
-    <div>
+    <div
+      aria-hidden="true"
+    >
       checked-icon.svg
     </div>
   </label>
@@ -496,7 +502,9 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
     name="name"
     value=""
   >
-    <div>
+    <div
+      aria-hidden="true"
+    >
       checked-icon.svg
     </div>
   </label>
@@ -614,7 +622,9 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
     name="name"
     value=""
   >
-    <div>
+    <div
+      aria-hidden="true"
+    >
       checked-icon.svg
     </div>
   </label>

--- a/src/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -43,7 +43,9 @@ exports[`CloseButton should render with default styles 1`] = `
   class="circuit-2 circuit-3 circuit-4"
   type="button"
 >
-  <div>
+  <div
+    role="presentation"
+  >
     close-icon.svg
   </div>
   <span

--- a/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
+++ b/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
@@ -199,7 +199,10 @@ HTMLCollection [
         data-testid="card-number-input-scheme"
         disabled=""
       >
-        <div>
+        <div
+          aria-label="icon mastercard"
+          role="img"
+        >
           mastercard.svg
         </div>
       </li>
@@ -207,7 +210,10 @@ HTMLCollection [
         class="circuit-6 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon visa"
+          role="img"
+        >
           visa.svg
         </div>
       </li>
@@ -216,7 +222,10 @@ HTMLCollection [
         data-testid="card-number-input-scheme"
         disabled=""
       >
-        <div>
+        <div
+          aria-label="icon diners"
+          role="img"
+        >
           diners.svg
         </div>
       </li>
@@ -225,7 +234,10 @@ HTMLCollection [
         data-testid="card-number-input-scheme"
         disabled=""
       >
-        <div>
+        <div
+          aria-label="icon jcb"
+          role="img"
+        >
           jcb.svg
         </div>
       </li>
@@ -415,7 +427,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon mastercard"
+          role="img"
+        >
           mastercard.svg
         </div>
       </li>
@@ -423,7 +438,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon visa"
+          role="img"
+        >
           visa.svg
         </div>
       </li>
@@ -431,7 +449,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon diners"
+          role="img"
+        >
           diners.svg
         </div>
       </li>
@@ -439,7 +460,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon jcb"
+          role="img"
+        >
           jcb.svg
         </div>
       </li>
@@ -645,7 +669,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon mastercard"
+          role="img"
+        >
           mastercard.svg
         </div>
       </li>
@@ -653,7 +680,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon visa"
+          role="img"
+        >
           visa.svg
         </div>
       </li>
@@ -661,7 +691,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon diners"
+          role="img"
+        >
           diners.svg
         </div>
       </li>
@@ -669,7 +702,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon discover"
+          role="img"
+        >
           discover.svg
         </div>
       </li>
@@ -677,7 +713,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon jcb"
+          role="img"
+        >
           jcb.svg
         </div>
       </li>
@@ -685,7 +724,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon elo"
+          role="img"
+        >
           elo.svg
         </div>
       </li>
@@ -693,7 +735,10 @@ HTMLCollection [
         class="circuit-4 circuit-5"
         data-testid="card-number-input-scheme"
       >
-        <div>
+        <div
+          aria-label="icon maestro"
+          role="img"
+        >
           maestro.svg
         </div>
       </li>

--- a/src/components/InfoIcon/InfoIcon.js
+++ b/src/components/InfoIcon/InfoIcon.js
@@ -32,7 +32,7 @@ const baseStyles = ({ theme }) => css`
  */
 
 const StyledIcon = styled(Icon)(baseStyles);
-const InfoIcon = props => <StyledIcon role="img" {...props} />;
+const InfoIcon = props => <StyledIcon {...props} />;
 
 /**
  * @component

--- a/src/components/InfoIcon/__snapshots__/InfoIcon.spec.js.snap
+++ b/src/components/InfoIcon/__snapshots__/InfoIcon.spec.js.snap
@@ -1,7 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InfoIcon should render with default styles 1`] = `
-<div>
+.circuit-0 {
+  border: 1px solid #9DA7B1;
+  border-radius: 100%;
+  fill: #9DA7B1;
+}
+
+<div
+  class="circuit-0 circuit-1"
+>
   info.svg
 </div>
 `;

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -70,14 +70,14 @@ exports[`Input should prioritize disabled over error styles 1`] = `
 `;
 
 exports[`Input should prioritize disabled over warning styles 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
   margin-bottom: 16px;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -89,6 +89,12 @@ exports[`Input should prioritize disabled over warning styles 1`] = `
   width: 16px;
   margin: 12px;
   pointer-events: none;
+}
+
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 .circuit-0 {
@@ -178,16 +184,19 @@ exports[`Input should prioritize disabled over warning styles 1`] = `
 }
 
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <input
     aria-invalid="true"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       error.svg
     </div>
   </div>
@@ -195,14 +204,14 @@ exports[`Input should prioritize disabled over warning styles 1`] = `
 `;
 
 exports[`Input should prioritize error over optional styles 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
   margin-bottom: 16px;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -214,6 +223,12 @@ exports[`Input should prioritize error over optional styles 1`] = `
   width: 16px;
   margin: 12px;
   pointer-events: none;
+}
+
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 .circuit-0 {
@@ -286,16 +301,19 @@ exports[`Input should prioritize error over optional styles 1`] = `
 }
 
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <input
     aria-invalid="true"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       error.svg
     </div>
   </div>
@@ -893,14 +911,14 @@ exports[`Input should render with inline styles when passed the inline prop 1`] 
 `;
 
 exports[`Input should render with invalid styles when passed the invalid prop 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
   margin-bottom: 16px;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -912,6 +930,12 @@ exports[`Input should render with invalid styles when passed the invalid prop 1`
   width: 16px;
   margin: 12px;
   pointer-events: none;
+}
+
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 .circuit-0 {
@@ -981,16 +1005,19 @@ exports[`Input should render with invalid styles when passed the invalid prop 1`
 }
 
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <input
     aria-invalid="true"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       error.svg
     </div>
   </div>
@@ -1243,7 +1270,7 @@ exports[`Input should render with right aligned text 1`] = `
 `;
 
 exports[`Input should render with valid styles when passed the showValid prop 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
@@ -1296,7 +1323,7 @@ exports[`Input should render with valid styles when passed the showValid prop 1`
   transition: color 200ms ease-in-out;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -1309,17 +1336,26 @@ exports[`Input should render with valid styles when passed the showValid prop 1`
   pointer-events: none;
 }
 
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <input
     aria-invalid="false"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       valid.svg
     </div>
   </div>
@@ -1327,7 +1363,7 @@ exports[`Input should render with valid styles when passed the showValid prop 1`
 `;
 
 exports[`Input should render with warning styles when passed the hasWarning prop 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
@@ -1400,7 +1436,7 @@ exports[`Input should render with warning styles when passed the hasWarning prop
   color: #D8A413;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -1414,17 +1450,26 @@ exports[`Input should render with warning styles when passed the hasWarning prop
   pointer-events: none;
 }
 
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <input
     aria-invalid="false"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       warning.svg
     </div>
   </div>

--- a/src/components/LoadingButton/__snapshots__/LoadingButton.spec.js.snap
+++ b/src/components/LoadingButton/__snapshots__/LoadingButton.spec.js.snap
@@ -1,7 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LoadingButton Style tests should render with default styles 1`] = `
-.circuit-7 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-9 {
   background-color: #FAFBFC;
   border-color: #D8DDE1;
   border-radius: 4px;
@@ -22,32 +36,32 @@ exports[`LoadingButton Style tests should render with default styles 1`] = `
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7:active {
+.circuit-9:active {
   background-color: #D8DDE1;
   border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
-.circuit-7:focus {
+.circuit-9:focus {
   border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
-.circuit-7:hover {
+.circuit-9:hover {
   background-color: #D8DDE1;
 }
 
-.circuit-7:hover,
-.circuit-7:active {
+.circuit-9:hover,
+.circuit-9:active {
   border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7[disabled],
-.circuit-7:disabled {
+.circuit-9[disabled],
+.circuit-9:disabled {
   opacity: 0.4;
   pointer-events: none;
   -webkit-user-selectable: none;
@@ -56,11 +70,11 @@ exports[`LoadingButton Style tests should render with default styles 1`] = `
   user-selectable: none;
 }
 
-.circuit-5 {
+.circuit-7 {
   position: relative;
 }
 
-.circuit-1 {
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -78,7 +92,24 @@ exports[`LoadingButton Style tests should render with default styles 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.circuit-3 {
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
+.circuit-5 {
   opacity: 1;
   -webkit-transform: translate(0,0);
   -ms-transform: translate(0,0);
@@ -89,30 +120,47 @@ exports[`LoadingButton Style tests should render with default styles 1`] = `
 }
 
 <button
-  class="circuit-7 circuit-8"
+  class="circuit-9 circuit-10"
 >
   <div
-    class="circuit-5 circuit-6"
+    class="circuit-7 circuit-8"
   >
     <div
       aria-busy="true"
       aria-live="assertive"
-      class="circuit-0 circuit-1 circuit-2"
+      class="circuit-2 circuit-3 circuit-4"
       role="alert"
     >
-      <div>
+      <div
+        class="circuit-0 circuit-1"
+        dark="0"
+      >
         spinner.svg
       </div>
     </div>
     <div
-      class="circuit-3 circuit-4"
+      class="circuit-5 circuit-6"
     />
   </div>
 </button>
 `;
 
 exports[`LoadingButton Style tests should render with default styles after loading has finished 1`] = `
-.circuit-7 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-9 {
   background-color: #FAFBFC;
   border-color: #D8DDE1;
   border-radius: 4px;
@@ -133,32 +181,32 @@ exports[`LoadingButton Style tests should render with default styles after loadi
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7:active {
+.circuit-9:active {
   background-color: #D8DDE1;
   border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
-.circuit-7:focus {
+.circuit-9:focus {
   border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
-.circuit-7:hover {
+.circuit-9:hover {
   background-color: #D8DDE1;
 }
 
-.circuit-7:hover,
-.circuit-7:active {
+.circuit-9:hover,
+.circuit-9:active {
   border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7[disabled],
-.circuit-7:disabled {
+.circuit-9[disabled],
+.circuit-9:disabled {
   opacity: 0.4;
   pointer-events: none;
   -webkit-user-selectable: none;
@@ -167,11 +215,11 @@ exports[`LoadingButton Style tests should render with default styles after loadi
   user-selectable: none;
 }
 
-.circuit-5 {
+.circuit-7 {
   position: relative;
 }
 
-.circuit-1 {
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -189,7 +237,24 @@ exports[`LoadingButton Style tests should render with default styles after loadi
   transform: translate(-50%,-50%);
 }
 
-.circuit-3 {
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
+.circuit-5 {
   opacity: 1;
   -webkit-transform: translate(0,0);
   -ms-transform: translate(0,0);
@@ -200,34 +265,68 @@ exports[`LoadingButton Style tests should render with default styles after loadi
 }
 
 <button
-  class="circuit-7 circuit-8"
+  class="circuit-9 circuit-10"
 >
   <div
-    class="circuit-5 circuit-6"
+    class="circuit-7 circuit-8"
   >
     <div
       aria-busy="true"
       aria-live="assertive"
-      class="circuit-0 circuit-1 circuit-2"
+      class="circuit-2 circuit-3 circuit-4"
       role="alert"
     >
-      <div>
+      <div
+        class="circuit-0 circuit-1"
+        dark="0"
+      >
         spinner.svg
       </div>
     </div>
     <div
-      class="circuit-3 circuit-4"
+      class="circuit-5 circuit-6"
     />
   </div>
 </button>
 `;
 
 exports[`LoadingButton Style tests should render with loading styles 1`] = `
-.circuit-5 {
-  position: relative;
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
 }
 
 .circuit-7 {
+  position: relative;
+}
+
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
+.circuit-9 {
   background-color: #FAFBFC;
   border-color: #D8DDE1;
   border-radius: 4px;
@@ -250,32 +349,32 @@ exports[`LoadingButton Style tests should render with loading styles 1`] = `
   pointer-events: none;
 }
 
-.circuit-7:active {
+.circuit-9:active {
   background-color: #D8DDE1;
   border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
-.circuit-7:focus {
+.circuit-9:focus {
   border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
-.circuit-7:hover {
+.circuit-9:hover {
   background-color: #D8DDE1;
 }
 
-.circuit-7:hover,
-.circuit-7:active {
+.circuit-9:hover,
+.circuit-9:active {
   border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7[disabled],
-.circuit-7:disabled {
+.circuit-9[disabled],
+.circuit-9:disabled {
   opacity: 0.4;
   pointer-events: none;
   -webkit-user-selectable: none;
@@ -284,7 +383,7 @@ exports[`LoadingButton Style tests should render with loading styles 1`] = `
   user-selectable: none;
 }
 
-.circuit-1 {
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -303,7 +402,7 @@ exports[`LoadingButton Style tests should render with loading styles 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.circuit-3 {
+.circuit-5 {
   opacity: 1;
   -webkit-transform: translate(0,0);
   -ms-transform: translate(0,0);
@@ -318,23 +417,26 @@ exports[`LoadingButton Style tests should render with loading styles 1`] = `
 }
 
 <button
-  class="circuit-7 circuit-8"
+  class="circuit-9 circuit-10"
 >
   <div
-    class="circuit-5 circuit-6"
+    class="circuit-7 circuit-8"
   >
     <div
       aria-busy="true"
       aria-live="assertive"
-      class="circuit-0 circuit-1 circuit-2"
+      class="circuit-2 circuit-3 circuit-4"
       role="alert"
     >
-      <div>
+      <div
+        class="circuit-0 circuit-1"
+        dark="0"
+      >
         spinner.svg
       </div>
     </div>
     <div
-      class="circuit-3 circuit-4"
+      class="circuit-5 circuit-6"
     />
   </div>
 </button>

--- a/src/components/LoadingButton/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/LoadingButton/components/Button/__snapshots__/Button.spec.js.snap
@@ -1,7 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button Style tests should have active loading styles 1`] = `
-.circuit-7 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-9 {
   background-color: #FAFBFC;
   border-color: #D8DDE1;
   border-radius: 4px;
@@ -22,32 +36,32 @@ exports[`Button Style tests should have active loading styles 1`] = `
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7:active {
+.circuit-9:active {
   background-color: #D8DDE1;
   border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
-.circuit-7:focus {
+.circuit-9:focus {
   border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
-.circuit-7:hover {
+.circuit-9:hover {
   background-color: #D8DDE1;
 }
 
-.circuit-7:hover,
-.circuit-7:active {
+.circuit-9:hover,
+.circuit-9:active {
   border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7[disabled],
-.circuit-7:disabled {
+.circuit-9[disabled],
+.circuit-9:disabled {
   opacity: 0.4;
   pointer-events: none;
   -webkit-user-selectable: none;
@@ -56,11 +70,28 @@ exports[`Button Style tests should have active loading styles 1`] = `
   user-selectable: none;
 }
 
-.circuit-5 {
+.circuit-7 {
   position: relative;
 }
 
-.circuit-1 {
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -79,7 +110,7 @@ exports[`Button Style tests should have active loading styles 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.circuit-3 {
+.circuit-5 {
   opacity: 1;
   -webkit-transform: translate(0,0);
   -ms-transform: translate(0,0);
@@ -94,30 +125,47 @@ exports[`Button Style tests should have active loading styles 1`] = `
 }
 
 <button
-  class="circuit-7 circuit-8"
+  class="circuit-9 circuit-10"
 >
   <div
-    class="circuit-5 circuit-6"
+    class="circuit-7 circuit-8"
   >
     <div
       aria-busy="true"
       aria-live="assertive"
-      class="circuit-0 circuit-1 circuit-2"
+      class="circuit-2 circuit-3 circuit-4"
       role="alert"
     >
-      <div>
+      <div
+        class="circuit-0 circuit-1"
+        dark="0"
+      >
         spinner.svg
       </div>
     </div>
     <div
-      class="circuit-3 circuit-4"
+      class="circuit-5 circuit-6"
     />
   </div>
 </button>
 `;
 
 exports[`Button Style tests should have default styles 1`] = `
-.circuit-7 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-9 {
   background-color: #FAFBFC;
   border-color: #D8DDE1;
   border-radius: 4px;
@@ -138,32 +186,32 @@ exports[`Button Style tests should have default styles 1`] = `
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7:active {
+.circuit-9:active {
   background-color: #D8DDE1;
   border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
-.circuit-7:focus {
+.circuit-9:focus {
   border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
-.circuit-7:hover {
+.circuit-9:hover {
   background-color: #D8DDE1;
 }
 
-.circuit-7:hover,
-.circuit-7:active {
+.circuit-9:hover,
+.circuit-9:active {
   border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7[disabled],
-.circuit-7:disabled {
+.circuit-9[disabled],
+.circuit-9:disabled {
   opacity: 0.4;
   pointer-events: none;
   -webkit-user-selectable: none;
@@ -172,11 +220,11 @@ exports[`Button Style tests should have default styles 1`] = `
   user-selectable: none;
 }
 
-.circuit-5 {
+.circuit-7 {
   position: relative;
 }
 
-.circuit-1 {
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -194,7 +242,24 @@ exports[`Button Style tests should have default styles 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.circuit-3 {
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
+.circuit-5 {
   opacity: 1;
   -webkit-transform: translate(0,0);
   -ms-transform: translate(0,0);
@@ -205,34 +270,51 @@ exports[`Button Style tests should have default styles 1`] = `
 }
 
 <button
-  class="circuit-7 circuit-8"
+  class="circuit-9 circuit-10"
 >
   <div
-    class="circuit-5 circuit-6"
+    class="circuit-7 circuit-8"
   >
     <div
       aria-busy="true"
       aria-live="assertive"
-      class="circuit-0 circuit-1 circuit-2"
+      class="circuit-2 circuit-3 circuit-4"
       role="alert"
     >
-      <div>
+      <div
+        class="circuit-0 circuit-1"
+        dark="0"
+      >
         spinner.svg
       </div>
     </div>
     <div
-      class="circuit-3 circuit-4"
+      class="circuit-5 circuit-6"
     />
   </div>
 </button>
 `;
 
 exports[`Button Style tests should have isLoading styles 1`] = `
-.circuit-5 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-7 {
   position: relative;
 }
 
-.circuit-1 {
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -250,7 +332,24 @@ exports[`Button Style tests should have isLoading styles 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.circuit-3 {
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
+.circuit-5 {
   opacity: 1;
   -webkit-transform: translate(0,0);
   -ms-transform: translate(0,0);
@@ -260,7 +359,7 @@ exports[`Button Style tests should have isLoading styles 1`] = `
   transition: opacity 200ms ease-in-out,transform 200ms ease-in-out;
 }
 
-.circuit-7 {
+.circuit-9 {
   background-color: #FAFBFC;
   border-color: #D8DDE1;
   border-radius: 4px;
@@ -283,32 +382,32 @@ exports[`Button Style tests should have isLoading styles 1`] = `
   pointer-events: none;
 }
 
-.circuit-7:active {
+.circuit-9:active {
   background-color: #D8DDE1;
   border-color: #9DA7B1;
   box-shadow: inset 0 4px 8px 0 rgba(12,15,20,0.3);
 }
 
-.circuit-7:focus {
+.circuit-9:focus {
   border-color: #9DA7B1;
   border-width: 2px;
   outline: 0;
   padding: calc(8px - 1px) calc(24px - 1px);
 }
 
-.circuit-7:hover {
+.circuit-9:hover {
   background-color: #D8DDE1;
 }
 
-.circuit-7:hover,
-.circuit-7:active {
+.circuit-9:hover,
+.circuit-9:active {
   border-color: #9DA7B1;
   border-width: 1px;
   padding: calc(8px - 0px) calc(24px - 0px);
 }
 
-.circuit-7[disabled],
-.circuit-7:disabled {
+.circuit-9[disabled],
+.circuit-9:disabled {
   opacity: 0.4;
   pointer-events: none;
   -webkit-user-selectable: none;
@@ -318,23 +417,26 @@ exports[`Button Style tests should have isLoading styles 1`] = `
 }
 
 <button
-  class="circuit-7 circuit-8"
+  class="circuit-9 circuit-10"
 >
   <div
-    class="circuit-5 circuit-6"
+    class="circuit-7 circuit-8"
   >
     <div
       aria-busy="true"
       aria-live="assertive"
-      class="circuit-0 circuit-1 circuit-2"
+      class="circuit-2 circuit-3 circuit-4"
       role="alert"
     >
-      <div>
+      <div
+        class="circuit-0 circuit-1"
+        dark="0"
+      >
         spinner.svg
       </div>
     </div>
     <div
-      class="circuit-3 circuit-4"
+      class="circuit-5 circuit-6"
     />
   </div>
 </button>

--- a/src/components/LoadingButton/components/LoadingIcon/__snapshots__/LoadingIcon.spec.js.snap
+++ b/src/components/LoadingButton/components/LoadingIcon/__snapshots__/LoadingIcon.spec.js.snap
@@ -1,7 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LoadingIcon Style tests should have active LoadingIcon styles 1`] = `
-.circuit-1 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -23,17 +54,34 @@ exports[`LoadingIcon Style tests should have active LoadingIcon styles 1`] = `
 <div
   aria-busy="true"
   aria-live="assertive"
-  class="circuit-0 circuit-1 circuit-2"
+  class="circuit-2 circuit-3 circuit-4"
   role="alert"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+    dark="0"
+  >
     spinner.svg
   </div>
 </div>
 `;
 
 exports[`LoadingIcon Style tests should have disabled LoadingIcon styles 1`] = `
-.circuit-1 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -51,13 +99,33 @@ exports[`LoadingIcon Style tests should have disabled LoadingIcon styles 1`] = `
   transform: translate(-50%,-50%);
 }
 
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
 <div
   aria-busy="true"
   aria-live="assertive"
-  class="circuit-0 circuit-1 circuit-2"
+  class="circuit-2 circuit-3 circuit-4"
   role="alert"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+    dark="0"
+  >
     spinner.svg
   </div>
 </div>
@@ -65,7 +133,21 @@ exports[`LoadingIcon Style tests should have disabled LoadingIcon styles 1`] = `
 
 exports[`LoadingIcon Style tests should have error LoadingIcon styles 1`] = `
 HTMLCollection [
-  .circuit-1 {
+  @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -83,17 +165,53 @@ HTMLCollection [
   transform: translate(-50%,-50%);
 }
 
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
 <div
     aria-busy="true"
     aria-live="assertive"
-    class="circuit-0 circuit-1 circuit-2"
+    class="circuit-2 circuit-3 circuit-4"
     role="alert"
   >
-    <div>
+    <div
+      class="circuit-0 circuit-1"
+      dark="0"
+    >
       spinner.svg
     </div>
   </div>,
-  .circuit-0 {
+  @keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: scale3d(0,0,0);
+    -ms-transform: scale3d(0,0,0);
+    transform: scale3d(0,0,0);
+  }
+
+  100% {
+    opacity: 1;
+    -webkit-transform: scale3d(1,1,1);
+    -ms-transform: scale3d(1,1,1);
+    transform: scale3d(1,1,1);
+  }
+}
+
+.circuit-2 {
   height: 16px;
   width: 16px;
   position: absolute;
@@ -104,10 +222,29 @@ HTMLCollection [
   transform: translate(-50%,-50%);
 }
 
+.circuit-0 {
+  -webkit-transform: scale3d(0,0,0);
+  -ms-transform: scale3d(0,0,0);
+  transform: scale3d(0,0,0);
+  opacity: 0;
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+  height: 100%;
+  width: 100%;
+  -webkit-animation: animation-0 200ms ease-in-out;
+  animation: animation-0 200ms ease-in-out;
+  -webkit-animation-fill-mode: forwards;
+  animation-fill-mode: forwards;
+  -webkit-animation-iteration-count: 1;
+  animation-iteration-count: 1;
+}
+
 <div
-    class="circuit-0 circuit-1"
+    class="circuit-2 circuit-3"
   >
-    <div>
+    <div
+      class="circuit-0 circuit-1"
+    >
       error.svg
     </div>
   </div>,
@@ -115,7 +252,38 @@ HTMLCollection [
 `;
 
 exports[`LoadingIcon Style tests should have giga LoadingIcon styles 1`] = `
-.circuit-1 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -136,17 +304,34 @@ exports[`LoadingIcon Style tests should have giga LoadingIcon styles 1`] = `
 <div
   aria-busy="true"
   aria-live="assertive"
-  class="circuit-0 circuit-1 circuit-2"
+  class="circuit-2 circuit-3 circuit-4"
   role="alert"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+    dark="0"
+  >
     spinner.svg
   </div>
 </div>
 `;
 
 exports[`LoadingIcon Style tests should have kilo LoadingIcon styles 1`] = `
-.circuit-1 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -164,20 +349,71 @@ exports[`LoadingIcon Style tests should have kilo LoadingIcon styles 1`] = `
   transform: translate(-50%,-50%);
 }
 
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
 <div
   aria-busy="true"
   aria-live="assertive"
-  class="circuit-0 circuit-1 circuit-2"
+  class="circuit-2 circuit-3 circuit-4"
   role="alert"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+    dark="0"
+  >
     spinner.svg
   </div>
 </div>
 `;
 
 exports[`LoadingIcon Style tests should have mega LoadingIcon styles 1`] = `
-.circuit-1 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -198,10 +434,13 @@ exports[`LoadingIcon Style tests should have mega LoadingIcon styles 1`] = `
 <div
   aria-busy="true"
   aria-live="assertive"
-  class="circuit-0 circuit-1 circuit-2"
+  class="circuit-2 circuit-3 circuit-4"
   role="alert"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+    dark="0"
+  >
     spinner.svg
   </div>
 </div>
@@ -209,7 +448,21 @@ exports[`LoadingIcon Style tests should have mega LoadingIcon styles 1`] = `
 
 exports[`LoadingIcon Style tests should have success LoadingIcon styles 1`] = `
 HTMLCollection [
-  .circuit-1 {
+  @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-3 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -227,17 +480,53 @@ HTMLCollection [
   transform: translate(-50%,-50%);
 }
 
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
 <div
     aria-busy="true"
     aria-live="assertive"
-    class="circuit-0 circuit-1 circuit-2"
+    class="circuit-2 circuit-3 circuit-4"
     role="alert"
   >
-    <div>
+    <div
+      class="circuit-0 circuit-1"
+      dark="0"
+    >
       spinner.svg
     </div>
   </div>,
-  .circuit-0 {
+  @keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: scale3d(0,0,0);
+    -ms-transform: scale3d(0,0,0);
+    transform: scale3d(0,0,0);
+  }
+
+  100% {
+    opacity: 1;
+    -webkit-transform: scale3d(1,1,1);
+    -ms-transform: scale3d(1,1,1);
+    transform: scale3d(1,1,1);
+  }
+}
+
+.circuit-2 {
   height: 16px;
   width: 16px;
   position: absolute;
@@ -248,10 +537,29 @@ HTMLCollection [
   transform: translate(-50%,-50%);
 }
 
+.circuit-0 {
+  -webkit-transform: scale3d(0,0,0);
+  -ms-transform: scale3d(0,0,0);
+  transform: scale3d(0,0,0);
+  opacity: 0;
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+  height: 100%;
+  width: 100%;
+  -webkit-animation: animation-0 200ms ease-in-out;
+  animation: animation-0 200ms ease-in-out;
+  -webkit-animation-fill-mode: forwards;
+  animation-fill-mode: forwards;
+  -webkit-animation-iteration-count: 1;
+  animation-iteration-count: 1;
+}
+
 <div
-    class="circuit-0 circuit-1"
+    class="circuit-2 circuit-3"
   >
-    <div>
+    <div
+      class="circuit-0 circuit-1"
+    >
       success.svg
     </div>
   </div>,

--- a/src/components/Message/components/Icon/__snapshots__/Icon.spec.js.snap
+++ b/src/components/Message/components/Icon/__snapshots__/Icon.spec.js.snap
@@ -66,7 +66,7 @@ exports[`MessageIcon should render with error icon 1`] = `
 `;
 
 exports[`MessageIcon should render with warning icon 1`] = `
-.circuit-0 {
+.circuit-2 {
   display: block;
   margin-right: 16px;
   -webkit-box-flex: 0;
@@ -79,10 +79,16 @@ exports[`MessageIcon should render with warning icon 1`] = `
   line-height: 0;
 }
 
+.circuit-0 rect {
+  fill: #D8A413;
+}
+
 <div
-  class="circuit-0 circuit-1"
+  class="circuit-2 circuit-3"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+  >
     message-success.svg
   </div>
 </div>

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
@@ -2,6 +2,16 @@
 
 exports[`SearchInput should grey out icon when disabled 1`] = `
 .circuit-0 {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  height: 16px;
+  width: 16px;
+  margin: 12px;
+  pointer-events: none;
+}
+
+.circuit-1 {
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -18,37 +28,37 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
   padding-right: calc( 12px + 16px + 12px );
 }
 
-.circuit-0:focus,
-.circuit-0:active {
+.circuit-1:focus,
+.circuit-1:active {
   border: 1px solid #3388FF;
   outline: none;
 }
 
-.circuit-0::-webkit-input-placeholder {
+.circuit-1::-webkit-input-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0::-moz-placeholder {
+.circuit-1::-moz-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0:-ms-input-placeholder {
+.circuit-1:-ms-input-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0::placeholder {
+.circuit-1::placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-2 {
+.circuit-3 {
   color: #212933;
   display: block;
   position: relative;
@@ -59,15 +69,17 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
 }
 
 <div
-  class="circuit-2 circuit-3"
+  class="circuit-3 circuit-4"
   disabled=""
 >
-  <div>
+  <div
+    class="circuit-0"
+  >
     search.svg
   </div>
   <input
     aria-invalid="false"
-    class="circuit-0 circuit-1"
+    class="circuit-1 circuit-2"
     disabled=""
     type="search"
   />
@@ -75,7 +87,7 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
 `;
 
 exports[`SearchInput should render with default styles 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
@@ -83,6 +95,16 @@ exports[`SearchInput should render with default styles 1`] = `
 }
 
 .circuit-0 {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  height: 16px;
+  width: 16px;
+  margin: 12px;
+  pointer-events: none;
+}
+
+.circuit-1 {
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -99,37 +121,37 @@ exports[`SearchInput should render with default styles 1`] = `
   padding-right: calc( 12px + 16px + 12px );
 }
 
-.circuit-0:focus,
-.circuit-0:active {
+.circuit-1:focus,
+.circuit-1:active {
   border: 1px solid #3388FF;
   outline: none;
 }
 
-.circuit-0::-webkit-input-placeholder {
+.circuit-1::-webkit-input-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0::-moz-placeholder {
+.circuit-1::-moz-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0:-ms-input-placeholder {
+.circuit-1:-ms-input-placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-0::placeholder {
+.circuit-1::placeholder {
   color: #9DA7B1;
   -webkit-transition: color 200ms ease-in-out;
   transition: color 200ms ease-in-out;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -143,18 +165,20 @@ exports[`SearchInput should render with default styles 1`] = `
 }
 
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
-  <div>
+  <div
+    class="circuit-0"
+  >
     search.svg
   </div>
   <input
     aria-invalid="false"
-    class="circuit-0 circuit-1"
+    class="circuit-1 circuit-2"
     type="search"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   />
 </div>
 `;

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -40,6 +40,19 @@ exports[`Select should not render with invalid styles when also passed the disab
 }
 
 .circuit-2 {
+  fill: #5C656F;
+  display: block;
+  z-index: 40;
+  pointer-events: none;
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
+}
+
+.circuit-4 {
   color: #212933;
   display: block;
   position: relative;
@@ -50,7 +63,7 @@ exports[`Select should not render with invalid styles when also passed the disab
 }
 
 <div
-  class="circuit-2 circuit-3"
+  class="circuit-4 circuit-5"
   disabled=""
 >
   <select
@@ -78,18 +91,33 @@ exports[`Select should not render with invalid styles when also passed the disab
       Option 3
     </option>
   </select>
-  <div>
+  <div
+    class="circuit-2 circuit-3"
+  >
     arrows.svg
   </div>
 </div>
 `;
 
 exports[`Select should render with a prefix when passed the prefix prop 1`] = `
-.circuit-3 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
   margin-bottom: 16px;
+}
+
+.circuit-3 {
+  fill: #5C656F;
+  display: block;
+  z-index: 40;
+  pointer-events: none;
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
 }
 
 .circuit-0 {
@@ -144,7 +172,7 @@ exports[`Select should render with a prefix when passed the prefix prop 1`] = `
 }
 
 <div
-  class="circuit-3 circuit-4"
+  class="circuit-5 circuit-6"
 >
   <div
     class="circuit-0"
@@ -174,13 +202,155 @@ exports[`Select should render with a prefix when passed the prefix prop 1`] = `
       Option 3
     </option>
   </select>
-  <div>
+  <div
+    class="circuit-3 circuit-4"
+  >
     arrows.svg
   </div>
 </div>
 `;
 
 exports[`Select should render with a tooltip when passed a validation hint 1`] = `
+.circuit-6 {
+  color: #212933;
+  display: block;
+  position: relative;
+  margin-bottom: 16px;
+}
+
+.circuit-0 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #FFFFFF;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #D8DDE1;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 2px 0 rgba(102,113,123,0.12);
+  color: #212933;
+  padding: 8px 32px 8px 12px;
+  max-height: 42px;
+  position: relative;
+  width: 100%;
+  z-index: 20;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.circuit-0:focus,
+.circuit-0:hover,
+.circuit-0:active {
+  outline: none;
+}
+
+.circuit-0:focus {
+  border-color: #3388FF;
+}
+
+.circuit-0:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.circuit-2 {
+  fill: #5C656F;
+  display: block;
+  z-index: 40;
+  pointer-events: none;
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
+}
+
+.circuit-4 {
+  display: inline-block;
+  width: 100%;
+  max-width: 280px;
+  min-width: 120px;
+  background-color: #212933;
+  color: #FFFFFF;
+  border-radius: 4px;
+  padding: 8px 12px;
+  position: absolute;
+  z-index: 31;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  font-size: 13px;
+  line-height: 20px;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+  right: 50%;
+  right: calc(50% - (16px + 4px));
+  bottom: 100%;
+  bottom: calc(100% + 12px);
+  right: 1px;
+}
+
+.circuit-4::after {
+  display: block;
+  content: '';
+  width: 0;
+  height: 0;
+  position: absolute;
+  border: 8px solid transparent;
+}
+
+.circuit-4::after {
+  right: 12px;
+}
+
+.circuit-4::after {
+  top: 100%;
+  border-top-color: #212933;
+}
+
+<div
+  class="circuit-6 circuit-7"
+>
+  <select
+    class="circuit-0 circuit-1"
+  >
+    <option
+      value=""
+    >
+      Select an option
+    </option>
+    <option
+      value="1"
+    >
+      Option 1
+    </option>
+    <option
+      value="2"
+    >
+      Option 2
+    </option>
+    <option
+      value="3"
+    >
+      Option 3
+    </option>
+  </select>
+  <div
+    class="circuit-2 circuit-3"
+  >
+    arrows.svg
+  </div>
+  <div
+    class="circuit-4 circuit-5"
+  >
+    This field is required.
+  </div>
+</div>
+`;
+
+exports[`Select should render with default styles 1`] = `
 .circuit-4 {
   color: #212933;
   display: block;
@@ -227,44 +397,16 @@ exports[`Select should render with a tooltip when passed a validation hint 1`] =
 }
 
 .circuit-2 {
-  display: inline-block;
-  width: 100%;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
-  border-radius: 4px;
-  padding: 8px 12px;
-  position: absolute;
-  z-index: 31;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  font-size: 13px;
-  line-height: 20px;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
-  right: 50%;
-  right: calc(50% - (16px + 4px));
-  bottom: 100%;
-  bottom: calc(100% + 12px);
-  right: 1px;
-}
-
-.circuit-2::after {
+  fill: #5C656F;
   display: block;
-  content: '';
-  width: 0;
-  height: 0;
+  z-index: 40;
+  pointer-events: none;
   position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-2::after {
-  right: 12px;
-}
-
-.circuit-2::after {
-  top: 100%;
-  border-top-color: #212933;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
 }
 
 <div
@@ -294,91 +436,9 @@ exports[`Select should render with a tooltip when passed a validation hint 1`] =
       Option 3
     </option>
   </select>
-  <div>
-    arrows.svg
-  </div>
   <div
     class="circuit-2 circuit-3"
   >
-    This field is required.
-  </div>
-</div>
-`;
-
-exports[`Select should render with default styles 1`] = `
-.circuit-2 {
-  color: #212933;
-  display: block;
-  position: relative;
-  margin-bottom: 16px;
-}
-
-.circuit-0 {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #FFFFFF;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  box-shadow: inset 0 1px 2px 0 rgba(102,113,123,0.12);
-  color: #212933;
-  padding: 8px 32px 8px 12px;
-  max-height: 42px;
-  position: relative;
-  width: 100%;
-  z-index: 20;
-  overflow-x: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 16px;
-  line-height: 24px;
-}
-
-.circuit-0:focus,
-.circuit-0:hover,
-.circuit-0:active {
-  outline: none;
-}
-
-.circuit-0:focus {
-  border-color: #3388FF;
-}
-
-.circuit-0:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
-<div
-  class="circuit-2 circuit-3"
->
-  <select
-    class="circuit-0 circuit-1"
-  >
-    <option
-      value=""
-    >
-      Select an option
-    </option>
-    <option
-      value="1"
-    >
-      Option 1
-    </option>
-    <option
-      value="2"
-    >
-      Option 2
-    </option>
-    <option
-      value="3"
-    >
-      Option 3
-    </option>
-  </select>
-  <div>
     arrows.svg
   </div>
 </div>
@@ -424,6 +484,19 @@ exports[`Select should render with disabled styles when passed the disabled prop
 }
 
 .circuit-2 {
+  fill: #5C656F;
+  display: block;
+  z-index: 40;
+  pointer-events: none;
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
+}
+
+.circuit-4 {
   color: #212933;
   display: block;
   position: relative;
@@ -434,7 +507,7 @@ exports[`Select should render with disabled styles when passed the disabled prop
 }
 
 <div
-  class="circuit-2 circuit-3"
+  class="circuit-4 circuit-5"
   disabled=""
 >
   <select
@@ -462,7 +535,9 @@ exports[`Select should render with disabled styles when passed the disabled prop
       Option 3
     </option>
   </select>
-  <div>
+  <div
+    class="circuit-2 circuit-3"
+  >
     arrows.svg
   </div>
 </div>
@@ -508,6 +583,19 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
 }
 
 .circuit-2 {
+  fill: #5C656F;
+  display: block;
+  z-index: 40;
+  pointer-events: none;
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
+}
+
+.circuit-4 {
   color: #212933;
   display: block;
   position: relative;
@@ -517,7 +605,7 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
 }
 
 <div
-  class="circuit-2 circuit-3"
+  class="circuit-4 circuit-5"
 >
   <select
     class="circuit-0 circuit-1"
@@ -543,14 +631,16 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
       Option 3
     </option>
   </select>
-  <div>
+  <div
+    class="circuit-2 circuit-3"
+  >
     arrows.svg
   </div>
 </div>
 `;
 
 exports[`Select should render with invalid styles when passed the invalid prop 1`] = `
-.circuit-2 {
+.circuit-6 {
   color: #212933;
   display: block;
   position: relative;
@@ -597,8 +687,35 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
   text-shadow: 0 0 0 #000;
 }
 
+.circuit-2 {
+  fill: #5C656F;
+  display: block;
+  z-index: 40;
+  pointer-events: none;
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
+  right: calc(1px + 24px);
+}
+
+.circuit-4 {
+  fill: #5C656F;
+  display: block;
+  z-index: 40;
+  pointer-events: none;
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
+}
+
 <div
-  class="circuit-2 circuit-3"
+  class="circuit-6 circuit-7"
 >
   <select
     class="circuit-0 circuit-1"
@@ -624,10 +741,14 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
       Option 3
     </option>
   </select>
-  <div>
+  <div
+    class="circuit-2 circuit-3"
+  >
     arrows.svg
   </div>
-  <div>
+  <div
+    class="circuit-4 circuit-5"
+  >
     error.svg
   </div>
 </div>
@@ -673,6 +794,19 @@ exports[`Select should render with no margin styles when passed the noMargin pro
 }
 
 .circuit-2 {
+  fill: #5C656F;
+  display: block;
+  z-index: 40;
+  pointer-events: none;
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
+}
+
+.circuit-4 {
   color: #212933;
   display: block;
   position: relative;
@@ -681,7 +815,7 @@ exports[`Select should render with no margin styles when passed the noMargin pro
 }
 
 <div
-  class="circuit-2 circuit-3"
+  class="circuit-4 circuit-5"
 >
   <select
     class="circuit-0 circuit-1"
@@ -707,7 +841,9 @@ exports[`Select should render with no margin styles when passed the noMargin pro
       Option 3
     </option>
   </select>
-  <div>
+  <div
+    class="circuit-2 circuit-3"
+  >
     arrows.svg
   </div>
 </div>

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -130,7 +130,9 @@ HTMLCollection [
     <span
       class="circuit-0 circuit-1"
     />
-    <div>
+    <div
+      aria-hidden="true"
+    >
       closeIcon.svg
     </div>
   </button>,
@@ -251,7 +253,9 @@ HTMLCollection [
     <span
       class="circuit-0 circuit-1"
     />
-    <div>
+    <div
+      aria-hidden="true"
+    >
       closeIcon.svg
     </div>
   </button>,

--- a/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -57,7 +57,9 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
   <span
     class="circuit-0 circuit-1"
   />
-  <div>
+  <div
+    aria-hidden="true"
+  >
     closeIcon.svg
   </div>
 </button>
@@ -122,7 +124,9 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
   <span
     class="circuit-0 circuit-1"
   />
-  <div>
+  <div
+    aria-hidden="true"
+  >
     closeIcon.svg
   </div>
 </button>

--- a/src/components/Spinner/__snapshots__/Spinner.spec.js.snap
+++ b/src/components/Spinner/__snapshots__/Spinner.spec.js.snap
@@ -1,7 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Spinner should render with dark styles 1`] = `
-.circuit-0 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-2 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -12,20 +40,58 @@ exports[`Spinner should render with dark styles 1`] = `
   opacity: 1;
 }
 
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  fill: #212933;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
 <div
   aria-busy="true"
   aria-live="assertive"
-  class="circuit-0 circuit-1"
+  class="circuit-2 circuit-3"
   role="alert"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+    dark="1"
+  >
     spinner.svg
   </div>
 </div>
 `;
 
 exports[`Spinner should render with default styles 1`] = `
-.circuit-0 {
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate3d(0,0,1,0deg);
+    -ms-transform: rotate3d(0,0,1,0deg);
+    transform: rotate3d(0,0,1,0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate3d(0,0,1,360deg);
+    -ms-transform: rotate3d(0,0,1,360deg);
+    transform: rotate3d(0,0,1,360deg);
+  }
+}
+
+.circuit-2 {
   opacity: 0;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
@@ -36,13 +102,33 @@ exports[`Spinner should render with default styles 1`] = `
   opacity: 1;
 }
 
+.circuit-0 {
+  width: 100%;
+  height: 100%;
+}
+
+.circuit-0 > path {
+  fill: #FFFFFF;
+}
+
+.circuit-0 > path {
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+}
+
 <div
   aria-busy="true"
   aria-live="assertive"
-  class="circuit-0 circuit-1"
+  class="circuit-2 circuit-3"
   role="alert"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+    dark="0"
+  >
     spinner.svg
   </div>
 </div>

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -1,36 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table Style tests should not render a scrollable table if the rowHeaders prop is true 1`] = `
-.circuit-50 {
+.circuit-54 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-48 {
+.circuit-52 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-48 {
+  .circuit-52 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-46 {
+.circuit-50 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-46 {
+  .circuit-50 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-46:after {
+  .circuit-50:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -41,16 +41,16 @@ exports[`Table Style tests should not render a scrollable table if the rowHeader
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   vertical-align: middle;
 }
 
-tbody .circuit-12:last-child th,
-tbody .circuit-12:last-child td {
+tbody .circuit-16:last-child th,
+tbody .circuit-16:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -72,7 +72,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-2 {
+  .circuit-4 {
     left: 0;
     top: auto;
     position: absolute;
@@ -81,16 +81,16 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -112,7 +112,14 @@ tbody .circuit-12:last-child td {
   fill: #3388FF;
 }
 
-.circuit-4 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -128,7 +135,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -136,7 +143,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-8 {
+.circuit-12 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -157,16 +164,16 @@ tbody .circuit-12:last-child td {
   user-select: none;
 }
 
-.circuit-8:hover {
+.circuit-12:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-8:hover > span {
+.circuit-12:hover > span {
   opacity: 1;
 }
 
-.circuit-10 {
+.circuit-14 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -181,7 +188,7 @@ tbody .circuit-12:last-child td {
   vertical-align: middle;
 }
 
-.circuit-16 {
+.circuit-20 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -192,7 +199,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-16 {
+  .circuit-20 {
     left: 0;
     top: auto;
     position: absolute;
@@ -201,7 +208,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-18 {
+.circuit-22 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -214,7 +221,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-18 {
+  .circuit-22 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -222,7 +229,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -234,30 +241,32 @@ tbody .circuit-12:last-child td {
 }
 
 <div
-  class="circuit-50 circuit-51"
+  class="circuit-54 circuit-55"
 >
   <div
-    class="circuit-48 circuit-49"
+    class="circuit-52 circuit-53"
   >
     <table
-      class="circuit-46 circuit-47"
+      class="circuit-50 circuit-51"
     >
       <thead
-        class="circuit-14 circuit-15"
+        class="circuit-18 circuit-19"
       >
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
         >
           <th
             aria-sort="none"
-            class="circuit-2 circuit-3"
+            class="circuit-4 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -268,7 +277,7 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
@@ -276,14 +285,16 @@ tbody .circuit-12:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-8 circuit-3"
+            class="circuit-12 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -293,7 +304,7 @@ tbody .circuit-12:last-child td {
             Numbers
           </th>
           <th
-            class="circuit-10 circuit-3"
+            class="circuit-14 circuit-5"
             data-testid="table-header"
             scope="col"
           >
@@ -303,11 +314,11 @@ tbody .circuit-12:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -315,31 +326,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -347,31 +358,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -379,20 +390,20 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Baz
@@ -405,33 +416,33 @@ tbody .circuit-12:last-child td {
 `;
 
 exports[`Table Style tests should render a collapsed table 1`] = `
-.circuit-50 {
+.circuit-54 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-48 {
+.circuit-52 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-48 {
+  .circuit-52 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   vertical-align: middle;
 }
 
-tbody .circuit-12:last-child th,
-tbody .circuit-12:last-child td {
+tbody .circuit-16:last-child th,
+tbody .circuit-16:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -453,7 +464,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-2 {
+  .circuit-4 {
     left: 0;
     top: auto;
     position: absolute;
@@ -462,16 +473,16 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -493,7 +504,14 @@ tbody .circuit-12:last-child td {
   fill: #3388FF;
 }
 
-.circuit-4 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -509,7 +527,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -517,7 +535,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-8 {
+.circuit-12 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -538,16 +556,16 @@ tbody .circuit-12:last-child td {
   user-select: none;
 }
 
-.circuit-8:hover {
+.circuit-12:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-8:hover > span {
+.circuit-12:hover > span {
   opacity: 1;
 }
 
-.circuit-10 {
+.circuit-14 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -562,7 +580,7 @@ tbody .circuit-12:last-child td {
   vertical-align: middle;
 }
 
-.circuit-16 {
+.circuit-20 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -573,7 +591,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-16 {
+  .circuit-20 {
     left: 0;
     top: auto;
     position: absolute;
@@ -582,7 +600,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-18 {
+.circuit-22 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -595,7 +613,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-18 {
+  .circuit-22 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -603,7 +621,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -614,7 +632,7 @@ tbody .circuit-12:last-child td {
   white-space: nowrap;
 }
 
-.circuit-46 {
+.circuit-50 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
@@ -622,12 +640,12 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-46 {
+  .circuit-50 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-46:after {
+  .circuit-50:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -639,30 +657,32 @@ tbody .circuit-12:last-child td {
 }
 
 <div
-  class="circuit-50 circuit-51"
+  class="circuit-54 circuit-55"
 >
   <div
-    class="circuit-48 circuit-49"
+    class="circuit-52 circuit-53"
   >
     <table
-      class="circuit-46 circuit-47"
+      class="circuit-50 circuit-51"
     >
       <thead
-        class="circuit-14 circuit-15"
+        class="circuit-18 circuit-19"
       >
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
         >
           <th
             aria-sort="none"
-            class="circuit-2 circuit-3"
+            class="circuit-4 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -673,7 +693,7 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
@@ -681,14 +701,16 @@ tbody .circuit-12:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-8 circuit-3"
+            class="circuit-12 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -698,7 +720,7 @@ tbody .circuit-12:last-child td {
             Numbers
           </th>
           <th
-            class="circuit-10 circuit-3"
+            class="circuit-14 circuit-5"
             data-testid="table-header"
             scope="col"
           >
@@ -708,11 +730,11 @@ tbody .circuit-12:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -720,31 +742,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -752,31 +774,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -784,20 +806,20 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Baz
@@ -810,36 +832,36 @@ tbody .circuit-12:last-child td {
 `;
 
 exports[`Table Style tests should render a condensed table 1`] = `
-.circuit-50 {
+.circuit-54 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-48 {
+.circuit-52 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-48 {
+  .circuit-52 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-46 {
+.circuit-50 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-46 {
+  .circuit-50 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-46:after {
+  .circuit-50:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -850,16 +872,23 @@ exports[`Table Style tests should render a condensed table 1`] = `
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   vertical-align: middle;
 }
 
-tbody .circuit-12:last-child th,
-tbody .circuit-12:last-child td {
+tbody .circuit-16:last-child th,
+tbody .circuit-16:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -886,7 +915,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-2 {
+  .circuit-4 {
     left: 0;
     top: auto;
     position: absolute;
@@ -895,16 +924,16 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -927,7 +956,7 @@ tbody .circuit-12:last-child td {
   left: 8px;
 }
 
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -950,7 +979,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -958,7 +987,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-8 {
+.circuit-12 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -984,16 +1013,16 @@ tbody .circuit-12:last-child td {
   padding: 8px 16px;
 }
 
-.circuit-8:hover {
+.circuit-12:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-8:hover > span {
+.circuit-12:hover > span {
   opacity: 1;
 }
 
-.circuit-10 {
+.circuit-14 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1013,7 +1042,7 @@ tbody .circuit-12:last-child td {
   padding: 8px 16px;
 }
 
-.circuit-16 {
+.circuit-20 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1028,7 +1057,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-16 {
+  .circuit-20 {
     left: 0;
     top: auto;
     position: absolute;
@@ -1037,7 +1066,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-18 {
+.circuit-22 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1056,7 +1085,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-18 {
+  .circuit-22 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -1064,7 +1093,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1079,30 +1108,32 @@ tbody .circuit-12:last-child td {
 }
 
 <div
-  class="circuit-50 circuit-51"
+  class="circuit-54 circuit-55"
 >
   <div
-    class="circuit-48 circuit-49"
+    class="circuit-52 circuit-53"
   >
     <table
-      class="circuit-46 circuit-47"
+      class="circuit-50 circuit-51"
     >
       <thead
-        class="circuit-14 circuit-15"
+        class="circuit-18 circuit-19"
       >
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
         >
           <th
             aria-sort="none"
-            class="circuit-2 circuit-3"
+            class="circuit-4 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -1113,7 +1144,7 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
@@ -1121,14 +1152,16 @@ tbody .circuit-12:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-8 circuit-3"
+            class="circuit-12 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -1138,7 +1171,7 @@ tbody .circuit-12:last-child td {
             Numbers
           </th>
           <th
-            class="circuit-10 circuit-3"
+            class="circuit-14 circuit-5"
             data-testid="table-header"
             scope="col"
           >
@@ -1148,11 +1181,11 @@ tbody .circuit-12:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -1160,31 +1193,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -1192,31 +1225,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -1224,20 +1257,20 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Baz
@@ -1250,16 +1283,16 @@ tbody .circuit-12:last-child td {
 `;
 
 exports[`Table Style tests should render a scrollable table 1`] = `
-.circuit-10 {
+.circuit-14 {
   vertical-align: middle;
 }
 
-tbody .circuit-10:last-child th,
-tbody .circuit-10:last-child td {
+tbody .circuit-14:last-child th,
+tbody .circuit-14:last-child td {
   border-bottom: none;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1281,7 +1314,14 @@ tbody .circuit-10:last-child td {
   fill: #3388FF;
 }
 
-.circuit-2 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1302,16 +1342,16 @@ tbody .circuit-10:last-child td {
   user-select: none;
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-8 {
+.circuit-12 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1326,7 +1366,7 @@ tbody .circuit-10:last-child td {
   vertical-align: middle;
 }
 
-.circuit-14 {
+.circuit-18 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1337,69 +1377,71 @@ tbody .circuit-10:last-child td {
   white-space: nowrap;
 }
 
-.circuit-42 {
+.circuit-46 {
   position: relative;
   height: 100%;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 @media (max-width:767px) {
-  .circuit-42 {
+  .circuit-46 {
     height: 100%;
   }
 }
 
-.circuit-38 {
+.circuit-42 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
-.circuit-12 {
+.circuit-16 {
   -webkit-transform: translateY(px);
   -ms-transform: translateY(px);
   transform: translateY(px);
 }
 
 @media (max-width:767px) {
-  .circuit-12 {
+  .circuit-16 {
     -webkit-transform: translateY(nullpx);
     -ms-transform: translateY(nullpx);
     transform: translateY(nullpx);
   }
 }
 
-.circuit-40 {
+.circuit-44 {
   height: 0px;
   overflow-y: auto;
 }
 
 <div
-  class="circuit-42 circuit-43"
+  class="circuit-46 circuit-47"
 >
   <div
-    class="circuit-40 circuit-41"
+    class="circuit-44 circuit-45"
     height="0px"
   >
     <table
-      class="circuit-38 circuit-39"
+      class="circuit-42 circuit-43"
     >
       <thead
-        class="circuit-12 circuit-13"
+        class="circuit-16 circuit-17"
       >
         <tr
-          class="circuit-10 circuit-11"
+          class="circuit-14 circuit-15"
         >
           <th
             aria-sort="none"
-            class="circuit-2 circuit-3"
+            class="circuit-4 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -1410,14 +1452,16 @@ tbody .circuit-10:last-child td {
           </th>
           <th
             aria-sort="none"
-            class="circuit-2 circuit-3"
+            class="circuit-4 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -1427,7 +1471,7 @@ tbody .circuit-10:last-child td {
             Numbers
           </th>
           <th
-            class="circuit-8 circuit-3"
+            class="circuit-12 circuit-5"
             data-testid="table-header"
             scope="col"
           >
@@ -1437,69 +1481,69 @@ tbody .circuit-10:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-10 circuit-11"
+          class="circuit-14 circuit-15"
           data-testid="table-row"
         >
           <td
-            class="circuit-14 circuit-15"
+            class="circuit-18 circuit-19"
             data-testid="table-cell"
           >
             b
           </td>
           <td
-            class="circuit-14 circuit-15"
+            class="circuit-18 circuit-19"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-14 circuit-15"
+            class="circuit-18 circuit-19"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-10 circuit-11"
+          class="circuit-14 circuit-15"
           data-testid="table-row"
         >
           <td
-            class="circuit-14 circuit-15"
+            class="circuit-18 circuit-19"
             data-testid="table-cell"
           >
             a
           </td>
           <td
-            class="circuit-14 circuit-15"
+            class="circuit-18 circuit-19"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-14 circuit-15"
+            class="circuit-18 circuit-19"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-10 circuit-11"
+          class="circuit-14 circuit-15"
           data-testid="table-row"
         >
           <td
-            class="circuit-14 circuit-15"
+            class="circuit-18 circuit-19"
             data-testid="table-cell"
           >
             c
           </td>
           <td
-            class="circuit-14 circuit-15"
+            class="circuit-18 circuit-19"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-14 circuit-15"
+            class="circuit-18 circuit-19"
             data-testid="table-cell"
           >
             Baz
@@ -1512,36 +1556,36 @@ tbody .circuit-10:last-child td {
 `;
 
 exports[`Table Style tests should render with default styles 1`] = `
-.circuit-50 {
+.circuit-54 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-48 {
+.circuit-52 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-48 {
+  .circuit-52 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-46 {
+.circuit-50 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-46 {
+  .circuit-50 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-46:after {
+  .circuit-50:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -1552,16 +1596,16 @@ exports[`Table Style tests should render with default styles 1`] = `
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   vertical-align: middle;
 }
 
-tbody .circuit-12:last-child th,
-tbody .circuit-12:last-child td {
+tbody .circuit-16:last-child th,
+tbody .circuit-16:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1583,7 +1627,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-2 {
+  .circuit-4 {
     left: 0;
     top: auto;
     position: absolute;
@@ -1592,16 +1636,16 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1623,7 +1667,14 @@ tbody .circuit-12:last-child td {
   fill: #3388FF;
 }
 
-.circuit-4 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1639,7 +1690,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -1647,7 +1698,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-8 {
+.circuit-12 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1668,16 +1719,16 @@ tbody .circuit-12:last-child td {
   user-select: none;
 }
 
-.circuit-8:hover {
+.circuit-12:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-8:hover > span {
+.circuit-12:hover > span {
   opacity: 1;
 }
 
-.circuit-10 {
+.circuit-14 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1692,7 +1743,7 @@ tbody .circuit-12:last-child td {
   vertical-align: middle;
 }
 
-.circuit-16 {
+.circuit-20 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1703,7 +1754,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-16 {
+  .circuit-20 {
     left: 0;
     top: auto;
     position: absolute;
@@ -1712,7 +1763,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-18 {
+.circuit-22 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1725,7 +1776,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-18 {
+  .circuit-22 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -1733,7 +1784,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1745,30 +1796,32 @@ tbody .circuit-12:last-child td {
 }
 
 <div
-  class="circuit-50 circuit-51"
+  class="circuit-54 circuit-55"
 >
   <div
-    class="circuit-48 circuit-49"
+    class="circuit-52 circuit-53"
   >
     <table
-      class="circuit-46 circuit-47"
+      class="circuit-50 circuit-51"
     >
       <thead
-        class="circuit-14 circuit-15"
+        class="circuit-18 circuit-19"
       >
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
         >
           <th
             aria-sort="none"
-            class="circuit-2 circuit-3"
+            class="circuit-4 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -1779,7 +1832,7 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
@@ -1787,14 +1840,16 @@ tbody .circuit-12:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-8 circuit-3"
+            class="circuit-12 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -1804,7 +1859,7 @@ tbody .circuit-12:last-child td {
             Numbers
           </th>
           <th
-            class="circuit-10 circuit-3"
+            class="circuit-14 circuit-5"
             data-testid="table-header"
             scope="col"
           >
@@ -1814,11 +1869,11 @@ tbody .circuit-12:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -1826,31 +1881,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -1858,31 +1913,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -1890,20 +1945,20 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Baz
@@ -1916,36 +1971,36 @@ tbody .circuit-12:last-child td {
 `;
 
 exports[`Table Style tests should render with rowHeader styles 1`] = `
-.circuit-50 {
+.circuit-54 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-48 {
+.circuit-52 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-48 {
+  .circuit-52 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-46 {
+.circuit-50 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-46 {
+  .circuit-50 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-46:after {
+  .circuit-50:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -1956,16 +2011,16 @@ exports[`Table Style tests should render with rowHeader styles 1`] = `
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   vertical-align: middle;
 }
 
-tbody .circuit-12:last-child th,
-tbody .circuit-12:last-child td {
+tbody .circuit-16:last-child th,
+tbody .circuit-16:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1987,7 +2042,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-2 {
+  .circuit-4 {
     left: 0;
     top: auto;
     position: absolute;
@@ -1996,16 +2051,16 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2027,7 +2082,14 @@ tbody .circuit-12:last-child td {
   fill: #3388FF;
 }
 
-.circuit-4 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2043,7 +2105,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -2051,7 +2113,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-8 {
+.circuit-12 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2072,16 +2134,16 @@ tbody .circuit-12:last-child td {
   user-select: none;
 }
 
-.circuit-8:hover {
+.circuit-12:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-8:hover > span {
+.circuit-12:hover > span {
   opacity: 1;
 }
 
-.circuit-10 {
+.circuit-14 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2096,7 +2158,7 @@ tbody .circuit-12:last-child td {
   vertical-align: middle;
 }
 
-.circuit-16 {
+.circuit-20 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2107,7 +2169,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-16 {
+  .circuit-20 {
     left: 0;
     top: auto;
     position: absolute;
@@ -2116,7 +2178,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-18 {
+.circuit-22 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2129,7 +2191,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-18 {
+  .circuit-22 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -2137,7 +2199,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2149,30 +2211,32 @@ tbody .circuit-12:last-child td {
 }
 
 <div
-  class="circuit-50 circuit-51"
+  class="circuit-54 circuit-55"
 >
   <div
-    class="circuit-48 circuit-49"
+    class="circuit-52 circuit-53"
   >
     <table
-      class="circuit-46 circuit-47"
+      class="circuit-50 circuit-51"
     >
       <thead
-        class="circuit-14 circuit-15"
+        class="circuit-18 circuit-19"
       >
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
         >
           <th
             aria-sort="none"
-            class="circuit-2 circuit-3"
+            class="circuit-4 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -2183,7 +2247,7 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
@@ -2191,14 +2255,16 @@ tbody .circuit-12:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-8 circuit-3"
+            class="circuit-12 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -2208,7 +2274,7 @@ tbody .circuit-12:last-child td {
             Numbers
           </th>
           <th
-            class="circuit-10 circuit-3"
+            class="circuit-14 circuit-5"
             data-testid="table-header"
             scope="col"
           >
@@ -2218,11 +2284,11 @@ tbody .circuit-12:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -2230,31 +2296,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -2262,31 +2328,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -2294,20 +2360,20 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Baz
@@ -2320,31 +2386,31 @@ tbody .circuit-12:last-child td {
 `;
 
 exports[`Table Style tests should render without the table shadow 1`] = `
-.circuit-48 {
+.circuit-52 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-48 {
+  .circuit-52 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-46 {
+.circuit-50 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-46 {
+  .circuit-50 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-46:after {
+  .circuit-50:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -2355,16 +2421,16 @@ exports[`Table Style tests should render without the table shadow 1`] = `
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   vertical-align: middle;
 }
 
-tbody .circuit-12:last-child th,
-tbody .circuit-12:last-child td {
+tbody .circuit-16:last-child th,
+tbody .circuit-16:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2386,7 +2452,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-2 {
+  .circuit-4 {
     left: 0;
     top: auto;
     position: absolute;
@@ -2395,16 +2461,16 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2426,7 +2492,14 @@ tbody .circuit-12:last-child td {
   fill: #3388FF;
 }
 
-.circuit-4 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2442,7 +2515,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -2450,7 +2523,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-8 {
+.circuit-12 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2471,16 +2544,16 @@ tbody .circuit-12:last-child td {
   user-select: none;
 }
 
-.circuit-8:hover {
+.circuit-12:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-8:hover > span {
+.circuit-12:hover > span {
   opacity: 1;
 }
 
-.circuit-10 {
+.circuit-14 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2495,7 +2568,7 @@ tbody .circuit-12:last-child td {
   vertical-align: middle;
 }
 
-.circuit-16 {
+.circuit-20 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2506,7 +2579,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-16 {
+  .circuit-20 {
     left: 0;
     top: auto;
     position: absolute;
@@ -2515,7 +2588,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-18 {
+.circuit-22 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2528,7 +2601,7 @@ tbody .circuit-12:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-18 {
+  .circuit-22 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -2536,7 +2609,7 @@ tbody .circuit-12:last-child td {
   }
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2547,37 +2620,39 @@ tbody .circuit-12:last-child td {
   white-space: nowrap;
 }
 
-.circuit-50 {
+.circuit-54 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   box-shadow: none;
 }
 
 <div
-  class="circuit-50 circuit-51"
+  class="circuit-54 circuit-55"
 >
   <div
-    class="circuit-48 circuit-49"
+    class="circuit-52 circuit-53"
   >
     <table
-      class="circuit-46 circuit-47"
+      class="circuit-50 circuit-51"
     >
       <thead
-        class="circuit-14 circuit-15"
+        class="circuit-18 circuit-19"
       >
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
         >
           <th
             aria-sort="none"
-            class="circuit-2 circuit-3"
+            class="circuit-4 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -2588,7 +2663,7 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
@@ -2596,14 +2671,16 @@ tbody .circuit-12:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-8 circuit-3"
+            class="circuit-12 circuit-5"
             data-testid="table-header"
             scope="col"
           >
             <span
-              class="circuit-0 circuit-1"
+              class="circuit-2 circuit-3"
             >
-              <div>
+              <div
+                class="circuit-0 circuit-1"
+              >
                 arrow.svg
               </div>
               <div>
@@ -2613,7 +2690,7 @@ tbody .circuit-12:last-child td {
             Numbers
           </th>
           <th
-            class="circuit-10 circuit-3"
+            class="circuit-14 circuit-5"
             data-testid="table-header"
             scope="col"
           >
@@ -2623,11 +2700,11 @@ tbody .circuit-12:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -2635,31 +2712,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -2667,31 +2744,31 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-12 circuit-13"
+          class="circuit-16 circuit-17"
           data-testid="table-row"
         >
           <th
-            class="circuit-16 circuit-3"
+            class="circuit-20 circuit-5"
             data-testid="table-header"
             scope="row"
           >
@@ -2699,20 +2776,20 @@ tbody .circuit-12:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-cell"
           >
             Baz

--- a/src/components/Table/components/SortArrow/__snapshots__/SortArrow.spec.js.snap
+++ b/src/components/Table/components/SortArrow/__snapshots__/SortArrow.spec.js.snap
@@ -33,7 +33,7 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
 `;
 
 exports[`SortArrow Style tests should render with both arrows styles 1`] = `
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -55,10 +55,19 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
   fill: #3388FF;
 }
 
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
 <span
-  class="circuit-0 circuit-1"
+  class="circuit-2 circuit-3"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+  >
     arrow.svg
   </div>
   <div>
@@ -68,7 +77,7 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
 `;
 
 exports[`SortArrow Style tests should render with descending arrow styles 1`] = `
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,10 +99,19 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
   fill: #3388FF;
 }
 
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
 <span
-  class="circuit-0 circuit-1"
+  class="circuit-2 circuit-3"
 >
-  <div>
+  <div
+    class="circuit-0 circuit-1"
+  >
     arrow.svg
   </div>
 </span>

--- a/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
+++ b/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableHead Style tests should render with default styles 1`] = `
-.circuit-8 {
+.circuit-10 {
   vertical-align: middle;
 }
 
-tbody .circuit-8:last-child th,
-tbody .circuit-8:last-child td {
+tbody .circuit-10:last-child th,
+tbody .circuit-10:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -31,16 +31,16 @@ tbody .circuit-8:last-child td {
   user-select: none;
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -62,7 +62,14 @@ tbody .circuit-8:last-child td {
   fill: #3388FF;
 }
 
-.circuit-4 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -78,21 +85,23 @@ tbody .circuit-8:last-child td {
 }
 
 <thead
-  class="circuit-10 circuit-11"
+  class="circuit-12 circuit-13"
 >
   <tr
-    class="circuit-8 circuit-9"
+    class="circuit-10 circuit-11"
   >
     <th
       aria-sort="none"
-      class="circuit-2 circuit-3"
+      class="circuit-4 circuit-5"
       data-testid="table-header"
       scope="col"
     >
       <span
-        class="circuit-0 circuit-1"
+        class="circuit-2 circuit-3"
       >
-        <div>
+        <div
+          class="circuit-0 circuit-1"
+        >
           arrow.svg
         </div>
         <div>
@@ -102,14 +111,14 @@ tbody .circuit-8:last-child td {
       Foo
     </th>
     <th
-      class="circuit-4 circuit-3"
+      class="circuit-6 circuit-5"
       data-testid="table-header"
       scope="col"
     >
       Bar
     </th>
     <th
-      class="circuit-4 circuit-3"
+      class="circuit-6 circuit-5"
       data-testid="table-header"
       scope="col"
     >
@@ -120,16 +129,16 @@ tbody .circuit-8:last-child td {
 `;
 
 exports[`TableHead Style tests should render with rowHeader styles 1`] = `
-.circuit-8 {
+.circuit-10 {
   vertical-align: middle;
 }
 
-tbody .circuit-8:last-child th,
-tbody .circuit-8:last-child td {
+tbody .circuit-10:last-child th,
+tbody .circuit-10:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -150,16 +159,16 @@ tbody .circuit-8:last-child td {
   user-select: none;
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -181,7 +190,14 @@ tbody .circuit-8:last-child td {
   fill: #3388FF;
 }
 
-.circuit-4 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -197,21 +213,23 @@ tbody .circuit-8:last-child td {
 }
 
 <thead
-  class="circuit-10 circuit-11"
+  class="circuit-12 circuit-13"
 >
   <tr
-    class="circuit-8 circuit-9"
+    class="circuit-10 circuit-11"
   >
     <th
       aria-sort="none"
-      class="circuit-2 circuit-3"
+      class="circuit-4 circuit-5"
       data-testid="table-header"
       scope="col"
     >
       <span
-        class="circuit-0 circuit-1"
+        class="circuit-2 circuit-3"
       >
-        <div>
+        <div
+          class="circuit-0 circuit-1"
+        >
           arrow.svg
         </div>
         <div>
@@ -221,14 +239,14 @@ tbody .circuit-8:last-child td {
       Foo
     </th>
     <th
-      class="circuit-4 circuit-3"
+      class="circuit-6 circuit-5"
       data-testid="table-header"
       scope="col"
     >
       Bar
     </th>
     <th
-      class="circuit-4 circuit-3"
+      class="circuit-6 circuit-5"
       data-testid="table-header"
       scope="col"
     >

--- a/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
@@ -102,7 +102,7 @@ exports[`TableHeader Style tests should render with row styles 1`] = `
 `;
 
 exports[`TableHeader Style tests should render with sortable styles 1`] = `
-.circuit-2 {
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -123,16 +123,16 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   user-select: none;
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -154,16 +154,25 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   fill: #3388FF;
 }
 
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
 <th
   aria-sort="none"
-  class="circuit-2 circuit-3"
+  class="circuit-4 circuit-5"
   data-testid="table-header"
   scope="col"
 >
   <span
-    class="circuit-0 circuit-1"
+    class="circuit-2 circuit-3"
   >
-    <div>
+    <div
+      class="circuit-0 circuit-1"
+    >
       arrow.svg
     </div>
     <div>
@@ -249,7 +258,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 `;
 
 exports[`TableHeader Style tests sortable + sorted should render with sortable + sorted descending styles 1`] = `
-.circuit-0 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -271,7 +280,14 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   fill: #3388FF;
 }
 
-.circuit-2 {
+.circuit-0 {
+  margin-top: 2px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.circuit-4 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -292,29 +308,31 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   user-select: none;
 }
 
-.circuit-2:hover {
+.circuit-4:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-2:hover > span {
+.circuit-4:hover > span {
   opacity: 1;
 }
 
-.circuit-2 > span {
+.circuit-4 > span {
   opacity: 1;
 }
 
 <th
   aria-sort="descending"
-  class="circuit-2 circuit-3"
+  class="circuit-4 circuit-5"
   data-testid="table-header"
   scope="col"
 >
   <span
-    class="circuit-0 circuit-1"
+    class="circuit-2 circuit-3"
   >
-    <div>
+    <div
+      class="circuit-0 circuit-1"
+    >
       arrow.svg
     </div>
   </span>

--- a/src/components/Tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.js.snap
@@ -110,7 +110,9 @@ exports[`Tag when is selected should change the close icon color 1`] = `
     data-testid="tag-close"
     type="button"
   >
-    <div>
+    <div
+      role="presentation"
+    >
       close-icon.svg
     </div>
     <span

--- a/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
@@ -72,14 +72,14 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
 `;
 
 exports[`TextArea should prioritize disabled over warning styles 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
   margin-bottom: 16px;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -91,6 +91,12 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
   width: 16px;
   margin: 12px;
   pointer-events: none;
+}
+
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 .circuit-0 {
@@ -182,16 +188,19 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
 }
 
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <textarea
     aria-invalid="true"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       error.svg
     </div>
   </div>
@@ -199,14 +208,14 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
 `;
 
 exports[`TextArea should prioritize error over optional styles 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
   margin-bottom: 16px;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -218,6 +227,12 @@ exports[`TextArea should prioritize error over optional styles 1`] = `
   width: 16px;
   margin: 12px;
   pointer-events: none;
+}
+
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 .circuit-0 {
@@ -292,16 +307,19 @@ exports[`TextArea should prioritize error over optional styles 1`] = `
 }
 
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <textarea
     aria-invalid="true"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       error.svg
     </div>
   </div>
@@ -838,14 +856,14 @@ exports[`TextArea should render with inline styles when passed the inline prop 1
 `;
 
 exports[`TextArea should render with invalid styles when passed the invalid prop 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
   margin-bottom: 16px;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -857,6 +875,12 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
   width: 16px;
   margin: 12px;
   pointer-events: none;
+}
+
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 .circuit-0 {
@@ -928,16 +952,19 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
 }
 
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <textarea
     aria-invalid="true"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       error.svg
     </div>
   </div>
@@ -1113,7 +1140,7 @@ exports[`TextArea should render with optional styles when passed the optional pr
 `;
 
 exports[`TextArea should render with valid styles when passed the showValid prop 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
@@ -1168,7 +1195,7 @@ exports[`TextArea should render with valid styles when passed the showValid prop
   transition: color 200ms ease-in-out;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -1181,17 +1208,26 @@ exports[`TextArea should render with valid styles when passed the showValid prop
   pointer-events: none;
 }
 
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <textarea
     aria-invalid="false"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       valid.svg
     </div>
   </div>
@@ -1199,7 +1235,7 @@ exports[`TextArea should render with valid styles when passed the showValid prop
 `;
 
 exports[`TextArea should render with warning styles when passed the hasWarning prop 1`] = `
-.circuit-4 {
+.circuit-5 {
   color: #212933;
   display: block;
   position: relative;
@@ -1274,7 +1310,7 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
   color: #D8A413;
 }
 
-.circuit-2 {
+.circuit-3 {
   opacity: 0;
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
@@ -1288,17 +1324,26 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
   pointer-events: none;
 }
 
+.circuit-2 {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
 <div
-  class="circuit-4 circuit-5"
+  class="circuit-5 circuit-6"
 >
   <textarea
     aria-invalid="false"
     class="circuit-0 circuit-1"
   />
   <div
-    class="circuit-2 circuit-3"
+    class="circuit-3 circuit-4"
   >
-    <div>
+    <div
+      class="circuit-2"
+      role="img"
+    >
       warning.svg
     </div>
   </div>


### PR DESCRIPTION
Follow up to #471.

## Purpose

SVGs are inlined as React components. In Jest, they are mocked as simple `<div />`s with the filename inside. The mock `<div />` should behave as much as possible like the real SVG. 

## Approach and changes

- Pass props to the mock `<div />`
- Update snapshots (most added LOCs are SVG styles that were missing before)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
