### PR TITLE
fix(components): disable interactions on disabled Selector

### DIFF
--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -55,6 +55,7 @@ const disabledStyles = ({ disabled, theme }) =>
     label: selector--disabled;
     color: ${theme.colors.n500};
     cursor: default;
+    pointer-events: none;
   `;
 
 /**

--- a/src/components/Selector/__snapshots__/Selector.spec.js.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.js.snap
@@ -30,6 +30,7 @@ exports[`Selector should render a disabled selector appropriately 1`] = `
   margin-bottom: 16px;
   color: #9DA7B1;
   cursor: default;
+  pointer-events: none;
 }
 
 .circuit-0:hover {


### PR DESCRIPTION
## Purpose

When a Selector is disabled, it should no longer be interactive, i.e. the `onClick` handler should not fire.

## Approach and changes

- Disable interactions with `pointer-events: none`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
