### PR TITLE
fix(components): pass href to NavItem link

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -60,6 +60,10 @@ const alignmentMap = {
 };
 
 const alignmentStyles = ({ align }) => {
+  if (!align) {
+    return null;
+  }
+
   const label = `button-group--${align}`;
 
   return css`

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -32,6 +32,7 @@ const baseStyles = ({ theme }) => css`
   padding: ${theme.spacings.bit};
   cursor: pointer;
   color: ${theme.colors.n500};
+  text-decoration: none;
   * {
     fill: ${theme.colors.n500};
   }
@@ -98,7 +99,8 @@ const NavItem = ({
   selected,
   disabled,
   onClick,
-  components
+  components,
+  ...rest
 }) => {
   const icon = getIcon({ defaultIcon, selected, selectedIcon, disabled });
   const Link = StyledLink.withComponent(components.Link);
@@ -111,6 +113,7 @@ const NavItem = ({
         secondary={secondary}
         visible={visible}
         disabled={disabled}
+        {...rest}
       >
         {icon}
         <NavLabel secondary={secondary} visible={visible}>

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -19,6 +19,8 @@ exports[`NavItem styles should render with default styles and match the snapshot
   padding: 4px;
   cursor: pointer;
   color: #9DA7B1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .circuit-2 * {
@@ -67,6 +69,8 @@ exports[`NavItem styles should render with default styles and match the snapshot
   padding: 4px;
   cursor: pointer;
   color: #9DA7B1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   margin: 0px 24px;
   padding: 4px 0px;
   -webkit-transition: top 200ms ease-in-out;
@@ -128,6 +132,8 @@ exports[`NavItem styles should render with disabled state styles and match the s
   padding: 4px;
   cursor: pointer;
   color: #9DA7B1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   cursor: not-allowed;
   color: #5C656F;
 }
@@ -175,6 +181,8 @@ exports[`NavItem styles should render with selected state styles and match the s
   padding: 4px;
   cursor: pointer;
   color: #9DA7B1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   font-weight: 700;
   color: #FAFBFC;
 }

--- a/src/util/shared-prop-types.js
+++ b/src/util/shared-prop-types.js
@@ -180,7 +180,7 @@ export const themePropType = PropTypes.shape({
 });
 
 export const componentsPropType = PropTypes.shape({
-  Link: PropTypes.element
+  Link: PropTypes.oneOfType([PropTypes.element, PropTypes.func])
 });
 
 export const localePropType = isRequired => (


### PR DESCRIPTION
Follow up to #466.

## Purpose

In the original PR, I forgot to pass the `href` through to the Link component in the NavItem. 

## Approach and changes

- pass `href` to NavItem link
- remove link underline

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x]  Meets accessibility requirements
