### PR TITLE
feat(components): add component context and Link component

### DIFF
--- a/docs/content/getting-started/developers.mdx
+++ b/docs/content/getting-started/developers.mdx
@@ -54,6 +54,31 @@ export default App;
 Simply import components by name from the `@sumup/circuit-ui` package, as demonstrated
 above.
 
+### Custom base components
+
+Some of the low-level components that are used in Circuit UI can be overridden with custom components. This is useful e.g. when your application is using a custom router and needs to use a special `Link` component.
+
+```javascript
+import { Link } from 'react-router-dom';
+import { ComponentsContext, Button } from '@sumup/circuit-ui';
+
+const CustomLink = ({ to, ...rest }) => <Link href={to} {...rest} />;
+
+const App = () => (
+  <ComponentsContext.Provider value={{ Link: CustomLink }}>
+    <Button href="/">Home</Button>
+  </ComponentsContext.Provider>
+);
+
+export default App;
+```
+
+Using the context provider and specifying custom components is fully optional. Circuit will fall back to basic components. You can also override a subset of components, Circuit will merge them with the default components. Below is an overview of the base components that can be overridden:
+
+#### `Link`
+
+Accepts the same props as the `<a>` HTML tag. If your custom component expects different props, you need to map them to the standard attributes (see the example above).
+
 ## Contributing
 
 Please see our [contribution guidelines](https://github.com/sumup/circuit-ui/blob/master/.github/CONTRIBUTING.md)

--- a/docs/content/getting-started/developers.mdx
+++ b/docs/content/getting-started/developers.mdx
@@ -73,7 +73,27 @@ const App = () => (
 export default App;
 ```
 
-Using the context provider and specifying custom components is fully optional. Circuit will fall back to basic components. You can also override a subset of components, Circuit will merge them with the default components. Below is an overview of the base components that can be overridden:
+Using the context provider and specifying custom components is fully optional, Circuit will fall back to built-in components. You can also override only a subset of components, Circuit will merge them with the default components.
+
+In order to access the base components in your own application you can use the `withComponents` higher-order component or the `useComponents` hook:
+
+```javascript
+import { useComponents, withComponents } from '@sumup/circuit-ui';
+
+const Navigation = ({ links }) => {
+  const { Link } = useComponents();
+  return links.map(({ href, label }) => <Link href={href}>{label}</Link>);
+};
+
+const Logo = ({ components, companyName, companyUrl }) => {
+  const { Link } = components;
+  return <Link href={companyUrl}>{companyName}</Link>;
+};
+
+const FooterWithComponents = withComponents(Footer);
+```
+
+Below is an overview of the base components:
 
 #### `Link`
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -22,11 +22,16 @@ import { render, fireEvent, wait, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from 'emotion-theming';
 
+import ComponentsContext, {
+  defaultComponents
+} from './src/components/ComponentsContext';
 import { circuit } from './src/themes';
 
 // eslint-disable-next-line react/prop-types
 const WithProviders = ({ children }) => (
-  <ThemeProvider theme={circuit}>{children}</ThemeProvider>
+  <ComponentsContext.Provider value={defaultComponents}>
+    <ThemeProvider theme={circuit}>{children}</ThemeProvider>
+  </ComponentsContext.Provider>
 );
 
 const renderWithProviders = renderFn => (component, ...rest) =>

--- a/src/components/Button/components/PlainButton/PlainButton.js
+++ b/src/components/Button/components/PlainButton/PlainButton.js
@@ -53,14 +53,15 @@ const ButtonLinkWrapper = styled(StyledText.withComponent('button'))(
   primaryStyles
 );
 
-const PlainButtonWrapper = ButtonLinkWrapper.withComponent('a');
+/* eslint-disable react/prop-types */
+const PlainButton = ({ components, href, ...rest }) => {
+  const PlainButtonWrapper = ButtonLinkWrapper.withComponent(components.Link);
 
-// eslint-disable-next-line react/prop-types
-const PlainButton = ({ href, ...rest }) =>
-  href ? (
+  return href ? (
     <PlainButtonWrapper noMargin {...{ ...rest, href }} />
   ) : (
     <ButtonLinkWrapper noMargin {...rest} />
   );
+};
 
 export default PlainButton;

--- a/src/components/Button/components/PlainButton/index.js
+++ b/src/components/Button/components/PlainButton/index.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { withComponents } from '../../../ComponentsContext';
 import PlainButton from './PlainButton';
 
-export default PlainButton;
+export default withComponents(PlainButton);

--- a/src/components/Button/components/RegularButton/RegularButton.js
+++ b/src/components/Button/components/RegularButton/RegularButton.js
@@ -223,15 +223,15 @@ const ButtonElement = styled('button')`
   ${buttonLoadingStyles};
 `;
 
-const LinkButtonElement = ButtonElement.withComponent('a');
-
-// eslint-disable-next-line react/prop-types
-const RegularButton = ({ href, ...props }) =>
-  href ? (
+/* eslint-disable react/prop-types */
+const RegularButton = ({ components, href, ...props }) => {
+  const LinkButtonElement = ButtonElement.withComponent(components.Link);
+  return href ? (
     <LinkButtonElement {...{ ...props, href }} />
   ) : (
     <ButtonElement {...props} />
   );
+};
 
 export default RegularButton;
 export { calculatePadding };

--- a/src/components/Button/components/RegularButton/index.js
+++ b/src/components/Button/components/RegularButton/index.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { withComponents } from '../../../ComponentsContext';
 import RegularButton from './RegularButton';
 
-export default RegularButton;
+export default withComponents(RegularButton);

--- a/src/components/ComponentsContext/ComponentsContext.js
+++ b/src/components/ComponentsContext/ComponentsContext.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext } from 'react';
+
+import * as defaultComponents from './components';
+
+const ComponentsContext = createContext(defaultComponents);
+
+export default ComponentsContext;

--- a/src/components/ComponentsContext/components/Link/Link.js
+++ b/src/components/ComponentsContext/components/Link/Link.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { childrenPropType } from '../../../../util/shared-prop-types';
+
+/**
+ * A barebones Link component that's basically just an `<a>` tag
+ */
+const Link = ({ children, ...props }) => <a {...props}>{children}</a>;
+
+Link.propTypes = {
+  children: childrenPropType
+};
+
+/**
+ * @component
+ */
+export default Link;

--- a/src/components/ComponentsContext/components/Link/Link.spec.js
+++ b/src/components/ComponentsContext/components/Link/Link.spec.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import Link from './Link';
+
+describe('Link', () => {
+  const defaultProps = {
+    children: 'Click me',
+    href: 'https://sumup.com',
+    target: '_blank',
+    rel: 'noreferrer',
+    'data-testid': 'link'
+  };
+
+  describe('styles', () => {
+    it('should render with the attributes it receives', () => {
+      const { getByTestId } = render(<Link {...defaultProps} />);
+      const linkEl = getByTestId('link');
+
+      expect(linkEl).toHaveAttribute('href', defaultProps.href);
+      expect(linkEl).toHaveAttribute('target', defaultProps.target);
+      expect(linkEl).toHaveAttribute('rel', defaultProps.rel);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const wrapper = renderToHtml(<Link {...defaultProps} />);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/ComponentsContext/components/Link/index.js
+++ b/src/components/ComponentsContext/components/Link/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Link from './Link';
+
+export default Link;

--- a/src/components/ComponentsContext/components/index.js
+++ b/src/components/ComponentsContext/components/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Link from './Link';
+
+export { Link };

--- a/src/components/ComponentsContext/index.js
+++ b/src/components/ComponentsContext/index.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ComponentsContext from './ComponentsContext';
+import withComponents from './withComponents';
+import useComponents from './useComponents';
+import * as defaultComponents from './components';
+
+export { withComponents, useComponents, defaultComponents };
+export default ComponentsContext;

--- a/src/components/ComponentsContext/useComponents.js
+++ b/src/components/ComponentsContext/useComponents.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext } from 'react';
+
+import ComponentsContext from './ComponentsContext';
+import * as defaultComponents from './components';
+
+/**
+ * Subscribe to the components context with a hook.
+ */
+const useComponents = () => {
+  const components = useContext(ComponentsContext) || {};
+  return { ...defaultComponents, ...components };
+};
+
+/**
+ * @component
+ */
+export default useComponents;

--- a/src/components/ComponentsContext/withComponents.js
+++ b/src/components/ComponentsContext/withComponents.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { wrapDisplayName } from 'recompose';
+
+import ComponentsContext from './ComponentsContext';
+import * as defaultComponents from './components';
+
+/**
+ * Subscribe to the components context with a HOC.
+ */
+const withComponents = Component => {
+  function WrappedComponent(props) {
+    return (
+      <ComponentsContext.Consumer>
+        {(components = {}) => (
+          <Component
+            {...props}
+            components={{ ...defaultComponents, ...components }}
+          />
+        )}
+      </ComponentsContext.Consumer>
+    );
+  }
+
+  WrappedComponent.displayName = wrapDisplayName(Component, 'withComponents');
+
+  return WrappedComponent;
+};
+
+/**
+ * @component
+ */
+export default withComponents;

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -17,6 +17,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+
+import { componentsPropType } from '../../../../util/shared-prop-types';
 import NavLabel from '../NavLabel';
 import { getIcon } from './utils';
 
@@ -79,7 +81,7 @@ const disabledStyles = ({ theme, disabled }) =>
     }
   `;
 
-const ListItem = styled.li(
+const StyledLink = styled.a(
   baseStyles,
   hoverStyles,
   selectedStyles,
@@ -95,23 +97,27 @@ const NavItem = ({
   selectedIcon,
   selected,
   disabled,
-  onClick
+  onClick,
+  components
 }) => {
   const icon = getIcon({ defaultIcon, selected, selectedIcon, disabled });
+  const Link = StyledLink.withComponent(components.Link);
 
   return (
-    <ListItem
-      selected={selected}
-      secondary={secondary}
-      visible={visible}
-      disabled={disabled}
-      onClick={disabled ? null : onClick}
-    >
-      {icon}
-      <NavLabel secondary={secondary} visible={visible}>
-        {label}
-      </NavLabel>
-    </ListItem>
+    <li>
+      <Link
+        onClick={disabled ? null : onClick}
+        selected={selected}
+        secondary={secondary}
+        visible={visible}
+        disabled={disabled}
+      >
+        {icon}
+        <NavLabel secondary={secondary} visible={visible}>
+          {label}
+        </NavLabel>
+      </Link>
+    </li>
   );
 };
 
@@ -147,7 +153,8 @@ NavItem.propTypes = {
   /**
    * The onClick method to handle the click event on NavItems
    */
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  components: componentsPropType
 };
 
 NavItem.defaultProps = {

--- a/src/components/Sidebar/components/NavItem/NavItem.spec.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.spec.js
@@ -16,7 +16,7 @@
 import React from 'react';
 
 import NavList from '../NavList';
-import NavItem from './NavItem';
+import NavItem from '.';
 
 describe('NavItem', () => {
   describe('styles', () => {

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -37,12 +37,14 @@ exports[`NavItem styles should render with default styles and match the snapshot
   margin-left: 12px;
 }
 
-<li
-  class="circuit-2 circuit-3"
->
-  <div
-    class="circuit-0 circuit-1"
-  />
+<li>
+  <a
+    class="circuit-2 circuit-3"
+  >
+    <div
+      class="circuit-0 circuit-1"
+    />
+  </a>
 </li>
 `;
 
@@ -92,12 +94,14 @@ exports[`NavItem styles should render with default styles and match the snapshot
   margin-top: 0px;
 }
 
-<li
-  class="circuit-2 circuit-3"
->
-  <div
-    class="circuit-0 circuit-1"
-  />
+<li>
+  <a
+    class="circuit-2 circuit-3"
+  >
+    <div
+      class="circuit-0 circuit-1"
+    />
+  </a>
 </li>
 `;
 
@@ -136,13 +140,15 @@ exports[`NavItem styles should render with disabled state styles and match the s
   fill: #5C656F;
 }
 
-<li
-  class="circuit-2 circuit-3"
-  disabled=""
->
-  <div
-    class="circuit-0 circuit-1"
-  />
+<li>
+  <a
+    class="circuit-2 circuit-3"
+    disabled=""
+  >
+    <div
+      class="circuit-0 circuit-1"
+    />
+  </a>
 </li>
 `;
 
@@ -181,11 +187,13 @@ exports[`NavItem styles should render with selected state styles and match the s
   fill: #FAFBFC;
 }
 
-<li
-  class="circuit-2 circuit-3"
->
-  <div
-    class="circuit-0 circuit-1"
-  />
+<li>
+  <a
+    class="circuit-2 circuit-3"
+  >
+    <div
+      class="circuit-0 circuit-1"
+    />
+  </a>
 </li>
 `;

--- a/src/components/Sidebar/components/NavItem/index.js
+++ b/src/components/Sidebar/components/NavItem/index.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { withComponents } from '../../../ComponentsContext';
 import NavItem from './NavItem';
 
-export default NavItem;
+export default withComponents(NavItem);

--- a/src/index.js
+++ b/src/index.js
@@ -188,6 +188,12 @@ export { default as Header } from './components/Header';
 export { default as State } from './components/State';
 export { default as InlineElements } from './components/InlineElements';
 
+export {
+  default as ComponentsContext,
+  withComponents,
+  useComponents
+} from './components/ComponentsContext';
+
 // Theme
 const standard = { ...circuit }; // otherwise this get exported as a `Module`
 const theme = {

--- a/src/util/shared-prop-types.js
+++ b/src/util/shared-prop-types.js
@@ -179,6 +179,10 @@ export const themePropType = PropTypes.shape({
   }).isRequired
 });
 
+export const componentsPropType = PropTypes.shape({
+  Link: PropTypes.element
+});
+
 export const localePropType = isRequired => (
   props,
   propName,


### PR DESCRIPTION
Closes #466.

## Purpose

Some of the low-level functional components in Circuit UI need to be customizable. This is useful e.g. when your application is using a custom router and needs to use a special `Link` component.

## Approach and changes

- Add a `ComponentsContext` with a `withComponents` HOC and `useComponents` hook
- Add a default `Link` component
- Use the `Link` component in the `Button` and `Sidebar` components
- Add documentation how to override the base components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
