### PR TITLE
fix(components): sort Table rows with nested cells

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -228,7 +228,7 @@ class Table extends Component {
   defaultSortBy = (i, direction, rows) => {
     const sortFn = direction === ASCENDING ? ascendingSort : descendingSort;
 
-    return [...rows].sort(sortFn(i), rows);
+    return [...rows].sort(sortFn(i));
   };
 
   handleScroll = e => {
@@ -252,6 +252,8 @@ class Table extends Component {
       scrollTop,
       tableBodyHeight
     } = this.state;
+
+    const rows = this.getSortedRows();
 
     return (
       <TableContainer
@@ -286,7 +288,7 @@ class Table extends Component {
             <TableBody
               condensed={condensed}
               scrollable={scrollable}
-              rows={this.getSortedRows()}
+              rows={rows}
               rowHeaders={rowHeaders}
               sortHover={sortHover}
               onRowClick={onRowClick}

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -20,6 +20,8 @@ import { childrenPropType } from '../../util/shared-prop-types';
 
 export const mapRowProps = props => (isArray(props) ? { cells: props } : props);
 
+export const getRowCells = props => mapRowProps(props).cells;
+
 export const mapCellProps = props =>
   isString(props) || isNumber(props) ? { children: props } : props;
 
@@ -39,8 +41,10 @@ export const getSortDirection = (isActive, currentSort) => {
 };
 
 export const ascendingSort = curry((i, a, b) => {
-  const first = getSortByValue(a[i]);
-  const second = getSortByValue(b[i]);
+  const firstRow = getRowCells(a);
+  const secondRow = getRowCells(b);
+  const first = getSortByValue(firstRow[i]);
+  const second = getSortByValue(secondRow[i]);
 
   if (first < second) {
     return -1;
@@ -53,8 +57,10 @@ export const ascendingSort = curry((i, a, b) => {
 });
 
 export const descendingSort = curry((i, a, b) => {
-  const first = getSortByValue(a[i]);
-  const second = getSortByValue(b[i]);
+  const firstRow = getRowCells(a);
+  const secondRow = getRowCells(b);
+  const first = getSortByValue(firstRow[i]);
+  const second = getSortByValue(secondRow[i]);
 
   if (first > second) {
     return -1;

--- a/src/components/Table/utils.spec.js
+++ b/src/components/Table/utils.spec.js
@@ -36,6 +36,27 @@ describe('Table utils', () => {
       expect(actual).toEqual(expected);
     });
   });
+
+  describe('getRowCells()', () => {
+    describe('isArray', () => {
+      it('should return it', () => {
+        const props = ['Foo'];
+        const expected = props;
+        const actual = utils.getRowCells(props);
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    it('should return the cells prop', () => {
+      const props = { cells: ['Foo'] };
+      const expected = ['Foo'];
+      const actual = utils.getRowCells(props);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
   describe('mapCellProps()', () => {
     describe('isString', () => {
       it('should map the string to children key', () => {


### PR DESCRIPTION
## Purpose

#423 broke Table sorting when a row included its cells as a nested prop, e.g.: 

```js
  const row = {
    cells: [
      'Lorem ipsum dolor',
      {
        children: '12/01/2017',
        sortByValue: 0,
        'data-selector': 'item-1-cell-date-12/01/2017'
      },
      '-',
      { children: 'Disabled', align: TableCell.RIGHT }
    ],
    'data-selector': 'item-1'
  };
```

## Approach and changes

- Get the `cells` before sorting the column

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
