### PR TITLE
fix(components): minor fixes for ListItem, Tabs and Table components

### DIFF
--- a/src/components/CardList/__snapshots__/CardList.spec.js.snap
+++ b/src/components/CardList/__snapshots__/CardList.spec.js.snap
@@ -83,6 +83,7 @@ exports[`CardList should render with default styles 1`] = `
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
   background: #EDF4FC;
+  color: #003C8B;
 }
 
 .circuit-2:first-child {

--- a/src/components/CardList/components/Item/Item.js
+++ b/src/components/CardList/components/Item/Item.js
@@ -63,7 +63,7 @@ const selectedStyles = ({ theme, selected }) =>
     label: cardlist__item--selected;
 
     background: ${theme.colors.p100};
-    color: ${theme.colors.b900};
+    color: ${theme.colors.p900};
   `;
 
 const getBorderStyles = theme => css`

--- a/src/components/CardList/components/Item/Item.js
+++ b/src/components/CardList/components/Item/Item.js
@@ -63,6 +63,7 @@ const selectedStyles = ({ theme, selected }) =>
     label: cardlist__item--selected;
 
     background: ${theme.colors.p100};
+    color: ${theme.colors.b900};
   `;
 
 const getBorderStyles = theme => css`

--- a/src/components/Table/components/TableRow/TableRow.js
+++ b/src/components/Table/components/TableRow/TableRow.js
@@ -30,11 +30,21 @@ const baseStyles = () => css`
   }
 `;
 
-const clickableStyles = ({ onClick }) =>
+const clickableStyles = ({ theme, onClick }) =>
   onClick &&
   css`
     label: table-row--clickable;
     cursor: pointer;
+
+    tbody & {
+      &:hover {
+        td,
+        th {
+          color: ${theme.colors.b500};
+          background-color: ${theme.colors.n100};
+        }
+      }
+    }
   `;
 
 const TableRow = styled.tr`

--- a/src/components/Table/components/TableRow/TableRow.js
+++ b/src/components/Table/components/TableRow/TableRow.js
@@ -40,7 +40,7 @@ const clickableStyles = ({ theme, onClick }) =>
       &:hover {
         td,
         th {
-          color: ${theme.colors.b500};
+          color: ${theme.colors.p500};
           background-color: ${theme.colors.n100};
         }
       }

--- a/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
+++ b/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
@@ -11,6 +11,12 @@ tbody .circuit-0:last-child td {
   border-bottom: none;
 }
 
+tbody .circuit-0:hover td,
+tbody .circuit-0:hover th {
+  color: #3388FF;
+  background-color: #FAFBFC;
+}
+
 <tr
   class="circuit-0 circuit-1"
 >

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -39,7 +39,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #9DA7B1;
+  color: #5C656F;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -70,7 +70,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #9DA7B1;
+  color: #5C656F;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -96,6 +96,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   justify-content: center;
   outline: none;
   position: relative;
+  color: #212933;
 }
 
 .circuit-2::after {
@@ -151,7 +152,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #9DA7B1;
+  color: #5C656F;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -182,7 +183,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #9DA7B1;
+  color: #5C656F;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -208,6 +209,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   justify-content: center;
   outline: none;
   position: relative;
+  color: #212933;
 }
 
 .circuit-2::after {

--- a/src/components/Tabs/components/Tab/Tab.js
+++ b/src/components/Tabs/components/Tab/Tab.js
@@ -24,7 +24,7 @@ const defaultTabStyles = ({ theme }) => css`
   label: tab;
   ${textMega({ theme })};
   padding: ${theme.spacings.kilo} ${theme.spacings.tera};
-  color: ${theme.colors.n500};
+  color: ${theme.colors.n700};
   text-decoration: none;
   cursor: pointer;
   background-color: transparent;
@@ -45,6 +45,7 @@ const selectedTabStyles = ({ theme, selected }) =>
   css`
     label: tab--selected;
     position: relative;
+    color: ${theme.colors.n900};
 
     &::after {
       content: ' ';

--- a/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
+++ b/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Tab styles should render with default styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #9DA7B1;
+  color: #5C656F;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -47,7 +47,7 @@ exports[`Tab styles should render with selected styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #9DA7B1;
+  color: #5C656F;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -73,6 +73,7 @@ exports[`Tab styles should render with selected styles 1`] = `
   justify-content: center;
   outline: none;
   position: relative;
+  color: #212933;
 }
 
 .circuit-0::after {


### PR DESCRIPTION
Addresses [PMNTSS-138](https://sumupteam.atlassian.net/browse/PMNTSS-138), [PMNTSS-137](https://sumupteam.atlassian.net/browse/PMNTSS-137) and [PMNTSS-139](https://sumupteam.atlassian.net/browse/PMNTSS-139)

## Purpose

- Fix the `Tabs` component which currently always show its elements as disabled/grayed out and does not visually differentiate between normal and selected state
- Fix the `Table` component which currently does not show any visual clue of when a cell is hovered
-  Fix for `ListItem` component which currently does not show any visual clue when hovered

## Approach and changes

- Fix the related CSS rules

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [ ] Meets accessibility requirements
