### PR TITLE
feat(components): add mobile styles for Messages

### DIFF
--- a/src/components/Message/Message.js
+++ b/src/components/Message/Message.js
@@ -18,12 +18,16 @@ import { css } from '@emotion/core';
 
 import { childrenPropType } from '../../util/shared-prop-types';
 
-const baseStyles = () => css`
+const baseStyles = ({ theme }) => css`
   label: message;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
+
+  ${theme.mq.kilo} {
+    flex-direction: row;
+  }
 `;
 
 /**

--- a/src/components/Message/__snapshots__/Message.spec.js.snap
+++ b/src/components/Message/__snapshots__/Message.spec.js.snap
@@ -6,9 +6,9 @@ exports[`Message should render with default styles 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -17,6 +17,14 @@ exports[`Message should render with default styles 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
 }
 
 <div

--- a/src/components/Message/components/Button/Button.js
+++ b/src/components/Message/components/Button/Button.js
@@ -24,9 +24,14 @@ const baseStyles = ({ theme }) => css`
   label: message__button;
   display: block;
   padding-left: ${theme.spacings.giga};
+  margin-top: ${theme.spacings.mega};
   margin-left: auto;
   flex-grow: 0;
   flex-shrink: 0;
+
+  ${theme.mq.kilo} {
+    margin-top: 0;
+  }
 `;
 
 const alignmentStyles = ({ align }) => {

--- a/src/components/Message/components/Button/__snapshots__/Button.spec.js.snap
+++ b/src/components/Message/components/Button/__snapshots__/Button.spec.js.snap
@@ -4,6 +4,7 @@ exports[`MessageButton should render alignment styles when passed the align prop
 .circuit-0 {
   display: block;
   padding-left: 24px;
+  margin-top: 16px;
   margin-left: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
@@ -17,6 +18,12 @@ exports[`MessageButton should render alignment styles when passed the align prop
   align-self: center;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    margin-top: 0;
+  }
+}
+
 <div
   class="circuit-0 circuit-1"
 />
@@ -26,6 +33,7 @@ exports[`MessageButton should render with default styles 1`] = `
 .circuit-0 {
   display: block;
   padding-left: 24px;
+  margin-top: 16px;
   margin-left: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
@@ -37,6 +45,12 @@ exports[`MessageButton should render with default styles 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    margin-top: 0;
+  }
 }
 
 <div

--- a/src/components/Message/components/Icon/Icon.js
+++ b/src/components/Message/components/Icon/Icon.js
@@ -37,10 +37,14 @@ const ICON_MAP = {
 const baseStyles = ({ theme }) => css`
   label: message__icon;
   display: block;
-  margin-right: ${theme.spacings.mega};
+  margin: 0 0 ${theme.spacings.mega} 0;
   flex-grow: 0;
   flex-shrink: 0;
   line-height: 0;
+
+  ${theme.mq.kilo} {
+    margin: 0 ${theme.spacings.mega} 0 0;
+  }
 `;
 
 /**

--- a/src/components/Message/components/Icon/__snapshots__/Icon.spec.js.snap
+++ b/src/components/Message/components/Icon/__snapshots__/Icon.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`MessageIcon should render with custom icon content 1`] = `
 .circuit-0 {
   display: block;
-  margin-right: 16px;
+  margin: 0 0 16px 0;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
@@ -12,6 +12,12 @@ exports[`MessageIcon should render with custom icon content 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   line-height: 0;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    margin: 0 16px 0 0;
+  }
 }
 
 <div
@@ -26,7 +32,7 @@ exports[`MessageIcon should render with custom icon content 1`] = `
 exports[`MessageIcon should render with default styles 1`] = `
 .circuit-0 {
   display: block;
-  margin-right: 16px;
+  margin: 0 0 16px 0;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
@@ -37,6 +43,12 @@ exports[`MessageIcon should render with default styles 1`] = `
   line-height: 0;
 }
 
+@media (min-width:480px) {
+  .circuit-0 {
+    margin: 0 16px 0 0;
+  }
+}
+
 <div
   class="circuit-0 circuit-1"
 />
@@ -45,7 +57,7 @@ exports[`MessageIcon should render with default styles 1`] = `
 exports[`MessageIcon should render with error icon 1`] = `
 .circuit-0 {
   display: block;
-  margin-right: 16px;
+  margin: 0 0 16px 0;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
@@ -54,6 +66,12 @@ exports[`MessageIcon should render with error icon 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   line-height: 0;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    margin: 0 16px 0 0;
+  }
 }
 
 <div
@@ -68,7 +86,7 @@ exports[`MessageIcon should render with error icon 1`] = `
 exports[`MessageIcon should render with warning icon 1`] = `
 .circuit-2 {
   display: block;
-  margin-right: 16px;
+  margin: 0 0 16px 0;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
@@ -77,6 +95,12 @@ exports[`MessageIcon should render with warning icon 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   line-height: 0;
+}
+
+@media (min-width:480px) {
+  .circuit-2 {
+    margin: 0 16px 0 0;
+  }
 }
 
 .circuit-0 rect {


### PR DESCRIPTION
## Purpose

The message component is currently not responsive and breaks badly when used with a button.

## Approach and changes

- Display the message components in a column on mobile:

![Captura de tela 2019-10-14 14 09 15](https://user-images.githubusercontent.com/11017722/66769937-c174cc00-ee8c-11e9-8bdd-a5d4ea44c809.png)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
